### PR TITLE
Create and use a default MUI theme

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,5 +1,12 @@
+import React from "react";
 import { withConsole } from "@storybook/addon-console";
 import { addDecorator, configure } from "@storybook/react";
+import { ThemeProvider } from "@material-ui/core/styles";
+import theme from "../src/components/theme/default";
+
+addDecorator((storyFn) => (
+    <ThemeProvider theme={theme}>{storyFn()}</ThemeProvider>
+));
 
 //redirect console error / logs / warns to action logger
 addDecorator((storyFn, context) => withConsole()(storyFn)(context));

--- a/src/components/appBar/CyVerseAppBar.js
+++ b/src/components/appBar/CyVerseAppBar.js
@@ -44,7 +44,7 @@ const useStyles = makeStyles((theme) => ({
         flexGrow: 1,
     },
     appBar: {
-        backgroundColor: theme.palette.blue,
+        backgroundColor: theme.palette.primary,
     },
     title: {
         flexGrow: 1,

--- a/src/components/appBar/CyVerseAppBar.js
+++ b/src/components/appBar/CyVerseAppBar.js
@@ -172,7 +172,10 @@ function CyverseAppBar(props) {
                             >
                                 <AccountCircleIcon
                                     fontSize="large"
-                                    style={{ color: theme.palette.white }}
+                                    style={{
+                                        color:
+                                            theme.palette.primary.contrastText,
+                                    }}
                                 />
                             </IconButton>
                         </div>

--- a/src/components/appBar/CyVerseAppBar.js
+++ b/src/components/appBar/CyVerseAppBar.js
@@ -12,7 +12,6 @@ import constants from "../../constants";
 
 import {
     build,
-    palette,
     formatHTMLMessage,
     formatMessage,
     withI18N,
@@ -35,7 +34,7 @@ import {
     Toolbar,
     Typography,
 } from "@material-ui/core";
-import { fade, makeStyles } from "@material-ui/core/styles";
+import { fade, makeStyles, useTheme } from "@material-ui/core/styles";
 import SearchIcon from "@material-ui/icons/Search";
 import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown";
 import AccountCircleIcon from "@material-ui/icons/AccountCircle";
@@ -45,7 +44,7 @@ const useStyles = makeStyles((theme) => ({
         flexGrow: 1,
     },
     appBar: {
-        backgroundColor: palette.blue,
+        backgroundColor: theme.palette.blue,
     },
     title: {
         flexGrow: 1,
@@ -98,6 +97,7 @@ const useStyles = makeStyles((theme) => ({
 const searchOptions = ["All", "Data", "Apps", "Analyses"];
 
 function CyverseAppBar(props) {
+    const theme = useTheme();
     const classes = useStyles();
     const router = useRouter();
     const { intl, children } = props;
@@ -172,7 +172,7 @@ function CyverseAppBar(props) {
                             >
                                 <AccountCircleIcon
                                     fontSize="large"
-                                    style={{ color: palette.white }}
+                                    style={{ color: theme.palette.white }}
                                 />
                             </IconButton>
                         </div>
@@ -186,6 +186,7 @@ function CyverseAppBar(props) {
 
 function SearchOptions(props) {
     const { intl } = props;
+    const theme = useTheme();
     const [open, setOpen] = React.useState(false);
     const anchorRef = React.useRef(null);
     const [selectedIndex, setSelectedIndex] = React.useState(0);
@@ -221,7 +222,7 @@ function SearchOptions(props) {
                 <Button
                     id={build(ids.APP_BAR_BASE_ID, ids.SEARCH_FILTER_BTN)}
                     onClick={handleClick}
-                    style={{ backgroundColor: palette.white }}
+                    style={{ backgroundColor: theme.palette.white }}
                 >
                     {searchOptions[selectedIndex]}
                 </Button>
@@ -230,7 +231,7 @@ function SearchOptions(props) {
                         ids.APP_BAR_BASE_ID,
                         ids.SEARCH_FILTER_OPTIONS_BTN
                     )}
-                    style={{ backgroundColor: palette.white }}
+                    style={{ backgroundColor: theme.palette.white }}
                     size="small"
                     aria-controls={
                         open

--- a/src/components/apps/tile/AppMenu.js
+++ b/src/components/apps/tile/AppMenu.js
@@ -8,13 +8,7 @@ import UnFavoriteIcon from "@material-ui/icons/FavoriteBorderOutlined";
 import FavoriteIcon from "@material-ui/icons/Favorite";
 import CommentsIcon from "@material-ui/icons/CommentOutlined";
 import PlayIcon from "@material-ui/icons/PlayArrow";
-import {
-    palette,
-    build,
-    withI18N,
-    formatMessage,
-    getMessage,
-} from "@cyverse-de/ui-lib";
+import { build, withI18N, formatMessage, getMessage } from "@cyverse-de/ui-lib";
 import intlData from "./messages";
 import ids from "./ids";
 
@@ -31,7 +25,7 @@ const useStyles = makeStyles((theme) => ({
         fontSize: 10,
     },
     toolbarItemColor: {
-        color: palette.darkBlue,
+        color: theme.palette.darkBlue,
     },
 }));
 

--- a/src/components/apps/tile/AppStatusIcon.js
+++ b/src/components/apps/tile/AppStatusIcon.js
@@ -41,7 +41,7 @@ function PrivateIcon(props) {
 
     return (
         <ToolTip title={getMessage("privateAppTooltip")}>
-            <Lock {...props} style={{ color: theme.palette.blue }} />
+            <Lock {...props} style={{ color: theme.palette.primary }} />
         </ToolTip>
     );
 }
@@ -51,7 +51,7 @@ function DisabledIcon(props) {
 
     return (
         <ToolTip title={getMessage("disabledAppTooltip")}>
-            <Disabled {...props} style={{ color: theme.palette.red }} />
+            <Disabled {...props} style={{ color: theme.palette.error }} />
         </ToolTip>
     );
 }

--- a/src/components/apps/tile/AppStatusIcon.js
+++ b/src/components/apps/tile/AppStatusIcon.js
@@ -5,7 +5,8 @@ import messages from "./messages";
 import Disabled from "@material-ui/icons/Block";
 import Lock from "@material-ui/icons/Lock";
 import ToolTip from "@material-ui/core/Tooltip";
-import { palette, withI18N, getMessage } from "@cyverse-de/ui-lib";
+import { withI18N, getMessage } from "@cyverse-de/ui-lib";
+import { useTheme } from "@material-ui/core";
 
 /**
  * @author aramsey
@@ -36,17 +37,21 @@ AppStatusIcon.propTypes = {
 };
 
 function PrivateIcon(props) {
+    const theme = useTheme();
+
     return (
         <ToolTip title={getMessage("privateAppTooltip")}>
-            <Lock {...props} style={{ color: palette.blue }} />
+            <Lock {...props} style={{ color: theme.palette.blue }} />
         </ToolTip>
     );
 }
 
 function DisabledIcon(props) {
+    const theme = useTheme();
+
     return (
         <ToolTip title={getMessage("disabledAppTooltip")}>
-            <Disabled {...props} style={{ color: palette.red }} />
+            <Disabled {...props} style={{ color: theme.palette.red }} />
         </ToolTip>
     );
 }

--- a/src/components/apps/tile/AppTile.js
+++ b/src/components/apps/tile/AppTile.js
@@ -16,13 +16,7 @@ import { withStyles } from "@material-ui/core";
 import AppName from "./AppName";
 import AppMenu from "./AppMenu";
 import ids from "./ids";
-import {
-    Highlighter,
-    build,
-    withI18N,
-    palette,
-    Rate,
-} from "@cyverse-de/ui-lib";
+import { Highlighter, build, withI18N, Rate } from "@cyverse-de/ui-lib";
 
 const styles = (theme) => ({
     card: {
@@ -43,7 +37,7 @@ const styles = (theme) => ({
     selectedCard: {
         backgroundColor:
             theme.palette.type === "light"
-                ? palette.lightBlue
+                ? theme.palette.lightBlue
                 : "rgba(255, 255, 255, 0.16)",
     },
     avatar: {

--- a/src/components/theme/default/index.js
+++ b/src/components/theme/default/index.js
@@ -1,0 +1,15 @@
+import { createMuiTheme } from "@material-ui/core/styles";
+import { palette } from "@cyverse-de/ui-lib";
+
+const theme = createMuiTheme({
+    palette: {
+        primary: {
+            main: palette.blue,
+        },
+        secondary: {
+            main: palette.lightBlue,
+        },
+    },
+});
+
+export default theme;

--- a/src/components/theme/default/index.js
+++ b/src/components/theme/default/index.js
@@ -9,6 +9,7 @@ const theme = createMuiTheme({
         secondary: {
             main: palette.lightBlue,
         },
+        ...palette,
     },
 });
 

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,6 +1,8 @@
 import React from "react";
 import App from "next/app";
 import CyverseAppBar from "../components/appBar/CyVerseAppBar";
+import theme from "../components/theme/default";
+import { ThemeProvider } from "@material-ui/core/styles";
 
 export default class MyApp extends App {
     static async getInitialProps({ Component, ctx }) {
@@ -30,9 +32,11 @@ export default class MyApp extends App {
         };
 
         return (
-            <CyverseAppBar>
-                <Component {...props} />
-            </CyverseAppBar>
+            <ThemeProvider theme={theme}>
+                <CyverseAppBar>
+                    <Component {...props} />
+                </CyverseAppBar>
+            </ThemeProvider>
         );
     }
 }


### PR DESCRIPTION
This adds a default theme that lives in `src/components/theme/default` that uses theme information from ui-lib.

The custom app in `src/pages/_app.js` has been wrapped in a `ThemeProvider` that sets the theme to the new one mentioned above.

A decorator has been added to the Storybook config that wraps the stories in a `ThemeProvider` that is passed the new default theme mentioned above.

Explicit references to the ui-lib palette have been removed from the existing components (`appBar`, and `apps/tile`) and replaced with references to the new default theme as returned by MUI's `useTheme()` or passed into `withStyles()`.