### PR TITLE
Initial auth implementation using OAuth2

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -2,9 +2,17 @@ base_url: http://localhost:3000
 terrain_url: http://terrain
 listen_port: 3000
 
+db:
+    host: localhost
+    port: 5432
+    user: null
+    password: null
+    database: de
+
 sessions:
     secret: "keyboard cat"
     secure_cookie: false
+    ttl: 8
 
 oauth2:
     authorization_url: "https://olson.cyverse.org/cas/oauth2.0/authorize"

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,2 +1,14 @@
+base_url: http://localhost:3000
 terrain_url: http://terrain
 listen_port: 3000
+
+sessions:
+    secret: "keyboard cat"
+    secure_cookie: false
+
+oauth2:
+    authorization_url: "https://olson.cyverse.org/cas/oauth2.0/authorize"
+    token_url: "https://olson.cyverse.org/cas/oauth2.0/token"
+    profile_url: "https://olson.cyverse.org/cas/oauth2.0/profile"
+    client_id: null
+    client_secret: null

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -10,5 +10,6 @@ oauth2:
     authorization_url: "https://olson.cyverse.org/cas/oauth2.0/authorize"
     token_url: "https://olson.cyverse.org/cas/oauth2.0/token"
     profile_url: "https://olson.cyverse.org/cas/oauth2.0/profile"
+    logout_url: "https://olson.cyverse.org/cas/logout"
     client_id: null
     client_secret: null

--- a/package-lock.json
+++ b/package-lock.json
@@ -6964,6 +6964,11 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -9939,6 +9944,46 @@
         }
       }
     },
+    "express-session": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.0.tgz",
+      "integrity": "sha512-t4oX2z7uoSqATbMfsxWMbNjAL0T5zpvcJCk3Z9wnPPN7ibddhnmDZXHfEcoBMG2ojKXZoCyPMc5FbtK+G7SoDg==",
+      "requires": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.0",
+        "uid-safe": "~2.1.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        }
+      }
+    },
     "ext": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
@@ -10526,13 +10571,14 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
       "optional": true,
       "requires": {
+        "bindings": "^1.5.0",
         "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
+        "node-pre-gyp": "*"
       },
       "dependencies": {
         "abbrev": {
@@ -10574,7 +10620,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.3",
           "bundled": true,
           "optional": true
         },
@@ -10599,7 +10645,7 @@
           "optional": true
         },
         "debug": {
-          "version": "4.1.1",
+          "version": "3.2.6",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -10622,11 +10668,11 @@
           "optional": true
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -10650,7 +10696,7 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.6",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -10676,7 +10722,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -10693,7 +10739,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true,
           "optional": true
         },
@@ -10729,7 +10775,7 @@
           "optional": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.9.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -10738,11 +10784,11 @@
           }
         },
         "minizlib": {
-          "version": "1.2.1",
+          "version": "1.3.3",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
@@ -10754,22 +10800,22 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
+          "version": "2.1.2",
           "bundled": true,
           "optional": true
         },
         "needle": {
-          "version": "2.3.0",
+          "version": "2.4.0",
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "^4.1.0",
+            "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.12.0",
+          "version": "0.14.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -10782,7 +10828,7 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
@@ -10795,12 +10841,20 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.6",
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
           "bundled": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.4.1",
+          "version": "1.4.7",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -10862,7 +10916,7 @@
           "optional": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "optional": true
         },
@@ -10899,7 +10953,7 @@
           }
         },
         "rimraf": {
-          "version": "2.6.3",
+          "version": "2.7.1",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -10922,7 +10976,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true,
           "optional": true
         },
@@ -10968,17 +11022,17 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.8",
+          "version": "4.4.13",
           "bundled": true,
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           }
         },
         "util-deprecate": {
@@ -11000,7 +11054,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "3.1.1",
           "bundled": true,
           "optional": true
         }
@@ -15084,6 +15138,11 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
     },
+    "oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -15545,6 +15604,32 @@
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
+    "passport": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.1.tgz",
+      "integrity": "sha512-IxXgZZs8d7uFSt3eqNjM9NQ3g3uQCW5avD8mRNoXV99Yig50vjuaez6dQK2qC0kVWPRTujxY0dWgGfT09adjYg==",
+      "requires": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1"
+      }
+    },
+    "passport-oauth2": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.5.0.tgz",
+      "integrity": "sha512-kqBt6vR/5VlCK8iCx1/KpY42kQ+NEHZwsSyt4Y6STiNjU+wWICG1i8ucc1FapXDGO15C5O5VZz7+7vRzrDPXXQ==",
+      "requires": {
+        "base64url": "3.x.x",
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      }
+    },
+    "passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
     "path-browserify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
