### PR TITLE
Move accessToken checking into middleware, route /api calls through Express Middleware

### DIFF
--- a/src/__tests__/fileio.js
+++ b/src/__tests__/fileio.js
@@ -28,13 +28,6 @@ const mockResponse = () => {
 };
 
 describe("/api/upload handler", () => {
-    test("with no authentication provided", async () => {
-        const res = mockResponse();
-        await configurableUploadHandler({}, res);
-        expect(res.status).toHaveBeenCalledWith(401);
-        expect(res.send).toHaveBeenCalledWith("Authorization required.");
-    });
-
     test("with no destination provided", async () => {
         const req = mockRequest();
         const res = mockResponse();
@@ -47,13 +40,6 @@ describe("/api/upload handler", () => {
 });
 
 describe("/api/download handler", () => {
-    test("with no authentication provided", async () => {
-        const res = mockResponse();
-        await configurableDownloadHandler({}, res);
-        expect(res.status).toHaveBeenCalledWith(401);
-        expect(res.send).toHaveBeenCalledWith("Authorization required.");
-    });
-
     test("with no destination provided", async () => {
         const req = mockRequest();
         const res = mockResponse();

--- a/src/server/authStrategy.js
+++ b/src/server/authStrategy.js
@@ -7,7 +7,6 @@ import * as config from "./configuration";
 
 import OAuth2Strategy from "passport-oauth2";
 import rp from "request-promise";
-import passport from "passport";
 
 /**
  * Defines the authentication strategy used by passport.
@@ -72,4 +71,19 @@ export const serializeUser = (user, done) => {
  */
 export const deserializeUser = (user, done) => {
     done(null, JSON.parse(user));
+};
+
+/**
+ * Checks for the accessToken in the user object and bounces logic back out to
+ * the router if it's not present.
+ */
+export const authnTokenMiddleware = (req, res, next) => {
+    const token = req?.user?.accessToken;
+
+    if (!token) {
+        res.status(401);
+        return next("Authorization required.");
+    }
+
+    next();
 };

--- a/src/server/authStrategy.js
+++ b/src/server/authStrategy.js
@@ -79,14 +79,9 @@ export const deserializeUser = (user, done) => {
 export const authnTokenMiddleware = (req, res, next) => {
     const token = req?.user?.accessToken;
 
-    if (!token) {
-        res.status(401);
-        return next("Authorization required.");
+    if (token) {
+        req.headers["Authorization"] = `Bearer ${req.user.accessToken}`;
     }
-
-    // Add the Authorization header to the request, that way the request can be piped
-    // to an outgoing request without having to manually set the header.
-    req.headers["Authorization"] = `Bearer ${req.user.accessToken}`;
 
     next();
 };

--- a/src/server/authStrategy.js
+++ b/src/server/authStrategy.js
@@ -84,5 +84,9 @@ export const authnTokenMiddleware = (req, res, next) => {
         return next("Authorization required.");
     }
 
+    // Add the Authorization header to the request, that way the request can be piped
+    // to an outgoing request without having to manually set the header.
+    req.headers["Authorization"] = `Bearer ${req.user.accessToken}`;
+
     next();
 };

--- a/src/server/authStrategy.js
+++ b/src/server/authStrategy.js
@@ -74,8 +74,7 @@ export const deserializeUser = (user, done) => {
 };
 
 /**
- * Checks for the accessToken in the user object and bounces logic back out to
- * the router if it's not present.
+ * Checks for the accessToken in the user object and returns a 401 if it's not present.
  */
 export const authnTokenMiddleware = (req, res, next) => {
     const token = req?.user?.accessToken;

--- a/src/server/fileio.js
+++ b/src/server/fileio.js
@@ -10,13 +10,6 @@ import path from "path";
  * @returns null
  */
 export const configurableUploadHandler = (req, res, apiBaseURL) => {
-    const token = req?.user?.accessToken;
-
-    if (!token) {
-        res.status(401).send("Authorization required.");
-        return;
-    }
-
     const { destination } = req.query;
     if (!destination || destination === "") {
         res.status(400).send("destination query parameter must be set.");
@@ -32,7 +25,7 @@ export const configurableUploadHandler = (req, res, apiBaseURL) => {
     req.pipe(
         request.post(apiURL.href, {
             headers: {
-                Authorization: `Bearer ${token}`,
+                Authorization: `Bearer ${req.user.accessToken}`,
             },
         })
     ).pipe(res);
@@ -53,13 +46,6 @@ export const uploadHandler = (req, res) =>
  * @returns null
  */
 export const configurableDownloadHandler = (req, res, apiBaseURL) => {
-    const token = req?.user?.accessToken;
-
-    if (!token) {
-        res.status(401).send("Authorization required.");
-        return;
-    }
-
     const { source } = req.query;
     if (!source || source === "") {
         res.status(400).send("source query parameter must be set.");
@@ -81,7 +67,7 @@ export const configurableDownloadHandler = (req, res, apiBaseURL) => {
     req.pipe(
         request.get(apiURL.href, {
             headers: {
-                Authorization: `Bearer ${token}`,
+                Authorization: `Bearer ${req.user.accessToken}`,
             },
         })
     ).pipe(res);

--- a/src/server/fileio.js
+++ b/src/server/fileio.js
@@ -22,13 +22,7 @@ export const configurableUploadHandler = (req, res, apiBaseURL) => {
 
     console.log(apiURL.href);
 
-    req.pipe(
-        request.post(apiURL.href, {
-            headers: {
-                Authorization: `Bearer ${req.user.accessToken}`,
-            },
-        })
-    ).pipe(res);
+    req.pipe(request.post(apiURL.href)).pipe(res);
 };
 
 /**
@@ -64,13 +58,7 @@ export const configurableDownloadHandler = (req, res, apiBaseURL) => {
         `attachment; filename=${path.basename(source)}`
     );
 
-    req.pipe(
-        request.get(apiURL.href, {
-            headers: {
-                Authorization: `Bearer ${req.user.accessToken}`,
-            },
-        })
-    ).pipe(res);
+    req.pipe(request.get(apiURL.href)).pipe(res);
 };
 
 /**

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -102,9 +102,12 @@ app.prepare()
         });
 
         const api = express.Router();
-        api.use(authStrategy.authnTokenMiddleware);
-        api.post("/upload", uploadHandler);
-        api.get("/download", downloadHandler);
+        api.post("/upload", authStrategy.authnTokenMiddleware, uploadHandler);
+        api.get(
+            "/download",
+            authStrategy.authnTokenMiddleware,
+            downloadHandler
+        );
 
         server.use("/api", api, (req, res) => {
             res.sendStatus(401);

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -101,8 +101,14 @@ app.prepare()
             );
         });
 
-        server.post("/api/upload", uploadHandler);
-        server.get("/api/download", downloadHandler);
+        const api = express.Router();
+        api.use(authStrategy.authnTokenMiddleware);
+        api.post("/upload", uploadHandler);
+        api.get("/download", downloadHandler);
+
+        server.use("/api", api, (req, res) => {
+            res.sendStatus(401);
+        });
 
         server.get("*", (req, res) => {
             return nextHandler(req, res);

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -109,10 +109,6 @@ app.prepare()
             downloadHandler
         );
 
-        server.use("/api", api, (req, res) => {
-            res.sendStatus(401);
-        });
-
         server.get("*", (req, res) => {
             return nextHandler(req, res);
         });


### PR DESCRIPTION
This pulls the logic for checking the accessToken out of the handlers and into a very basic Express middleware function.

Creates a new Express router and uses the new middleware on it. Change the /api/upload and /api/download endpoints to be routed with the new router.

This is all to show how we can proxy requests to terrain.