### PR TITLE
Sanitize the filesystem data model and query.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8616,6 +8616,11 @@
         }
       }
     },
+    "dataloader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
+      "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
+    },
     "date-fns": {
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "apollo-server-express": "^2.9.15",
     "config": "^3.2.4",
     "connect-pg-simple": "^6.1.0",
+    "dataloader": "^2.0.0",
     "express": "^4.17.1",
     "express-session": "^1.17.0",
     "formik": "^1.5.8",

--- a/src/server/graphql/dataSources/TerrainDataSource.js
+++ b/src/server/graphql/dataSources/TerrainDataSource.js
@@ -39,7 +39,9 @@ export default class TerrainDataSource extends RESTDataSource {
     /**
      * Returns info about a file or folder from terrain.
      * @param {string} fullPath - The full path to the file in the data store.
-     * @returns {(File | Folder)}
+     *
+     * Each object in the returned array is either a File or a Folder.
+     * @returns {Array<Object>}
      */
     fsStatDataLoader = new DataLoader(async (fullPaths) => {
         const resp = await this.post("/secured/filesystem/stat", {
@@ -60,7 +62,7 @@ export default class TerrainDataSource extends RESTDataSource {
      * @param {string} entityType - The type of items included in the results. Should be one of FILE, FOLDER, or ANY.
      * @param {string} sortColumn - The column to sort on. One of NAME, ID, LASTMODIFIED, DATECREATED, SIZE, or PATH.
      * @param {string} sortDirection - One of "ASC" (for ascending order) or "DESC" (for descending order).
-     * @returns {Array<{(File | Folder)}>}
+     * @returns {FolderContents}
      */
     async listFolder(
         path,

--- a/src/server/graphql/dataSources/TerrainDataSource.js
+++ b/src/server/graphql/dataSources/TerrainDataSource.js
@@ -83,7 +83,7 @@ export default class TerrainDataSource extends RESTDataSource {
 
         // Unlike the stat endpoint, the page-directory call doesn't include
         // the type field, so we add it in here for consistency.
-        const { files, folders } = responseValue;
+        const { files, folders, total, totalBad } = responseValue;
 
         const listingFolders = folders.map((f) => {
             f.type = FOLDER;
@@ -95,6 +95,10 @@ export default class TerrainDataSource extends RESTDataSource {
             return f;
         });
 
-        return [...listingFolders, ...listingFiles];
+        return {
+            total,
+            totalBad,
+            listing: [...listingFolders, ...listingFiles],
+        };
     }
 }

--- a/src/server/graphql/dataSources/TerrainDataSource.js
+++ b/src/server/graphql/dataSources/TerrainDataSource.js
@@ -6,7 +6,6 @@
 
 import { RESTDataSource } from "apollo-datasource-rest";
 import { terrainURL } from "../../configuration";
-import _ from "lodash";
 import DataLoader from "dataloader";
 
 export const FILE = "file";
@@ -48,7 +47,7 @@ export default class TerrainDataSource extends RESTDataSource {
         });
 
         // Guarantees ordering, hopefully
-        return _.map(fullPaths, (path) => resp.paths[path]);
+        return fullPaths.map((path) => resp.paths[path]);
     });
 
     filesystemStat = async (path) => this.fsStatDataLoader.load(path);
@@ -82,24 +81,20 @@ export default class TerrainDataSource extends RESTDataSource {
             `/secured/filesystem/paged-directory?${pathParam}&${limitParam}&${offsetParam}&${entityTypeParam}&${sortColumnParam}&${sortDirectionParam}`
         );
 
-        let listing = [];
-
         // Unlike the stat endpoint, the page-directory call doesn't include
         // the type field, so we add it in here for consistency.
-        listing = listing.concat(
-            _.map(responseValue.folders, (f) => {
-                f.type = FOLDER;
-                return f;
-            })
-        );
+        const { files, folders } = responseValue;
 
-        listing = listing.concat(
-            _.map(responseValue.files, (f) => {
-                f.type = FILE;
-                return f;
-            })
-        );
+        const listingFolders = folders.map((f) => {
+            f.type = FOLDER;
+            return f;
+        });
 
-        return listing;
+        const listingFiles = files.map((f) => {
+            f.type = FILE;
+            return f;
+        });
+
+        return [...listingFolders, ...listingFiles];
     }
 }

--- a/src/server/graphql/dataSources/TerrainDataSource.js
+++ b/src/server/graphql/dataSources/TerrainDataSource.js
@@ -77,34 +77,24 @@ export default class TerrainDataSource extends RESTDataSource {
             `/secured/filesystem/paged-directory?${pathParam}&${limitParam}&${offsetParam}&${entityTypeParam}&${sortColumnParam}&${sortDirectionParam}`
         );
 
-        // The page-directory endpoint doesn't include a type field for the
-        // folder being listed (because you should already know), but for
-        // consistency we'll include it here.
-        let retval = {
-            listing: [],
-            stat: _.set(
-                _.omit(responseValue, ["files", "folders"]), // unify the listing.
-                "type",
-                "folder"
-            ),
-        };
+        let listing = [];
 
         // Unlike the stat endpoint, the page-directory call doesn't include
         // the type field, so we add it in here for consistency.
-        retval.listing = retval.listing.concat(
+        listing = listing.concat(
             _.map(responseValue.folders, (f) => {
                 f.type = FOLDER;
                 return f;
             })
         );
 
-        retval.listing = retval.listing.concat(
+        listing = listing.concat(
             _.map(responseValue.files, (f) => {
                 f.type = FILE;
                 return f;
             })
         );
 
-        return retval;
+        return listing;
     }
 }

--- a/src/server/graphql/resolvers/Filesystem.js
+++ b/src/server/graphql/resolvers/Filesystem.js
@@ -49,6 +49,10 @@ export default {
             const stat = await dataSources.terrain.filesystemStat(file.path);
             return stat["share-count"];
         },
+        contentType: async (file, _args, { dataSources }) => {
+            const stat = await dataSources.terrain.filesystemStat(file.path);
+            return stat["content-type"];
+        },
         md5: async (file, _args, { dataSources }) => {
             const stat = await dataSources.terrain.filesystemStat(file.path);
             return stat["md5"];

--- a/src/server/graphql/resolvers/Filesystem.js
+++ b/src/server/graphql/resolvers/Filesystem.js
@@ -46,27 +46,23 @@ export default {
 
     File: {
         md5: async (file, _args, { dataSources }) => {
-            const stats = await dataSources.terrain.filesystemStat([file.path]);
-            return stats[0]["md5"];
+            const stat = await dataSources.terrain.filesystemStat(file.path);
+            return stat["md5"];
         },
         shareCount: async (file, _args, { dataSources }) => {
-            const stats = await dataSources.terrain.filesystemStat([file.path]);
-            return stats[0]["share-count"];
+            const stat = await dataSources.terrain.filesystemStat(file.path);
+            return stat["share-count"];
         },
     },
 
     Folder: {
         fileCount: async (folder, _args, { dataSources }) => {
-            const stats = await dataSources.terrain.filesystemStat([
-                folder.path,
-            ]);
-            return stats[0]["file-count"];
+            const stat = await dataSources.terrain.filesystemStat(folder.path);
+            return stat["file-count"];
         },
         shareCount: async (folder, _args, { dataSources }) => {
-            const stats = await dataSources.terrain.filesystemStat([
-                folder.path,
-            ]);
-            return stats[0]["share-count"];
+            const stat = await dataSources.terrain.filesystemStat(folder.path);
+            return stat["share-count"];
         },
         contents: async (folder, args, { dataSources }) =>
             await dataSources.terrain.listFolder(

--- a/src/server/graphql/resolvers/Filesystem.js
+++ b/src/server/graphql/resolvers/Filesystem.js
@@ -45,10 +45,6 @@ export default {
     },
 
     File: {
-        md5: async (file, _args, { dataSources }) => {
-            const stat = await dataSources.terrain.filesystemStat(file.path);
-            return stat["md5"];
-        },
         shareCount: async (file, _args, { dataSources }) => {
             const stat = await dataSources.terrain.filesystemStat(file.path);
             return stat["share-count"];

--- a/src/server/graphql/resolvers/Filesystem.js
+++ b/src/server/graphql/resolvers/Filesystem.js
@@ -60,6 +60,10 @@ export default {
             const stat = await dataSources.terrain.filesystemStat(folder.path);
             return stat["file-count"];
         },
+        folderCount: async (folder, _args, { dataSources }) => {
+            const stat = await dataSources.terrain.filesystemStat(folder.path);
+            return stat["dir-count"];
+        },
         shareCount: async (folder, _args, { dataSources }) => {
             const stat = await dataSources.terrain.filesystemStat(folder.path);
             return stat["share-count"];

--- a/src/server/graphql/resolvers/Filesystem.js
+++ b/src/server/graphql/resolvers/Filesystem.js
@@ -49,6 +49,10 @@ export default {
             const stat = await dataSources.terrain.filesystemStat(file.path);
             return stat["share-count"];
         },
+        md5: async (file, _args, { dataSources }) => {
+            const stat = await dataSources.terrain.filesystemStat(file.path);
+            return stat["md5"];
+        },
     },
 
     Folder: {

--- a/src/server/graphql/resolvers/Filesystem.js
+++ b/src/server/graphql/resolvers/Filesystem.js
@@ -44,7 +44,30 @@ export default {
         },
     },
 
+    File: {
+        md5: async (file, _args, { dataSources }) => {
+            const stats = await dataSources.terrain.filesystemStat([file.path]);
+            return stats[0]["md5"];
+        },
+        shareCount: async (file, _args, { dataSources }) => {
+            const stats = await dataSources.terrain.filesystemStat([file.path]);
+            return stats[0]["share-count"];
+        },
+    },
+
     Folder: {
+        fileCount: async (folder, _args, { dataSources }) => {
+            const stats = await dataSources.terrain.filesystemStat([
+                folder.path,
+            ]);
+            return stats[0]["file-count"];
+        },
+        shareCount: async (folder, _args, { dataSources }) => {
+            const stats = await dataSources.terrain.filesystemStat([
+                folder.path,
+            ]);
+            return stats[0]["share-count"];
+        },
         contents: async (folder, args, { dataSources }) =>
             await dataSources.terrain.listFolder(
                 folder.path,

--- a/src/server/graphql/resolvers/Filesystem.js
+++ b/src/server/graphql/resolvers/Filesystem.js
@@ -30,7 +30,7 @@ export default {
         OWN: "own",
     },
 
-    FolderListingResult: {
+    FilesystemObject: {
         __resolveType(obj, _context, _info) {
             if (obj.type) {
                 if (obj.type.toUpperCase() === "FILE") {
@@ -44,17 +44,15 @@ export default {
         },
     },
 
-    FilesystemObject: {
-        __resolveType(obj, _context, _info) {
-            if (obj.type) {
-                if (obj.type.toUpperCase() === "FILE") {
-                    return "File"; // File is the name of the concrete GraphQL type.
-                }
-                if (obj.type === "dir" || obj.type.toUpperCase() === "FOLDER") {
-                    return "Folder"; // Folder is the name of the concrete GraphQL type.
-                }
-            }
-            return null;
-        },
+    Folder: {
+        contents: async (folder, args, { dataSources }) =>
+            await dataSources.terrain.listFolder(
+                folder.path,
+                args.limit || 50,
+                args.offset || 0,
+                args.entityType || "any",
+                args.sortColumn || "name",
+                args.sortDirection || "asc"
+            ),
     },
 };

--- a/src/server/graphql/resolvers/Query.js
+++ b/src/server/graphql/resolvers/Query.js
@@ -4,7 +4,7 @@ export default {
             await dataSources.terrain.getStatus(),
         newUUID: async (_source, _args, { dataSources }) =>
             await dataSources.terrain.getNewUUID(),
-        filesystem: async (_source, { paths }, { dataSources }) =>
-            await dataSources.terrain.filesystemStat(paths),
+        filesystem: async (_source, { path }, { dataSources }) =>
+            await dataSources.terrain.filesystemStat(path),
     },
 };

--- a/src/server/graphql/resolvers/Query.js
+++ b/src/server/graphql/resolvers/Query.js
@@ -4,19 +4,7 @@ export default {
             await dataSources.terrain.getStatus(),
         newUUID: async (_source, _args, { dataSources }) =>
             await dataSources.terrain.getNewUUID(),
-        filesystemStat: async (_source, { paths }, { dataSources }) =>
+        filesystem: async (_source, { paths }, { dataSources }) =>
             await dataSources.terrain.filesystemStat(paths),
-
-        // The defaults for the args don't seem to get passed down, we're setting
-        // them here.
-        listFolder: async (_source, args, { dataSources }) =>
-            await dataSources.terrain.listFolder(
-                args.path,
-                args.limit || 50,
-                args.offset || 0,
-                args.entityType || "any",
-                args.sortColumn || "name",
-                args.sortDirection || "asc"
-            ),
     },
 };

--- a/src/server/graphql/typesDefs/Filesystem.js
+++ b/src/server/graphql/typesDefs/Filesystem.js
@@ -78,11 +78,15 @@ export default gql`
         dateCreated: BigInt
         dateModified: BigInt
         type: EntityType
+
+        """
+        The number of times the file has been shared.
+        This is an expensive field, especially when nested inside of folder contents.
+        """
         shareCount: Int
 
         # Specific to files
         infoType: String
-        md5: String
         fileSize: BigInt
     }
 
@@ -95,9 +99,19 @@ export default gql`
         dateCreated: BigInt
         dateModified: BigInt
         type: EntityType
+
+        """
+        The number of times the file has been shared.
+        This is an expensive field, especially when nested inside the contents.
+        """
         shareCount: Int
 
         # Specific to folders
+
+        """
+        The number of files contained in the folder.
+        This is an expensive field, especially when nested inside the contents.
+        """
         fileCount: Int
         contents: [FilesystemObject]
     }

--- a/src/server/graphql/typesDefs/Filesystem.js
+++ b/src/server/graphql/typesDefs/Filesystem.js
@@ -86,9 +86,6 @@ export default gql`
         fileSize: BigInt
     }
 
-    # Allows us to later extend the kinds of objects returned by a listing
-    union FolderListingResult = File | Folder
-
     type Folder implements FilesystemObject {
         #Interface implementation
         id: String!
@@ -102,12 +99,6 @@ export default gql`
 
         # Specific to folders
         fileCount: Int
-    }
-
-    # Allows us to fetch everything at once without having to cache results or
-    # hit stat a bunch of times.
-    type FolderListing {
-        stat: Folder
-        listing: [FilesystemObject]
+        contents: [FilesystemObject]
     }
 `;

--- a/src/server/graphql/typesDefs/Filesystem.js
+++ b/src/server/graphql/typesDefs/Filesystem.js
@@ -124,6 +124,12 @@ export default gql`
         This an expensive field to include inside content listings.
         """
         folderCount: Int
-        contents: [FilesystemObject]
+        contents: FolderContents
+    }
+
+    type FolderContents {
+        total: Int
+        totalBad: Int
+        listing: [FilesystemObject]
     }
 `;

--- a/src/server/graphql/typesDefs/Filesystem.js
+++ b/src/server/graphql/typesDefs/Filesystem.js
@@ -12,8 +12,16 @@ import { gql } from "apollo-server-express";
  * @property {number} shareCount - The number of users the file has been shared with.
  * @property {string} infoType - The info type of the file.
  * @property {string} md5 - The MD5 hash of the file.
- * @property {fileSize} number - The size of the file in bytes.
+ * @property {string} contentType - The content-type of the file.
+ * @property {number} fileSize - The size of the file in bytes.
  * @
+ */
+
+/**
+ * @typedef {Object} FolderContents
+ * @property {number} total - The total number of items in the folder listing across all pages.
+ * @property {number} totalBad - The total number of items with bad names in the folder listing across all pages.
+ * @property {Array<Object>} listing - The list of files and folders contained in the parent directory.
  */
 
 /**
@@ -27,7 +35,8 @@ import { gql } from "apollo-server-express";
  * @property {string} type - Either "file" or "folder". Should be "folder".
  * @property {number} shareCount - The number of users the folder has been shared with.
  * @property {number} fileCount - The number of files contained in the folder.
- * @property {Array<Object>} listing - A list of files and folders contained in the folder.
+ * @property {number} folderCount - The number of folders contained in the folder.
+ * @property {FolderContents} contents - A list of files and folders contained in the folder.
  */
 
 export default gql`

--- a/src/server/graphql/typesDefs/Filesystem.js
+++ b/src/server/graphql/typesDefs/Filesystem.js
@@ -118,6 +118,11 @@ export default gql`
         This is an expensive field, especially when nested inside the contents.
         """
         fileCount: Int
+
+        """
+        This an expensive field to include inside content listings.
+        """
+        folderCount: Int
         contents: [FilesystemObject]
     }
 `;

--- a/src/server/graphql/typesDefs/Filesystem.js
+++ b/src/server/graphql/typesDefs/Filesystem.js
@@ -88,6 +88,11 @@ export default gql`
         # Specific to files
         infoType: String
         fileSize: BigInt
+
+        """
+        This is an expensive field to include in folder listings.
+        """
+        md5: String
     }
 
     type Folder implements FilesystemObject {

--- a/src/server/graphql/typesDefs/Filesystem.js
+++ b/src/server/graphql/typesDefs/Filesystem.js
@@ -87,6 +87,7 @@ export default gql`
 
         # Specific to files
         infoType: String
+        contentType: String
         fileSize: BigInt
 
         """

--- a/src/server/graphql/typesDefs/Query.js
+++ b/src/server/graphql/typesDefs/Query.js
@@ -9,15 +9,6 @@ export default gql`
 
         newUUID: String
 
-        filesystemStat(paths: [String]): [FilesystemObject]
-
-        listFolder(
-            path: String
-            limit: Int = 50
-            offset: Int = 0
-            entityType: EntityType = "any"
-            sortColumn: SortColumn = "name"
-            sortDirection: SortDirection = "asc"
-        ): FolderListing
+        filesystem(paths: [String]): [FilesystemObject]
     }
 `;

--- a/src/server/graphql/typesDefs/Query.js
+++ b/src/server/graphql/typesDefs/Query.js
@@ -9,6 +9,6 @@ export default gql`
 
         newUUID: String
 
-        filesystem(paths: [String]): [FilesystemObject]
+        filesystem(path: String): FilesystemObject
     }
 `;

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -7,7 +7,7 @@ import pgsimple from "connect-pg-simple";
 import * as config from "./configuration";
 import * as authStrategy from "./authStrategy";
 
-import { ApolloServer, UserInputError } from "apollo-server-express";
+import { ApolloServer } from "apollo-server-express";
 import { applyMiddleware } from "graphql-middleware";
 import { makeExecutableSchema } from "graphql-tools";
 


### PR DESCRIPTION
## Scope
Move the folder listing return value into the Folder type and rename the top-level query.

## Changes

- Moves listing into the Folder type and renames it 'contents'.
- Removes the top-level listFolder query.
- Modifies the resolvers to handle the new layout.
- Modifies TerrainDataSource to remove stat information from the listFolder return value, which is now an iterable.

## Problems
Nesting the folder listings gets expensive quickly. 

## Sample query containing nested listings
The return value is too large to reproduce here.

```
{
  filesystem(paths: [
    "/iplant/home/ipcdev/"
  ]) {
    id
    name: label
    path
    type
    
    ... on File {
      fileSize
    }
    
    ... on Folder {
      contents {
        id
        name: label
        path
        type
        
        ... on File {
          fileSize
        }
        
        ... on Folder {
          contents {
            id
            name: label
            path
            type
          }
        }
      }
    }
  }
}
```