@@ -15599,6 +15684,11 @@
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
       }
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "pbkdf2": {
       "version": "3.0.17",
@@ -17042,6 +17132,11 @@
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.21.0.tgz",
       "integrity": "sha1-oAGr7bP/YQd9T/HVd9RN536NCjU=",
       "dev": true
+    },
+    "random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -20531,6 +20626,19 @@
           "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
         }
       }
+    },
+    "uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "requires": {
+        "random-bytes": "~1.0.0"
+      }
+    },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
     },
     "undefsafe": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18664,6 +18664,17 @@
         }
       }
     },
+    "request-promise": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.5.tgz",
+      "integrity": "sha512-ZgnepCykFdmpq86fKGwqntyTiUrHycALuGggpyCZwMvGaZWgxW6yagT0FHkgo5LzYvOaCNvxYwWYIjevSH1EDg==",
+      "requires": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.3",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
     "request-promise-core": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7255,6 +7255,11 @@
       "resolved": "https://registry.npmjs.org/buffer-json/-/buffer-json-2.0.0.tgz",
       "integrity": "sha512-+jjPFVqyfF1esi9fvfUs3NqM0pH1ziZ36VP4hmA/y/Ssfo/5w5xHKfTw9BwQjoJ1w/oVtpLomqwUHKdefGyuHw=="
     },
+    "buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
+    },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -7959,6 +7964,14 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
       "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
+    },
+    "connect-pg-simple": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/connect-pg-simple/-/connect-pg-simple-6.1.0.tgz",
+      "integrity": "sha512-pWRuser61Opj/LtzrkuRkmBcCYY1dvZ7jLu83rR7vIsTzFpmQoe1KcmMalwlN3rCq1VVHssGjY42SCSe2vEizQ==",
+      "requires": {
+        "pg": "^7.4.3"
+      }
     },
     "console-browserify": {
       "version": "1.2.0",
@@ -15502,6 +15515,11 @@
         "semver": "^5.1.0"
       }
     },
+    "packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
     "pako": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
@@ -15706,6 +15724,68 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "pg": {
+      "version": "7.17.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.17.1.tgz",
+      "integrity": "sha512-SYWEip6eADsgDQIZk0bmB2JDOrC8Xu6z10KlhlXl03NSomwVmHB6ZTVyDCwOfT6bXHI8QndJdk5XxSSRXikaSA==",
+      "requires": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "0.1.3",
+        "pg-packet-stream": "^1.1.0",
+        "pg-pool": "^2.0.9",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x",
+        "semver": "4.3.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+          "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
+        }
+      }
+    },
+    "pg-connection-string": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
+      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-packet-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pg-packet-stream/-/pg-packet-stream-1.1.0.tgz",
+      "integrity": "sha512-kRBH0tDIW/8lfnnOyTwKD23ygJ/kexQVXZs7gEyBljw4FYqimZFxnMMx50ndZ8In77QgfGuItS5LLclC2TtjYg=="
+    },
+    "pg-pool": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.9.tgz",
+      "integrity": "sha512-gNiuIEKNCT3OnudQM2kvgSnXsLkSpd6mS/fRnqs6ANtrke6j8OY5l9mnAryf1kgwJMWLg0C1N1cYTZG1xmEYHQ=="
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
+      "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+      "requires": {
+        "split": "^1.0.0"
+      }
     },
     "picomatch": {
       "version": "2.2.1",
@@ -16846,6 +16926,29 @@
         "flatten": "^1.0.2",
         "indexes-of": "^1.0.1",
         "uniq": "^1.0.1"
+      }
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
+    },
+    "postgres-date": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.4.tgz",
+      "integrity": "sha512-bESRvKVuTrjoBluEcpv2346+6kgB7UlnqWZsnbnCccTNq/pqfj1j6oBaN5+b/NrDXepYUT/HKadqv3iS9lJuVA=="
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "requires": {
+        "xtend": "^4.0.0"
       }
     },
     "prelude-ls": {
@@ -19647,6 +19750,14 @@
             "util-deprecate": "^1.0.1"
           }
         }
