### PR TITLE
Convert pages/testing/upload to use fetch().

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10038,6 +10038,42 @@
         "ua-parser-js": "^0.7.18"
       }
     },
+    "fetch-mock": {
+      "version": "9.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.0.0-beta.2.tgz",
+      "integrity": "sha512-xLqgWqgNBMB+NQIOMa42g2Zrq8leKlN6B7TyxpBRSy1JeI9Pcht2LozPPm3rgqBtvxfhr4iwLPtASlQxgtzS5Q==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^3.0.0",
+        "debug": "^4.1.1",
+        "glob-to-regexp": "^0.4.0",
+        "lodash.isequal": "^4.5.0",
+        "path-to-regexp": "^2.2.1",
+        "querystring": "^0.2.0",
+        "whatwg-url": "^6.5.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.6.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+          "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
+          "dev": true
+        },
+        "glob-to-regexp": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+          "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+          "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+          "dev": true
+        }
+      }
+    },
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
@@ -14166,6 +14202,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
     "lodash.memoize": {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.17.0",
     "eslint-plugin-react-hooks": "^1.7.0",
+    "fetch-mock": "^9.0.0-beta.2",
     "husky": "^4.0.10",
     "jest": "^24.9.0",
     "jsdoc": "^3.6.3",

--- a/src/pages/testing/upload.js
+++ b/src/pages/testing/upload.js
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 import React, { useState } from "react";
 
 const Uploadform = () => {

--- a/src/pages/testing/upload.js
+++ b/src/pages/testing/upload.js
@@ -6,19 +6,18 @@ const Uploadform = () => {
     const [files, setFiles] = useState(null);
     const [uploadData, setUploadData] = useState({});
 
-    const handleSubmit = async (event) => {
+    const handleSubmit = (event) => {
         const formData = new FormData();
         formData.append("file", files[0]);
 
-        const uploadData = await fetch(`/api/upload?dest=${destination}`, {
+        fetch(`/api/upload?dest=${destination}`, {
             method: "POST",
             credentials: "include",
             body: formData,
         })
             .then((resp) => resp.json())
+            .then((uploadData) => setUploadData(uploadData))
             .catch((e) => console.log(`error ${e.message}`));
-
-        setUploadData(uploadData);
     };
 
     return (

--- a/src/pages/testing/upload.js
+++ b/src/pages/testing/upload.js
@@ -1,16 +1,28 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { useState } from "react";
 
 const Uploadform = () => {
     const [destination, setDestination] = useState("");
+    const [files, setFiles] = useState(null);
+    const [uploadData, setUploadData] = useState({});
 
-    const handleDestinationChange = (event) => {
-        setDestination(event.target.value);
+    const handleSubmit = async (event) => {
+        const formData = new FormData();
+        formData.append("file", files[0]);
+
+        const uploadData = await fetch(`/api/upload?dest=${destination}`, {
+            method: "POST",
+            credentials: "include",
+            body: formData,
+        })
+            .then((resp) => resp.json())
+            .catch((e) => console.log(`error ${e.message}`));
+
+        setUploadData(uploadData);
     };
 
-    const actionPath = `/api/upload?dest=${destination}`;
-
     return (
-        <form action={actionPath} method="post" encType="multipart/form-data">
+        <div>
             <br />
 
             <label>
@@ -18,7 +30,7 @@ const Uploadform = () => {
                 <input
                     type="text"
                     value={destination}
-                    onChange={handleDestinationChange}
+                    onChange={(e) => setDestination(e.target.value)}
                 />
             </label>
 
@@ -27,14 +39,21 @@ const Uploadform = () => {
 
             <label>
                 File: &nbsp;
-                <input type="file" name="file" id="file" />
+                <input
+                    type="file"
+                    name="file"
+                    id="file"
+                    onChange={(e) => setFiles(e.target.files)}
+                />
             </label>
 
             <br />
             <br />
 
-            <input type="submit" value="Upload File" />
-        </form>
+            <input type="submit" value="Upload File" onClick={handleSubmit} />
+
+            <pre>{JSON.stringify(uploadData, null, 2)}</pre>
+        </div>
     );
 };
 

--- a/stories/TestingUpload.stories.js
+++ b/stories/TestingUpload.stories.js
@@ -1,0 +1,46 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import Uploadform from "../src/pages/testing/upload";
+import fetchMock from "fetch-mock";
+
+storiesOf("Test Uploadform", module)
+    .add("with a mocked API call", () => {
+        fetchMock.restore().post(/\/api\/upload\/?\??.*/, {
+            file: {
+                infoType: "",
+                path: "/iplant/home/ipcdev/lein-plugins.txt",
+                "share-count": 0,
+                "date-created": 1580918919000,
+                md5: "1deaf230acfa890bb0dabab537aff216",
+                permission: "own",
+                "date-modified": 1580918919000,
+                type: "file",
+                "file-size": 285,
+                label: "lein-plugins.txt",
+                id: "c5f7e42a-4831-11ea-a8b1-fa163e806578",
+                "content-type": "text/plain",
+            },
+        });
+
+        return <Uploadform />;
+    })
+    .add("with another mocked API call", () => {
+        fetchMock.restore().post(/\/api\/upload\/?\??.*/, {
+            file: {
+                infoType: "",
+                path: "/iplant/home/ipcdev/plugins.json",
+                "share-count": 0,
+                "date-created": 1580918919000,
+                md5: "1deaf230acfa890bb0dabab537aff216",
+                permission: "own",
+                "date-modified": 1580918919000,
+                type: "file",
+                "file-size": 285,
+                label: "lein-plugins.txt",
+                id: "c5f7e42a-4831-11ea-a8b1-fa163e806578",
+                "content-type": "application/json",
+            },
+        });
+
+        return <Uploadform />;
+    });


### PR DESCRIPTION
- pages/testing/upload.js now uses fetch() to upload files to the Sonora
- API.
- fetch-mock was added to allow Stories to mock out API calls/responses.
- Example stories were added show how the mocking works.