### PR TITLE
Add handler for paged directory listings on /api/filesystem/paged-directory

### DIFF
--- a/src/server/filesystem.js
+++ b/src/server/filesystem.js
@@ -1,0 +1,26 @@
+import request from "request";
+import { terrainURL } from "./configuration";
+import path from "path";
+import querystring from "querystring";
+
+/**
+ * Proxies file listing requests to terrain.
+ *
+ * For request query parameters and return values, see
+ * https://cyverse-de.github.io/api/endpoints/filesystem/directory-listing.html#paged-directory-listing
+ */
+export const configurablePagedListingHandler = (req, res, apiBaseURL) => {
+    const apiURL = new URL(apiBaseURL);
+
+    apiURL.pathname = path.join(
+        apiURL.pathname,
+        "/secured/filesystem/paged-directory"
+    );
+
+    apiURL.search = querystring.stringify(req.query);
+
+    req.pipe(request.get(apiURL.href)).pipe(res);
+};
+
+export const pagedListingHandler = (req, res) =>
+    configurablePagedListingHandler(req, res, terrainURL);

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -7,6 +7,7 @@ import pgsimple from "connect-pg-simple";
 import * as config from "./configuration";
 import * as authStrategy from "./authStrategy";
 import { uploadHandler, downloadHandler } from "./fileio";
+import { pagedListingHandler } from "./filesystem";
 
 import { ApolloServer } from "apollo-server-express";
 import { applyMiddleware } from "graphql-middleware";
@@ -108,6 +109,13 @@ app.prepare()
             authStrategy.authnTokenMiddleware,
             downloadHandler
         );
+        api.get(
+            "/filesystem/paged-directory",
+            authStrategy.authnTokenMiddleware,
+            pagedListingHandler
+        );
+
+        server.use("/api", api);
 
         server.get("*", (req, res) => {
             return nextHandler(req, res);


### PR DESCRIPTION
Rehooks up the api router, adds a new route at /api/filesystem/paged-directory, and a handler to go along with it.