+      }
+    },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "requires": {
+        "through": "2"
       }
     },
     "split-string": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "apollo-datasource-rest": "^0.6.11",
     "apollo-server-express": "^2.9.15",
     "config": "^3.2.4",
+    "connect-pg-simple": "^6.1.0",
     "express": "^4.17.1",
     "express-session": "^1.17.0",
     "formik": "^1.5.8",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "apollo-server-express": "^2.9.15",
     "config": "^3.2.4",
     "express": "^4.17.1",
+    "express-session": "^1.17.0",
     "formik": "^1.5.8",
     "graphql": "^14.5.8",
     "graphql-middleware": "^4.0.2",
@@ -61,13 +62,15 @@
     "js-yaml": "^3.13.1",
     "next": "^9.1.7",
     "node-fetch": "^2.6.0",
+    "passport": "^0.4.1",
+    "passport-oauth2": "^1.5.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-intl": "^2.9.0",
     "react-select": "^2.4.4"
   },
   "optionalDependencies": {
-    "fsevents": "^1.2.9"
+    "fsevents": "^1.2.11"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.7",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-intl": "^2.9.0",
-    "react-select": "^2.4.4"
+    "react-select": "^2.4.4",
+    "request-promise": "^4.2.5"
   },
   "optionalDependencies": {
     "fsevents": "^1.2.11"

--- a/src/server/authStrategy.js
+++ b/src/server/authStrategy.js
@@ -1,0 +1,75 @@
+/**
+ * Application authentication strategy module.
+ * @module authStrategy
+ */
+
+import * as config from "./configuration";
+
+import OAuth2Strategy from "passport-oauth2";
+import rp from "request-promise";
+import passport from "passport";
+
+/**
+ * Defines the authentication strategy used by passport.
+ *
+ * @type {passport.strategy}
+ */
+export const strategy = new OAuth2Strategy(
+    {
+        authorizationURL: config.oauth2AuthorizationURL,
+        tokenURL: config.oauth2TokenURL,
+        clientID: config.oauth2ClientID,
+        clientSecret: config.oauth2ClientSecret,
+        callbackURL: `${config.baseURL}/login`,
+    },
+    function(accessToken, refreshToken, profile, done) {
+        done(null, {
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+            profile: profile,
+        });
+    }
+);
+
+/**
+ * Obtains the user profile using an access token from the OAuth provider.
+ *
+ * @param {string} accessToken
+ * @param {function} done
+ */
+strategy.userProfile = function(accessToken, done) {
+    const options = {
+        uri: config.oauth2ProfileURL,
+        qs: {
+            access_token: accessToken,
+        },
+        json: true,
+    };
+    rp(options)
+        .then((profile) => {
+            done(null, profile);
+        })
+        .catch((err) => {
+            done(`unable to obtain the user profile: ${err}`, null);
+        });
+};
+
+/**
+ * Serializes the user profile so that it can be stored in the session.
+ *
+ * @param {*} user
+ * @param {function} done
+ */
+export const serializeUser = (user, done) => {
+    done(null, JSON.stringify(user));
+};
+
+/**
+ * Deserializes the user profile so that it can be retrieved from the session.
+ *
+ * @param {*} user
+ * @param {function} done
+ */
+export const deserializeUser = (user, done) => {
+    done(null, JSON.parse(user));
+};

--- a/src/server/configuration.js
+++ b/src/server/configuration.js
@@ -52,6 +52,7 @@ export const validate = () => {
     validateConfigSetting("oauth2.authorization_url");
     validateConfigSetting("oauth2.token_url");
     validateConfigSetting("oauth2.profile_url");
+    validateConfigSetting("oauth2.logout_url");
     validateConfigSetting("oauth2.client_id");
     validateConfigSetting("oauth2.client_secret");
 };
@@ -126,6 +127,13 @@ export const oauth2TokenURL = config.get("oauth2.token_url");
  * @type {string}
  */
 export const oauth2ProfileURL = config.get("oauth2.profile_url");
+
+/**
+ * The URL to redirect the user too when logging out. Taken from the
+ * 'oauth2.logout_url' setting in the configuration file.
+ * @type {string}
+ */
+export const oauth2LogoutURL = config.get("oauth2.logout_url");
 
 /**
  * The client ID to use for the OAuth2 provider. Taken from the

--- a/src/server/configuration.js
+++ b/src/server/configuration.js
@@ -6,20 +6,63 @@
 import config from "config";
 
 /**
+ * Verifies that a setting is present in the configuration.
+ *
+ * @param {string} name
+ */
+function validateConfigSetting(name) {
+    if (!config.has(name)) {
+        throw Error(`${name} must be set in the configuration`);
+    }
+}
+
+/**
+ * Parses a configuration setting as a Boolean value. If the value is already Boolean then it's simply returned. If
+ * the value is a string then it's treated as true only if it is equal to "true" (case insensitive, with optional
+ * leading or trailing whitespace). If the value is any other type then it will be treated as false.
+ *
+ * @param {*} value
+ */
+function parseBoolean(value) {
+    if (typeof value == "boolean") {
+        return value;
+    } else if (typeof value == "string") {
+        return /^\s*true\s*$/i.test(value);
+    } else {
+        return false;
+    }
+}
+
+/**
  * Ensures that the values from the configuration file and the environment
  * variables are generally acceptable. Accepts no parameters. Throws an
  * exception if there is a problem.
  * @function
  */
 export const validate = () => {
-    if (!config.has("terrain_url")) {
-        throw Error("terrain_url must be set in the configuration");
-    }
+    validateConfigSetting("base_url");
+    validateConfigSetting("terrain_url");
+    validateConfigSetting("listen_port");
 
-    if (!config.has("listen_port")) {
-        throw Error("listen_port must be set in the configuration");
-    }
+    // Session configuration settings.
+    validateConfigSetting("sessions.secret");
+    validateConfigSetting("sessions.secure_cookie");
+
+    // OAuth2 configuration settings.
+    validateConfigSetting("oauth2.authorization_url");
+    validateConfigSetting("oauth2.token_url");
+    validateConfigSetting("oauth2.profile_url");
+    validateConfigSetting("oauth2.client_id");
+    validateConfigSetting("oauth2.client_secret");
 };
+
+/**
+ * The bse URL for the Discovery Environment. Taken from the 'base_url'
+ * setting in the configuration file.
+ *
+ * @type {string}
+ */
+export const baseURL = config.get("base_url");
 
 /**
  * The base URL for the Terrain service. Taken from the
@@ -44,3 +87,56 @@ export const isDevelopment = process.env.NODE_ENV !== "production";
  * @type {number}
  */
 export const listenPort = parseInt(config.get("listen_port"), 10);
+
+/**
+ * The secret to use when encoding and decoding secrets. Taken from the
+ * 'sessions.secret' setting in the configuration file.
+ * @type {string}
+ */
+export const sessionSecret = config.get("sessions.secret");
+
+/**
+ * Whether or not to use secure cookies to store a session. Secure cookies
+ * will not work if HTTPS isn't being used. Taken from the
+ * 'sessions.secure_cookie' setting in the configuration file.
+ * @type {boolean}
+ */
+export const sessionSecureCookie = parseBoolean(
+    config.get("sessions.secure_cookie")
+);
+
+/**
+ * The URL to redirect users to for OAuth2 authorization. Taken from the
+ * 'oauth2.authorization_url' setting in the configuration file.
+ * @type {string}
+ */
+export const oauth2AuthorizationURL = config.get("oauth2.authorization_url");
+
+/**
+ * The URL to connect to in order to get an OAuth2 token. Taken from the
+ * 'oauth2.token_url' setting in the configuration file.
+ * @type {string}
+ */
+export const oauth2TokenURL = config.get("oauth2.token_url");
+
+/**
+ * The URL to connect to in order to obtain the user profile once an access
+ * token has been obtained. Taken from the 'oauth2.profile_url' setting in
+ * the configuration file.
+ * @type {string}
+ */
+export const oauth2ProfileURL = config.get("oauth2.profile_url");
+
+/**
+ * The client ID to use for the OAuth2 provider. Taken from the
+ * 'oauth2.client_id' setting in the configuration file.
+ * @type {string}
+ */
+export const oauth2ClientID = config.get("oauth2.client_id");
+
+/**
+ * The client secret to use for the OAuth2 provider. Taken from the
+ * 'oauth2.client_secret' setting in the configuration file.
+ * @type {string}
+ */
+export const oauth2ClientSecret = config.get("oauth2.client_secret");

--- a/src/server/graphql/dataSources/TerrainDataSource.js
+++ b/src/server/graphql/dataSources/TerrainDataSource.js
@@ -7,6 +7,13 @@ export default class TerrainDataSource extends RESTDataSource {
         this.baseURL = terrainURL;
     }
 
+    willSendRequest(request) {
+        const token = this.context?.user?.accessToken;
+        if (typeof token !== "undefined") {
+            request.headers.set("Authorization", `Bearer ${token}`);
+        }
+    }
+
     async getStatus() {
         return await this.get("/");
     }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -34,6 +34,14 @@ const apolloServer = new ApolloServer({
     dataSources: () => ({
         terrain: new TerrainDataSource(),
     }),
+    context: ({ req }) => {
+        return { user: req.user };
+    },
+    playground: {
+        settings: {
+            "request.credentials": "include",
+        },
+    },
 });
 
 // Configure passport.

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,11 +1,13 @@
 import express from "express";
 import next from "next";
+import passport from "passport";
 
 import * as config from "./configuration";
 
 import { ApolloServer } from "apollo-server-express";
 import { applyMiddleware } from "graphql-middleware";
 import { makeExecutableSchema } from "graphql-tools";
+import { OAuth2Strategy } from "passport-oauth2";
 
 import typeDefs from "./graphql/typesDefs";
 import resolvers from "./graphql/resolvers";

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -74,6 +74,14 @@ app.prepare()
             })
         );
 
