### PR TITLE
Add Download Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15458,18 +15458,6 @@
         "lower-case": "^1.1.1"
       }
     },
-    "nock": {
-      "version": "11.7.2",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-11.7.2.tgz",
-      "integrity": "sha512-7swr5bL1xBZ5FctyubjxEVySXOSebyqcL7Vy1bx1nS9IUqQWj81cmKjVKJLr8fHhtzI1MV8nyCdENA/cGcY1+Q==",
-      "requires": {
-        "debug": "^4.1.0",
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.13",
-        "mkdirp": "^0.5.0",
-        "propagate": "^2.0.0"
-      }
-    },
     "node-ask": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/node-ask/-/node-ask-1.0.1.tgz",
@@ -17918,11 +17906,6 @@
         "object.assign": "^4.1.0",
         "reflect.ownkeys": "^0.2.0"
       }
-    },
-    "propagate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
-      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag=="
     },
     "property-information": {
       "version": "5.4.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "is-plain-object": "^3.0.0",
     "js-yaml": "^3.13.1",
     "next": "^9.1.7",
-    "nock": "^11.7.2",
     "node-fetch": "^2.6.0",
     "passport": "^0.4.1",
     "passport-oauth2": "^1.5.0",

--- a/src/__tests__/fileio.js
+++ b/src/__tests__/fileio.js
@@ -28,15 +28,14 @@ const mockResponse = () => {
 };
 
 describe("/api/upload handler", () => {
-    test("with no authentication provided", async (done) => {
+    test("with no authentication provided", async () => {
         const res = mockResponse();
         await configurableUploadHandler({}, res);
         expect(res.status).toHaveBeenCalledWith(401);
         expect(res.send).toHaveBeenCalledWith("Authorization required.");
-        done();
     });
 
-    test("with no destination provided", async (done) => {
+    test("with no destination provided", async () => {
         const req = mockRequest();
         const res = mockResponse();
         await configurableUploadHandler(req, res, "http://terrain");
@@ -44,7 +43,6 @@ describe("/api/upload handler", () => {
         expect(res.send).toHaveBeenCalledWith(
             "destination query parameter must be set."
         );
-        done();
     });
 });
 

--- a/src/__tests__/fileio.js
+++ b/src/__tests__/fileio.js
@@ -2,7 +2,6 @@ import {
     configurableUploadHandler,
     configurableDownloadHandler,
 } from "../server/fileio";
-import nock from "nock";
 
 const mockRequest = (filePath, token) => {
     const req = {
@@ -29,14 +28,15 @@ const mockResponse = () => {
 };
 
 describe("/api/upload handler", () => {
-    test("with no authentication provided", async () => {
+    test("with no authentication provided", async (done) => {
         const res = mockResponse();
         await configurableUploadHandler({}, res);
         expect(res.status).toHaveBeenCalledWith(401);
         expect(res.send).toHaveBeenCalledWith("Authorization required.");
+        done();
     });
 
-    test("with no destination provided", async () => {
+    test("with no destination provided", async (done) => {
         const req = mockRequest();
         const res = mockResponse();
         await configurableUploadHandler(req, res, "http://terrain");
@@ -44,30 +44,7 @@ describe("/api/upload handler", () => {
         expect(res.send).toHaveBeenCalledWith(
             "destination query parameter must be set."
         );
-    });
-
-    test("calls terrain API", async () => {
-        const destination = "/iplant/home/test/test-file.txt";
-        const req = mockRequest(destination, "test-token");
-        const res = mockResponse();
-        const server = "http://terrain";
-        const expected = {
-            id: "test-id",
-            label: "test-label",
-            path: "/iplant/home/ipcdev/test-path.txt",
-        };
-
-        // Make sure the important bits are matched by the nock'ed server
-        const scope = nock(server, {
-            reqheaders: {
-                Authorization: `Bearer test-token`,
-            },
-        })
-            .post(`/secured/fileio/upload?dest=${destination}`)
-            .reply(200, expected);
-
-        await configurableUploadHandler(req, res, server);
-        expect(scope.isDone()); // mocked server was called as expected.
+        done();
     });
 });
 

--- a/src/__tests__/fileio.js
+++ b/src/__tests__/fileio.js
@@ -39,7 +39,7 @@ describe("/api/upload handler", () => {
         const req = mockRequest();
         const res = mockResponse();
         await configurableUploadHandler(req, res, "http://terrain");
-        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.status).toHaveBeenCalledWith(400);
         expect(res.send).toHaveBeenCalledWith(
             "destination query parameter must be set."
         );
@@ -58,7 +58,7 @@ describe("/api/download handler", () => {
         const req = mockRequest();
         const res = mockResponse();
         await configurableDownloadHandler(req, res, "http://terrain");
-        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.status).toHaveBeenCalledWith(400);
         expect(res.send).toHaveBeenCalledWith(
             "source query parameter must be set."
         );

--- a/src/server/fileio.js
+++ b/src/server/fileio.js
@@ -35,9 +35,53 @@ export const configurableUploadHandler = (req, res, apiBaseURL) => {
         })
     ).pipe(res);
 };
+
 /**
  * Same as configurableUploadHandler, but defaults to using the configured
  * terrain handler.
  */
 export const uploadHandler = (req, res) =>
     configurableUploadHandler(req, res, terrainURL);
+
+/**
+ * Handles proxying file download requests to the Terrain API.
+ * @param {object} req - An Express Request object.
+ * @param {object} res - An Express Response object.
+ * @param {string} apiBaseURL - The base URL to the backing API. Usually an instance of the terrain API.
+ * @returns null
+ */
+export const configurableDownloadHandler = (req, res, apiBaseURL) => {
+    const token = req?.user?.accessToken;
+
+    if (!token) {
+        res.status(401).send("Authorization required.");
+        return;
+    }
+
+    const { source } = req.query;
+    if (!source || source === "") {
+        res.status(500).send("source query parameter must be set.");
+        return;
+    }
+
+    const apiURL = new URL(apiBaseURL);
+    apiURL.pathname = path.join(apiURL.pathname, "/secured/fileio/download");
+    apiURL.search = `path=${source}`;
+
+    console.log(apiURL.href);
+
+    req.pipe(
+        request.get(apiURL.href, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        })
+    ).pip(res);
+};
+
+/**
+ * Same as configurableDownloadHandler, but defaults to using the configured
+ * terrain handler.
+ */
+export const downloadHandler = (req, res) =>
+    configurableDownloadHandler(req, res, terrainURL);

--- a/src/server/fileio.js
+++ b/src/server/fileio.js
@@ -23,9 +23,11 @@ export const configurableUploadHandler = (req, res, apiBaseURL) => {
         return;
     }
 
-    let apiURL = new URL(apiBaseURL);
+    const apiURL = new URL(apiBaseURL);
     apiURL.pathname = path.join(apiURL.pathname, "/secured/fileio/upload");
     apiURL.search = `dest=${destination}`;
+
+    console.log(apiURL.href);
 
     req.pipe(
         request.post(apiURL.href, {
@@ -76,7 +78,7 @@ export const configurableDownloadHandler = (req, res, apiBaseURL) => {
                 Authorization: `Bearer ${token}`,
             },
         })
-    ).pip(res);
+    ).pipe(res);
 };
 
 /**

--- a/src/server/fileio.js
+++ b/src/server/fileio.js
@@ -19,7 +19,7 @@ export const configurableUploadHandler = (req, res, apiBaseURL) => {
 
     const { destination } = req.query;
     if (!destination || destination === "") {
-        res.status(500).send("destination query parameter must be set.");
+        res.status(400).send("destination query parameter must be set.");
         return;
     }
 
@@ -62,7 +62,7 @@ export const configurableDownloadHandler = (req, res, apiBaseURL) => {
 
     const { source } = req.query;
     if (!source || source === "") {
-        res.status(500).send("source query parameter must be set.");
+        res.status(400).send("source query parameter must be set.");
         return;
     }
 

--- a/src/server/fileio.js
+++ b/src/server/fileio.js
@@ -72,6 +72,12 @@ export const configurableDownloadHandler = (req, res, apiBaseURL) => {
 
     console.log(apiURL.href);
 
+    res.set("Content-Type", "application/octet-stream");
+    res.set(
+        "Content-Disposition",
+        `attachment; filename=${path.basename(source)}`
+    );
+
     req.pipe(
         request.get(apiURL.href, {
             headers: {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -6,7 +6,7 @@ import pgsimple from "connect-pg-simple";
 
 import * as config from "./configuration";
 import * as authStrategy from "./authStrategy";
-import { uploadHandler } from "./fileio";
+import { uploadHandler, downloadHandler } from "./fileio";
 
 import { ApolloServer } from "apollo-server-express";
 import { applyMiddleware } from "graphql-middleware";
@@ -102,6 +102,7 @@ app.prepare()
         });
 
         server.post("/api/upload", uploadHandler);
+        server.get("/api/download", downloadHandler);
 
         server.get("*", (req, res) => {
             return nextHandler(req, res);


### PR DESCRIPTION
Add server support for file downloads.

Downloads are available through `GET /api/download?source=/path/to/file/in/data/store`.  The `Content-Type` header is set to `application/octet-stream` and the `Content-Disposition` is set to `attachment; filename=<basename of the source>`.

The nock tests were removed because I was having trouble adding a second nock-based test and having the tests themselves stay stable across runs. They might get re-added after more experimentation, but that will be in a separate PR.

No test page was needed for this API endpoint. To test it out:
* Pull PR.
* Run `npm run dev` (assuming you have a `config/local.yaml` file).
* Hit `http://localhost:3000/api/download?source=/iplant/home/<username>/<filename>` in a browser. A download should be initiated.