### PR TITLE
Add listing component story with mocked API, extract fetch usage

### DIFF
--- a/src/common/callApi.js
+++ b/src/common/callApi.js
@@ -1,0 +1,71 @@
+/**
+ * @author aramsey
+ *
+ * A function which should help standardize how fetch calls are handled.
+ * The promise returned from fetch is returned to the caller so more
+ * can be chained to it.
+ *
+ * Sample usages:
+ * callApi({
+ *     endpoint: "/api/apps"
+ * }).then(resp => {
+ *     setAppListing(resp.apps)
+ * }
+ *
+ * callApi({
+ *     endpoint `/api/apps/${appId}/publish`,
+ *     method: "POST",
+ *     body: appInfo,
+ *     setLoading,
+ *     setError,
+ * }).then(resp => {
+ *     showPublishMessage()
+ * }
+ *
+ * @param props
+ * @returns {Promise<any>}
+ */
+
+const callApi = (props) => {
+    const {
+        method = "GET",
+        endpoint,
+        body = false,
+        headers,
+        setLoading,
+        setError,
+    } = props;
+
+    setLoading && setLoading(true);
+
+    return fetch(endpoint, {
+        method: method,
+        body: body ? JSON.stringify(body) : null,
+        headers: headers
+            ? headers
+            : {
+                  "Content-Type": "application/json",
+              },
+        credentials: "include",
+    })
+        .then((resp) => {
+            if (resp.status < 200 || resp.status > 299) {
+                throw Error(resp.status + " " + resp.statusText);
+            } else {
+                setError && setError(null);
+            }
+            return resp;
+        })
+        .then((resp) => {
+            return resp.json();
+        })
+        .catch((error) => {
+            setError && setError(error.toString());
+            console.error(error);
+        })
+        .finally(() => {
+            setLoading && setLoading(false);
+        });
+};
+
+export default callApi;

--- a/stories/data/Listing.stories.js
+++ b/stories/data/Listing.stories.js
@@ -1,0 +1,157 @@
+import React from "react";
+
+import fetchMock from "fetch-mock";
+import Listing from "../../src/components/data/listing/Listing";
+
+export default {
+    title: "Data",
+};
+
+function ListingTest(props) {
+    const logger = (message) => {
+        console.log(message);
+    };
+
+    return (
+        <Listing
+            baseId="tableView"
+            path="/iplant/home/ipcdev"
+            handlePathChange={(path) => logger("Change to path " + path)}
+        />
+    );
+}
+
+const successResp = {
+    infoType: null,
+    path: "/iplant/home/aramsey",
+    "date-created": 1444670130000,
+    folders: [
+        {
+            infoType: null,
+            path: "/iplant/home/aramsey/TestData_qa",
+            "date-created": 1565225021000,
+            permission: "own",
+            "date-modified": 1568318834000,
+            "file-size": 0,
+            badName: false,
+            isFavorite: false,
+            label: "TestData_qa",
+            id: "9183e702-b975-11e9-80ce-d8d385e427d4",
+        },
+        {
+            infoType: null,
+            path: "/iplant/home/aramsey/analyses",
+            "date-created": 1572887916000,
+            permission: "own",
+            "date-modified": 1572887916000,
+            "file-size": 0,
+            badName: false,
+            isFavorite: false,
+            label: "analyses",
+            id: "22d2ecfc-ff27-11e9-80e3-d8d385e427d4",
+        },
+        {
+            infoType: null,
+            path: "/iplant/home/aramsey/analyses_qa",
+            "date-created": 1565225575000,
+            permission: "own",
+            "date-modified": 1565225575000,
+            "file-size": 0,
+            badName: false,
+            isFavorite: false,
+            label: "analyses_qa",
+            id: "db968b28-b976-11e9-80ce-d8d385e427d4",
+        },
+        {
+            infoType: null,
+            path: "/iplant/home/aramsey/analyses_qa-3",
+            "date-created": 1473896447000,
+            permission: "own",
+            "date-modified": 1476220776000,
+            "file-size": 0,
+            badName: false,
+            isFavorite: false,
+            label: "analyses_qa-3",
+            id: "a9546754-7ad4-11e6-bf34-d8d385e427d4",
+        },
+        {
+            infoType: null,
+            path: "/iplant/home/aramsey/bad'name",
+            "date-created": 1486506280000,
+            permission: "own",
+            "date-modified": 1486507091000,
+            "file-size": 0,
+            badName: true,
+            isFavorite: false,
+            label: "bad'name",
+            id: "37982538-ed84-11e6-bf47-d8d385e427d4",
+        },
+        {
+            infoType: null,
+            path: "/iplant/home/aramsey/coge_data",
+            "date-created": 1554164907000,
+            permission: "own",
+            "date-modified": 1554164907000,
+            "file-size": 0,
+            badName: false,
+            isFavorite: false,
+            label: "coge_data",
+            id: "3bf32b14-54de-11e9-80be-d8d385e427d4",
+        },
+    ],
+    permission: "own",
+    "date-modified": 1570058506000,
+    hasSubDirs: true,
+    "file-size": 0,
+    badName: true,
+    total: 70,
+    isFavorite: false,
+    label: "aramsey",
+    id: "d6f46cca-7104-11e5-b73c-3c4a92e4a804",
+    totalBad: 0,
+    files: [
+        {
+            infoType: "ht-analysis-path-list",
+            path: "/iplant/home/aramsey/CORE-9077-path.list",
+            "date-created": 1512502386000,
+            permission: "own",
+            "date-modified": 1512502386000,
+            "file-size": 90046,
+            badName: false,
+            isFavorite: false,
+            label: "CORE-9077-path.list",
+            id: "1e7e91d4-d9f3-11e7-bf79-d8d385e427d4",
+        },
+        {
+            infoType: "unknown",
+            path: "/iplant/home/aramsey/CORE-9077_test_file.txt",
+            "date-created": 1512516445000,
+            permission: "own",
+            "date-modified": 1512516445000,
+            "file-size": 10,
+            badName: false,
+            isFavorite: false,
+            label: "CORE-9077_test_file.txt",
+            id: "da63e3c0-da13-11e7-bf79-d8d385e427d4",
+        },
+        {
+            infoType: "unknown",
+            path: "/iplant/home/aramsey/Discovery Environment-CyVerse-blue.svg",
+            "date-created": 1562000527000,
+            permission: "own",
+            "date-modified": 1562000527000,
+            "file-size": 7526,
+            badName: false,
+            isFavorite: false,
+            label: "Discovery Environment-CyVerse-blue.svg",
+            id: "f5469f94-9c21-11e9-80c7-d8d385e427d4",
+        },
+    ],
+};
+
+export const DataListingTest = () => {
+    fetchMock
+        .restore()
+        .get(/\/api\/filesystem\/paged-directory.*/, successResp);
+    return <ListingTest />;
+};


### PR DESCRIPTION
The big thing here is extracting `fetch` so that we can standardize logging and potentially error handling during API calls.  
There are some considerations there.  What I really wanted was a HOC that passed down this `callAPI` function plus `loading` and `error` props because I foresee us doing `const [loading, setLoading] = useState(false); const [error, setError] = useState(null);` everywhere, but I couldn't get it to work without encountering lots of lint warnings or taking away flexibility from the components using it.  For now, I've gone with this to keep it simple-ish.