### PR TITLE
Adding GraphQL support for stat and listing queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11335,6 +11335,11 @@
         "iterall": "^1.2.2"
       }
     },
+    "graphql-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/graphql-bigint/-/graphql-bigint-1.0.0.tgz",
+      "integrity": "sha512-eLDf9GinU0ioui1ipXCl7pMFa3Am8pxciS0D0LR68SXfY7EzLk5P58LKyk+7CgLD5f66kiFGa5OIqt6iRLE2cQ=="
+    },
     "graphql-extensions": {
       "version": "0.10.9",
       "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.10.9.tgz",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "express-session": "^1.17.0",
     "formik": "^1.5.8",
     "graphql": "^14.5.8",
+    "graphql-bigint": "^1.0.0",
     "graphql-middleware": "^4.0.2",
     "graphql-tools": "^4.0.6",
     "graphql-type-json": "^0.3.1",

--- a/src/server/graphql/dataSources/TerrainDataSource.js
+++ b/src/server/graphql/dataSources/TerrainDataSource.js
@@ -1,6 +1,17 @@
+/**
+ * The Apollo GraphQL REST data source for the terrain service.
+ *
+ * @module
+ */
+
 import { RESTDataSource } from "apollo-datasource-rest";
 import { terrainURL } from "../../configuration";
 
+/**
+ * The data source for the terrain service.
+ *
+ * @extends RESTDataSource
+ */
 export default class TerrainDataSource extends RESTDataSource {
     constructor() {
         super();
@@ -20,5 +31,46 @@ export default class TerrainDataSource extends RESTDataSource {
 
     async getNewUUID() {
         return await this.get("/uuid");
+    }
+
+    /**
+     * Returns info about a file or folder from terrain.
+     * @param {string} fullPath - The full path to the file in the data store.
+     * @returns {(File | Folder)}
+     */
+    async filesystemStat(fullPath) {
+        return await this.post(
+            "/secured/filesystem/stat",
+            JSON.stringify({ paths: [fullPath] })
+        );
+    }
+
+    /**
+     * Returns a folder listing.
+     * @param {string} folderPath - The full path to the folder being listed.
+     * @param {number} limit - The maximum number of items included in the response.
+     * @param {number} offset - The number of items to skip over before starting the list.
+     * @param {string} entityType - The type of items included in the results. Should be one of FILE, FOLDER, or ANY.
+     * @param {string} sortColumn - The column to sort on. One of NAME, ID, LASTMODIFIED, DATECREATED, SIZE, or PATH.
+     * @param {string} sortDirection - One of "ASC" (for ascending order) or "DESC" (for descending order).
+     * @returns {Array<{(File | Folder)}>}
+     */
+    async listFolder(
+        folderPath,
+        limit,
+        offset,
+        entityType,
+        sortColumn,
+        sortDirection
+    ) {
+        let pathParam = `path=${folderPath}`;
+        let limitParam = `limit=${limit}`;
+        let offsetParam = `offset=${offset}`;
+        let entityTypeParam = `entity-type=${entityType}`;
+        let sortColumnParam = `sort-col=${sortColumn}`;
+        let sortDirectionParam = `sort-dir=${sortDirection}`;
+        return await this.get(
+            `/secured/filesystem/paged-directory?${pathParam}&${limitParam}&${offsetParam}&${entityTypeParam}&${sortColumnParam}&${sortDirectionParam}`
+        );
     }
 }

--- a/src/server/graphql/dataSources/TerrainDataSource.js
+++ b/src/server/graphql/dataSources/TerrainDataSource.js
@@ -81,6 +81,7 @@ export default class TerrainDataSource extends RESTDataSource {
         // folder being listed (because you should already know), but for
         // consistency we'll include it here.
         let retval = {
+            listing: [],
             stat: _.set(
                 _.omit(responseValue, ["files", "folders"]), // unify the listing.
                 "type",
@@ -90,11 +91,14 @@ export default class TerrainDataSource extends RESTDataSource {
 
         // Unlike the stat endpoint, the page-directory call doesn't include
         // the type field, so we add it in here for consistency.
-        retval.listing = _.map(responseValue.folders, (f) => {
-            f.type = FOLDER;
-            return f;
-        });
-        retval.listing.concat(
+        retval.listing = retval.listing.concat(
+            _.map(responseValue.folders, (f) => {
+                f.type = FOLDER;
+                return f;
+            })
+        );
+
+        retval.listing = retval.listing.concat(
             _.map(responseValue.files, (f) => {
                 f.type = FILE;
                 return f;

--- a/src/server/graphql/resolvers/Filesystem.js
+++ b/src/server/graphql/resolvers/Filesystem.js
@@ -1,0 +1,31 @@
+export default {
+    // Mapping for the SortColumn enum.
+    SortColumn: {
+        NAME: "NAME",
+        ID: "ID",
+        LASTMODIFIED: "LASTMODIFIED",
+        DATECREATED: "DATECREATED",
+        SIZE: "SIZE",
+        PATH: "PATH",
+    },
+
+    // Mapping for the EntityType enum.
+    EntityType: {
+        FILE: "FILE",
+        FOLDER: "FOLDER",
+        ANY: "ANY",
+    },
+
+    // Mapping for the SortDirection enum.
+    SortDirection: {
+        ASC: "ASC",
+        DESC: "DESC",
+    },
+
+    // Mapping for the Permission enum.
+    Permission: {
+        READ: "read",
+        WRITE: "write",
+        OWN: "own",
+    },
+};

--- a/src/server/graphql/resolvers/Filesystem.js
+++ b/src/server/graphql/resolvers/Filesystem.js
@@ -1,25 +1,25 @@
 export default {
     // Mapping for the SortColumn enum.
     SortColumn: {
-        NAME: "NAME",
-        ID: "ID",
-        LASTMODIFIED: "LASTMODIFIED",
-        DATECREATED: "DATECREATED",
-        SIZE: "SIZE",
-        PATH: "PATH",
+        NAME: "name",
+        ID: "id",
+        LASTMODIFIED: "lastmodified",
+        DATECREATED: "datecreated",
+        SIZE: "size",
+        PATH: "path",
     },
 
     // Mapping for the EntityType enum.
     EntityType: {
-        FILE: "FILE",
-        FOLDER: "FOLDER",
-        ANY: "ANY",
+        FILE: "file",
+        FOLDER: "folder",
+        ANY: "any",
     },
 
     // Mapping for the SortDirection enum.
     SortDirection: {
-        ASC: "ASC",
-        DESC: "DESC",
+        ASC: "asc",
+        DESC: "desc",
     },
 
     // Mapping for the Permission enum.
@@ -31,29 +31,29 @@ export default {
 
     FolderListingResult: {
         __resolveType(obj, _context, _info) {
-            if (obj.type.toUpperCase() === "FILE") return "File";
-            if (obj.type.toUpperCase() === "FOLDER") return "Folder";
+            if (obj.type) {
+                if (obj.type.toUpperCase() === "FILE") {
+                    return "File"; // File is the name of the concrete GraphQL type.
+                }
+                if (obj.type.toUpperCase() === "FOLDER") {
+                    return "Folder"; // Folder is the name of the concrete GraphQL type.
+                }
+            }
             return null;
         },
     },
 
     FilesystemObject: {
         __resolveType(obj, _context, _info) {
-            if (obj.type.toUpperCase() === "FILE") return "File";
-            if (obj.type.toUpperCase() === "FOLDER") return "Folder";
+            if (obj.type) {
+                if (obj.type.toUpperCase() === "FILE") {
+                    return "File"; // File is the name of the concrete GraphQL type.
+                }
+                if (obj.type.toUpperCase() === "FOLDER") {
+                    return "Folder"; // Folder is the name of the concrete GraphQL type.
+                }
+            }
             return null;
         },
-    },
-
-    Folder: {
-        listing: async (folder, args, { dataSources }) =>
-            await dataSources.terrain.listFolder(
-                folder.path,
-                args.limit,
-                args.offset,
-                args.entityType,
-                args.sortColumn,
-                args.sortDirection
-            ),
     },
 };

--- a/src/server/graphql/resolvers/Filesystem.js
+++ b/src/server/graphql/resolvers/Filesystem.js
@@ -28,4 +28,32 @@ export default {
         WRITE: "write",
         OWN: "own",
     },
+
+    FolderListingResult: {
+        __resolveType(obj, _context, _info) {
+            if (obj.type.toUpperCase() === "FILE") return "File";
+            if (obj.type.toUpperCase() === "FOLDER") return "Folder";
+            return null;
+        },
+    },
+
+    FilesystemObject: {
+        __resolveType(obj, _context, _info) {
+            if (obj.type.toUpperCase() === "FILE") return "File";
+            if (obj.type.toUpperCase() === "FOLDER") return "Folder";
+            return null;
+        },
+    },
+
+    Folder: {
+        listing: async (folder, args, { dataSources }) =>
+            await dataSources.terrain.listFolder(
+                args.folderPath,
+                args.limit,
+                args.offset,
+                args.entityType,
+                args.sortColumn,
+                args.sortDirection
+            ),
+    },
 };

--- a/src/server/graphql/resolvers/Filesystem.js
+++ b/src/server/graphql/resolvers/Filesystem.js
@@ -13,6 +13,7 @@ export default {
     EntityType: {
         FILE: "file",
         FOLDER: "folder",
+        DIR: "dir",
         ANY: "any",
     },
 
@@ -35,7 +36,7 @@ export default {
                 if (obj.type.toUpperCase() === "FILE") {
                     return "File"; // File is the name of the concrete GraphQL type.
                 }
-                if (obj.type.toUpperCase() === "FOLDER") {
+                if (obj.type === "dir" || obj.type.toUpperCase() === "FOLDER") {
                     return "Folder"; // Folder is the name of the concrete GraphQL type.
                 }
             }
@@ -49,7 +50,7 @@ export default {
                 if (obj.type.toUpperCase() === "FILE") {
                     return "File"; // File is the name of the concrete GraphQL type.
                 }
-                if (obj.type.toUpperCase() === "FOLDER") {
+                if (obj.type === "dir" || obj.type.toUpperCase() === "FOLDER") {
                     return "Folder"; // Folder is the name of the concrete GraphQL type.
                 }
             }

--- a/src/server/graphql/resolvers/Filesystem.js
+++ b/src/server/graphql/resolvers/Filesystem.js
@@ -48,7 +48,7 @@ export default {
     Folder: {
         listing: async (folder, args, { dataSources }) =>
             await dataSources.terrain.listFolder(
-                args.folderPath,
+                folder.path,
                 args.limit,
                 args.offset,
                 args.entityType,

--- a/src/server/graphql/resolvers/Query.js
+++ b/src/server/graphql/resolvers/Query.js
@@ -4,5 +4,19 @@ export default {
             await dataSources.terrain.getStatus(),
         newUUID: async (_source, _args, { dataSources }) =>
             await dataSources.terrain.getNewUUID(),
+        filesystemStat: async (_source, { path }, { dataSources }) =>
+            await dataSources.terrain.filesystemStat(path),
+
+        // The defaults for the args don't seem to get passed down, we're setting
+        // them here.
+        listFolder: async (_source, args, { dataSources }) =>
+            await dataSources.terrain.listFolder(
+                args.path,
+                args.limit || 50,
+                args.offset || 0,
+                args.entityType || "any",
+                args.sortColumn || "name",
+                args.sortDirection || "asc"
+            ),
     },
 };

--- a/src/server/graphql/resolvers/Query.js
+++ b/src/server/graphql/resolvers/Query.js
@@ -4,8 +4,8 @@ export default {
             await dataSources.terrain.getStatus(),
         newUUID: async (_source, _args, { dataSources }) =>
             await dataSources.terrain.getNewUUID(),
-        filesystemStat: async (_source, { path }, { dataSources }) =>
-            await dataSources.terrain.filesystemStat(path),
+        filesystemStat: async (_source, { paths }, { dataSources }) =>
+            await dataSources.terrain.filesystemStat(paths),
 
         // The defaults for the args don't seem to get passed down, we're setting
         // them here.

--- a/src/server/graphql/resolvers/index.js
+++ b/src/server/graphql/resolvers/index.js
@@ -1,5 +1,11 @@
 import { merge } from "lodash";
 
 import Query from "./Query";
+import BigInt from "graphql-bigint";
 
-export default merge(Query);
+export default merge(
+    {
+        BigInt: BigInt,
+    },
+    Query
+);

--- a/src/server/graphql/resolvers/index.js
+++ b/src/server/graphql/resolvers/index.js
@@ -2,10 +2,12 @@ import { merge } from "lodash";
 
 import Query from "./Query";
 import BigInt from "graphql-bigint";
+import Filesystem from "./Filesystem";
 
 export default merge(
     {
         BigInt: BigInt,
     },
+    Filesystem,
     Query
 );

--- a/src/server/graphql/typesDefs/Filesystem.js
+++ b/src/server/graphql/typesDefs/Filesystem.js
@@ -43,6 +43,7 @@ export default gql`
     enum EntityType {
         FILE
         FOLDER
+        DIR
         ANY
     }
 
@@ -76,7 +77,7 @@ export default gql`
         permission: Permission
         dateCreated: BigInt
         dateModified: BigInt
-        type: EntityType!
+        type: EntityType
         shareCount: Int
 
         # Specific to files
@@ -96,10 +97,17 @@ export default gql`
         permission: Permission
         dateCreated: BigInt
         dateModified: BigInt
-        type: EntityType!
+        type: EntityType
         shareCount: Int
 
         # Specific to folders
         fileCount: Int
+    }
+
+    # Allows us to fetch everything at once without having to cache results or
+    # hit stat a bunch of times.
+    type FolderListing {
+        stat: Folder
+        listing: [FilesystemObject]
     }
 `;

--- a/src/server/graphql/typesDefs/Filesystem.js
+++ b/src/server/graphql/typesDefs/Filesystem.js
@@ -101,12 +101,5 @@ export default gql`
 
         # Specific to folders
         fileCount: Int
-        listing(
-            limit: Int = 50
-            offset: Int = 0
-            entityType: EntityType = ANY
-            sortColumn: SortColumn = NAME
-            SortDirection: SortDirection = ASC
-        ): [FolderListingResult]
     }
 `;

--- a/src/server/graphql/typesDefs/Filesystem.js
+++ b/src/server/graphql/typesDefs/Filesystem.js
@@ -1,0 +1,82 @@
+import { gql } from "apollo-server-express";
+
+export default gql`
+    enum SortColumn {
+        NAME
+        ID
+        LASTMODIFIED
+        DATECREATED
+        SIZE
+        PATH
+    }
+
+    enum EntityType {
+        FILE
+        FOLDER
+        ANY
+    }
+
+    enum SortDirection {
+        ASC
+        DESC
+    }
+
+    enum Permission {
+        READ
+        WRITE
+        OWN
+    }
+
+    interface FilesystemObject {
+        id: String!
+        label: String
+        path: String!
+        permission: Permission
+        dateCreated: BigInt
+        dateModified: BigInt
+        type: EntityType
+        shareCount: Int
+    }
+
+    type File implements FilesystemObject {
+        # Interface implementation
+        id: String!
+        label: String
+        path: String!
+        permission: Permission
+        dateCreated: BigInt
+        dateModified: BigInt
+        type: EntityType!
+        shareCount: Int
+
+        # Specific to files
+        infoType: String
+        md5: String
+        fileSize: BigInt
+    }
+
+    # Allows us to later extend the kinds of objects returned by a listing
+    union FolderListingResult = File | Folder
+
+    type Folder implements FilesystemObject {
+        #Interface implementation
+        id: String!
+        label: String
+        path: String!
+        permission: Permission
+        dateCreated: BigInt
+        dateModified: BigInt
+        type: EntityType!
+        shareCount: Int
+
+        # Specific to folders
+        fileCount: Int
+        listing(
+            limit: Int = 50
+            offset: Int = 0
+            entityType: EntityType = ANY
+            infoType: [String] = []
+            sortColumn: SortColumn = NAME
+        ): [FolderListingResult]
+    }
+`;

--- a/src/server/graphql/typesDefs/Filesystem.js
+++ b/src/server/graphql/typesDefs/Filesystem.js
@@ -106,6 +106,7 @@ export default gql`
             offset: Int = 0
             entityType: EntityType = ANY
             sortColumn: SortColumn = NAME
+            SortDirection: SortDirection = ASC
         ): [FolderListingResult]
     }
 `;

--- a/src/server/graphql/typesDefs/Filesystem.js
+++ b/src/server/graphql/typesDefs/Filesystem.js
@@ -1,5 +1,35 @@
 import { gql } from "apollo-server-express";
 
+/**
+ * @typedef {Object} File
+ * @property {string} id - The UUID assigned to the file.
+ * @property {string} label - The label for the file. Usually the file name without the path.
+ * @property {string} path - Full path to the file in the data store.
+ * @property {string} permission - The maximum permission level on the file for the user. One of "read", "write", or "own".
+ * @property {number} dateCreated - File creation date as milliseconds since the epoch.
+ * @property {number} dateModified - Last modified date as milliseconds since the epoch.
+ * @property {string} type - Either "file" or "folder". Should be "file".
+ * @property {number} shareCount - The number of users the file has been shared with.
+ * @property {string} infoType - The info type of the file.
+ * @property {string} md5 - The MD5 hash of the file.
+ * @property {fileSize} number - The size of the file in bytes.
+ * @
+ */
+
+/**
+ * @typedef {Object} Folder
+ * @property {string} id - The UUID assigned to the folder.
+ * @property {string} label - The label for the folder. Usually the folder name without the path.
+ * @property {string} path - Full path to the folder in the data store.
+ * @property {string} permission - The maximum permission level on the folder for the user. One of "read", "write", or "own".
+ * @property {number} dateCreated - Folder creation date as milliseconds since the epoch.
+ * @property {number} dateModified - Last modified date as milliseconds since the epoch.
+ * @property {string} type - Either "file" or "folder". Should be "folder".
+ * @property {number} shareCount - The number of users the folder has been shared with.
+ * @property {number} fileCount - The number of files contained in the folder.
+ * @property {Array<Object>} listing - A list of files and folders contained in the folder.
+ */
+
 export default gql`
     enum SortColumn {
         NAME
@@ -75,7 +105,6 @@ export default gql`
             limit: Int = 50
             offset: Int = 0
             entityType: EntityType = ANY
-            infoType: [String] = []
             sortColumn: SortColumn = NAME
         ): [FolderListingResult]
     }

--- a/src/server/graphql/typesDefs/Query.js
+++ b/src/server/graphql/typesDefs/Query.js
@@ -9,7 +9,7 @@ export default gql`
 
         newUUID: String
 
-        filesystemStat(path: String): FilesystemObject
+        filesystemStat(paths: [String]): [FilesystemObject]
 
         listFolder(
             path: String
@@ -18,6 +18,6 @@ export default gql`
             entityType: EntityType = "any"
             sortColumn: SortColumn = "name"
             sortDirection: SortDirection = "asc"
-        ): [FilesystemObject]
+        ): FolderListing
     }
 `;

--- a/src/server/graphql/typesDefs/Query.js
+++ b/src/server/graphql/typesDefs/Query.js
@@ -1,6 +1,9 @@
 import { gql } from "apollo-server-express";
 
 export default gql`
+    scalar JSON
+    scalar BigInt
+
     type Query {
         status: String
 

--- a/src/server/graphql/typesDefs/Query.js
+++ b/src/server/graphql/typesDefs/Query.js
@@ -8,5 +8,16 @@ export default gql`
         status: String
 
         newUUID: String
+
+        filesystemStat(path: String): FilesystemObject
+
+        listFolder(
+            path: String
+            limit: Int = 50
+            offset: Int = 0
+            entityType: EntityType = "any"
+            sortColumn: SortColumn = "name"
+            sortDirection: SortDirection = "asc"
+        ): [FilesystemObject]
     }
 `;

--- a/src/server/graphql/typesDefs/index.js
+++ b/src/server/graphql/typesDefs/index.js
@@ -1,3 +1,4 @@
 import query from "./Query";
+import filesystem from "./Filesystem";
 
-export default [query];
+export default [query, filesystem];

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -34,9 +34,9 @@ const apolloServer = new ApolloServer({
     dataSources: () => ({
         terrain: new TerrainDataSource(),
     }),
-    context: ({ req }) => {
-        return { user: req.user };
-    },
+    context: ({ req }) => ({
+        user: req.user,
+    }),
     playground: {
         settings: {
             "request.credentials": "include",


### PR DESCRIPTION
## Summary

This includes the type definitions, resolvers, and data sources needed for the queries. 

To try things out:
* Run `npm run dev`. 
* Hit `http://localhost:3000/login` in a browser. 
* Log in with your account. 
* Hit `http://localhost:3000/graphql` in the same browser to see the graphql UI. 

You'll have to modify the parameters in the query to work with your account.

## References:
* https://graphql.org/learn/schema/#interfaces
* https://graphql.org/learn/schema/#union-types
* https://www.apollographql.com/docs/apollo-server/schema/unions-interfaces/

## Examples

### stat query:
```
{
  stat: filesystemStat(paths: [
    "/iplant/home/ipcdev/testing-vice", 
    "/iplant/home/ipcdev/testing-vice/drop-notes.md"
  ]) {
    id
    name: label
    path
    type
    
    ... on File {
      fileSize
    }
    
    ... on Folder {
      fileCount
    }
  }
}
```
The `... on File` and `... on Folder` blocks define which fields we want to grab for each type, since the result is a list of both types mixed together. The fields above that (id, label, path, and type) are common to the File and Folder types so they don't need to be split out the way that the fileSize and fileCount fields are. 

I renamed the label field to `name` just to show how that can be controlled in a query.

There are more fields available than what are listed here, check out the schema in the graphql UI for more.

#### Result
```
{
  "data": {
    "stat": [
      {
        "id": "3a33976c-5567-11e9-80be-d8d385e427d4",
        "name": "testing-vice",
        "path": "/iplant/home/ipcdev/testing-vice",
        "type": "DIR",
        "fileCount": 4
      },
      {
        "id": "2dc7d5d8-5567-11e9-80be-d8d385e427d4",
        "name": "drop-notes.md",
        "path": "/iplant/home/ipcdev/testing-vice/drop-notes.md",
        "type": "FILE",
        "fileSize": 856
      }
    ]
  }
}
```

### Folder listing:
```
{
  folderListing: listFolder(path: "/iplant/home/ipcdev") {
    stat {
      id
      name: label
      path
      permission
      type
    }
    listing {
      id
      name: label
      path
      permission
      type
    }
  }
}
```
I nested the stat information so that we don't have to create a duplicate type containing all of the same info as the Folder type but with the added listing field. This way we can define a FolderListing as :

```
type FolderListing {
    stat: Folder
    listing: [FilesystemObject]
}
```

The `type` field always returns upper-case, though the entity-type parameter should accept lower-case values. Not exactly sure how to fix that without losing specificity in the types (I'm using an enum to define the range of possible types).

#### Result
```
{
  "data": {
    "folderListing": {
      "stat": {
        "id": "e23e208c-e210-11e3-b8e3-6abdce5a08d5",
        "name": "ipcdev",
        "path": "/iplant/home/ipcdev",
        "permission": "OWN",
        "type": "FOLDER"
      },
      "listing": [
        {
          "id": "4378cca2-e212-11e3-b983-6abdce5a08d5",
          "name": "CORE-5257",
          "path": "/iplant/home/ipcdev/CORE-5257",
          "permission": "OWN",
          "type": "FOLDER"
        },
        {
          "id": "e29e4e12-e210-11e3-b8e3-6abdce5a08d5",
          "name": "CORE-5413",
          "path": "/iplant/home/ipcdev/CORE-5413",
          "permission": "OWN",
          "type": "FOLDER"
        },
        {
          "id": "850d5c64-e212-11e3-b993-6abdce5a08d5",
          "name": "Sub",
          "path": "/iplant/home/ipcdev/Sub",
          "permission": "OWN",
          "type": "FOLDER"
        },
        {
          "id": "851497a4-e212-11e3-b993-6abdce5a08d5",
          "name": "TestCreateFolder",
          "path": "/iplant/home/ipcdev/TestCreateFolder",
          "permission": "OWN",
          "type": "FOLDER"
        },
        {
          "id": "63ab1806-f62f-11e7-bf82-d8d385e427d4",
          "name": "TestData_dpt",
          "path": "/iplant/home/ipcdev/TestData_dpt",
          "permission": "OWN",
          "type": "FOLDER"
        },
        {
          "id": "e2773be2-e210-11e3-b8e3-6abdce5a08d5",
          "name": "analyses",
          "path": "/iplant/home/ipcdev/analyses",
          "permission": "OWN",
          "type": "FOLDER"
        },
        {
          "id": "59ca58ec-f62f-11e7-bf82-d8d385e427d4",
          "name": "analyses_dpt",
          "path": "/iplant/home/ipcdev/analyses_dpt",
          "permission": "OWN",
          "type": "FOLDER"
        },
        {
          "id": "80f57eca-0d1c-11e8-803c-d8d385e427d4",
          "name": "analyses_qa",
          "path": "/iplant/home/ipcdev/analyses_qa",
          "permission": "OWN",
          "type": "FOLDER"
        },
        {
          "id": "e26a5dbe-e210-11e3-b8e3-6abdce5a08d5",
          "name": "analyses_qa-1",
          "path": "/iplant/home/ipcdev/analyses_qa-1",
          "permission": "OWN",
          "type": "FOLDER"
        },
        {
          "id": "b7d737ac-7f70-11e6-bf34-d8d385e427d4",
          "name": "analyses_qa-3",
          "path": "/iplant/home/ipcdev/analyses_qa-3",
          "permission": "OWN",
          "type": "FOLDER"
        },
        {
          "id": "a9db662e-ed26-11e4-ac76-3c4a92e4a804",
          "name": "coge_data",
          "path": "/iplant/home/ipcdev/coge_data",
          "permission": "OWN",
          "type": "FOLDER"
        },
        {
          "id": "239dc8f2-9693-11e9-80c6-d8d385e427d4",
          "name": "hello-shiny",
          "path": "/iplant/home/ipcdev/hello-shiny",
          "permission": "OWN",
          "type": "FOLDER"
        },
        {
          "id": "e8b9468a-0bd1-11e5-8297-3c4a92e4a804",
          "name": "logs",
          "path": "/iplant/home/ipcdev/logs",
          "permission": "OWN",
          "type": "FOLDER"
        },
        {
          "id": "72aa19a4-d01e-11e9-80d5-d8d385e427d4",
          "name": "lol",
          "path": "/iplant/home/ipcdev/lol",
          "permission": "OWN",
          "type": "FOLDER"
        },
        {
          "id": "a2327096-71c7-11e4-904d-3c4a92e4a804",
          "name": "nex",
          "path": "/iplant/home/ipcdev/nex",
          "permission": "OWN",
          "type": "FOLDER"
        },
        {
          "id": "3c1aeb2e-920c-11e5-81de-3c4a92e4a804",
          "name": "test",
          "path": "/iplant/home/ipcdev/test",
          "permission": "OWN",
          "type": "FOLDER"
        },
        {
          "id": "989f44ee-720e-11e5-87bf-3c4a92e4a804",
          "name": "test-bulk-metadata",
          "path": "/iplant/home/ipcdev/test-bulk-metadata",
          "permission": "OWN",
          "type": "FOLDER"
        },
        {
          "id": "c38e9696-7bcf-11e8-8071-d8d385e427d4",
          "name": "test-shiny-app",
          "path": "/iplant/home/ipcdev/test-shiny-app",
          "permission": "OWN",
          "type": "FOLDER"
        },
        {
          "id": "3a33976c-5567-11e9-80be-d8d385e427d4",
          "name": "testing-vice",
          "path": "/iplant/home/ipcdev/testing-vice",
          "permission": "OWN",
          "type": "FOLDER"
        },
        {
          "id": "70de0646-11cc-11e4-ba8f-3c4a92e4a804",
          "name": "4store-1.1.5.dmg",
          "path": "/iplant/home/ipcdev/4store-1.1.5.dmg",
          "permission": "OWN",
          "type": "FILE"
        },
        {
          "id": "07ffbe2c-ed92-11e6-bf47-d8d385e427d4",
          "name": "CORE-8424.txt",
          "path": "/iplant/home/ipcdev/CORE-8424.txt",
          "permission": "OWN",
          "type": "FILE"
        },
        {
          "id": "3f64162e-eab5-11e4-8068-3c4a92e4a804",
          "name": "PDAP.fel.tree",
          "path": "/iplant/home/ipcdev/PDAP.fel.tree",
          "permission": "OWN",
          "type": "FILE"
        },
        {
          "id": "b40be208-7bdb-11e8-8071-d8d385e427d4",
          "name": "demo-file.txt",
          "path": "/iplant/home/ipcdev/demo-file.txt",
          "permission": "OWN",
          "type": "FILE"
        },
        {
          "id": "919e444c-9af8-11e6-bf3b-d8d385e427d4",
          "name": "path.list",
          "path": "/iplant/home/ipcdev/path.list",
          "permission": "OWN",
          "type": "FILE"
        },
        {
          "id": "a4a681ca-6072-11e4-9d04-3c4a92e4a804",
          "name": "sample.csv",
          "path": "/iplant/home/ipcdev/sample.csv",
          "permission": "OWN",
          "type": "FILE"
        },
        {
          "id": "8f9119d4-f62f-11e7-bf82-d8d385e427d4",
          "name": "sample1.newick",
          "path": "/iplant/home/ipcdev/sample1.newick",
          "permission": "OWN",
          "type": "FILE"
        },
        {
          "id": "4a24a3fc-54bb-11e4-9ce0-3c4a92e4a804",
          "name": "savedParameters.txt",
          "path": "/iplant/home/ipcdev/savedParameters.txt",
          "permission": "OWN",
          "type": "FILE"
        },
        {
          "id": "d43dff62-cae1-11e7-bf75-d8d385e427d4",
          "name": "screenshot-localhost 9091-2017-05-03-08-36-13.png",
          "path": "/iplant/home/ipcdev/screenshot-localhost 9091-2017-05-03-08-36-13.png",
          "permission": "OWN",
          "type": "FILE"
        },
        {
          "id": "7617ea14-54bb-11e4-8cb6-3c4a92e4a804",
          "name": "soemthiong",
          "path": "/iplant/home/ipcdev/soemthiong",
          "permission": "OWN",
          "type": "FILE"
        },
        {
          "id": "43c93a70-e212-11e3-b983-6abdce5a08d5",
          "name": "tmp.txt",
          "path": "/iplant/home/ipcdev/tmp.txt",
          "permission": "OWN",
          "type": "FILE"
        }
      ]
    }
  }
}
```

More testing needs to be done with this, but it's a start at least and the basic functionality should work.