+        server.get("/logout", (req, res) => {
+            req.session.destroy(() =>
+                res.redirect(
+                    `${config.oauth2LogoutURL}?service=${config.baseURL}`
+                )
+            );
+        });
+
         server.get("*", (req, res) => {
             return nextHandler(req, res);
         });

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,13 +1,14 @@
 import express from "express";
 import next from "next";
 import passport from "passport";
+import session from "express-session";
 
 import * as config from "./configuration";
 
-import { ApolloServer } from "apollo-server-express";
+import { ApolloServer, UserInputError } from "apollo-server-express";
 import { applyMiddleware } from "graphql-middleware";
 import { makeExecutableSchema } from "graphql-tools";
-import { OAuth2Strategy } from "passport-oauth2";
+import * as authStrategy from "./authStrategy";
 
 import typeDefs from "./graphql/typesDefs";
 import resolvers from "./graphql/resolvers";
@@ -34,15 +35,44 @@ const apolloServer = new ApolloServer({
     }),
 });
 
+// Configure passport.
+passport.use(authStrategy.strategy);
+passport.serializeUser(authStrategy.serializeUser);
+passport.deserializeUser(authStrategy.deserializeUser);
+
 app.prepare()
 
     .then(() => {
         const server = express();
 
+        // Configure sessions.
+        server.use(
+            session({
+                secret: config.sessionSecret,
+                resave: false,
+                saveUninitialized: true,
+                cookie: {
+                    secure: config.sessionSecureCookie,
+                },
+            })
+        );
+
+        // Configure passport.
+        server.use(passport.initialize());
+        server.use(passport.session());
+
         // Add Apollo as middleware to Express.
         apolloServer.applyMiddleware({
             app: server,
         });
+
+        server.get(
+            "/login",
+            passport.authenticate("oauth2", {
+                session: true,
+                successReturnToOrRedirect: "/",
+            })
+        );
 
         server.get("*", (req, res) => {
             return nextHandler(req, res);


### PR DESCRIPTION
I wanted to get something working quickly, so I'm going to go with OAuth2 for the time being. The passport strategy for OAuth2 seems to be better documented than the one for OpenID Connect. This isn't quite where I want it to end up yet, but I think it's at a point where it can be merged so that other people can start working on this.

The default configuration settings are almost sufficient for local testing, but you will need a `local.yaml` file for some additional configuration settings:

```yaml
terrain_url: https://example.org/terrain

db:
    host: database.example.org
    user: dbuser
    password: dbpassword

oauth2:
    client_id: oauthclientid
    client_secret: oauthclientsecret
```

Once you have these settings configured, you can start up your local server and open up a browser connection to it. To log in, navigate to `http://localhost:3000/login`. You should be redirected to the OAuth provider's login page. After entering your credentials you can navigate to `http://localhost:3000/graphql` to get to the GraphQL playground. While you're logged in, the authorization header should automatically be added to GraphQL requests. To log out, point your browser to `http://localhost:3000/logout`.

The next step is to add ways for users to be redirected to the `/login` and `/logout` routes when they click on the appropriate widgets in the UI.