### PR TITLE
CORE-868: allow the client-side code to obtain user profile information.

### DIFF
--- a/src/components/appBar/CyVerseAppBar.js
+++ b/src/components/appBar/CyVerseAppBar.js
@@ -9,6 +9,7 @@ import React from "react";
 import intlData from "./messages";
 import ids from "./ids";
 import constants from "../../constants";
+import callApi from "../../common/callApi";
 
 import {
     build,
@@ -108,18 +109,18 @@ function CyverseAppBar(props) {
 
     React.useEffect(() => {
         const fetchUserProfile = async function() {
-            const profile = await fetch("/api/profile", {
+            const profile = await callApi({
+                endpoint: "/api/profile",
                 method: "GET",
                 credentials: "include",
-            })
-                .then((resp) => resp.json())
-                .catch((e) => console.log(`error ${e.message}`));
+            });
             setUserProfile(profile);
         };
         fetchUserProfile(setUserProfile);
     }, [setUserProfile]);
 
     const handleUserButtonClick = (event) => {
+        console.log(userProfile);
         if (!userProfile) {
             router.push(`/login${router.asPath}`);
         }

--- a/src/components/appBar/CyVerseAppBar.js
+++ b/src/components/appBar/CyVerseAppBar.js
@@ -116,7 +116,7 @@ function CyverseAppBar(props) {
             });
             setUserProfile(profile);
         };
-        fetchUserProfile(setUserProfile);
+        fetchUserProfile();
     }, [setUserProfile]);
 
     const handleUserButtonClick = (event) => {

--- a/src/components/appBar/CyVerseAppBar.js
+++ b/src/components/appBar/CyVerseAppBar.js
@@ -105,7 +105,7 @@ function CyverseAppBar(props) {
     const handleUserButtonClick = (event) => {
         const { user } = props.children.props;
         if (!user) {
-            router.push("/login");
+            router.push(`/login${router.asPath}`);
         }
     };
 

--- a/src/components/appBar/CyVerseAppBar.js
+++ b/src/components/appBar/CyVerseAppBar.js
@@ -39,6 +39,8 @@ import SearchIcon from "@material-ui/icons/Search";
 import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown";
 import AccountCircleIcon from "@material-ui/icons/AccountCircle";
 
+import { useUserProfile } from "../../contexts/userProfile";
+
 const useStyles = makeStyles((theme) => ({
     root: {
         flexGrow: 1,
@@ -102,21 +104,20 @@ function CyverseAppBar(props) {
     const router = useRouter();
     const { intl, children } = props;
 
-    const [userProfile, setUserProfile] = React.useState(null);
-
-    async function getUserProfile(setUserProfile) {
-        const profile = await fetch("/api/profile", {
-            method: "GET",
-            credentials: "include",
-        })
-            .then((resp) => resp.json())
-            .catch((e) => console.log(`error ${e.message}`));
-        setUserProfile(profile);
-    }
+    const [userProfile, setUserProfile] = useUserProfile();
 
     React.useEffect(() => {
-        getUserProfile(setUserProfile);
-    }, []);
+        const fetchUserProfile = async function() {
+            const profile = await fetch("/api/profile", {
+                method: "GET",
+                credentials: "include",
+            })
+                .then((resp) => resp.json())
+                .catch((e) => console.log(`error ${e.message}`));
+            setUserProfile(profile);
+        };
+        fetchUserProfile(setUserProfile);
+    }, [setUserProfile]);
 
     const handleUserButtonClick = (event) => {
         if (!userProfile) {

--- a/src/components/appBar/CyVerseAppBar.js
+++ b/src/components/appBar/CyVerseAppBar.js
@@ -102,9 +102,24 @@ function CyverseAppBar(props) {
     const router = useRouter();
     const { intl, children } = props;
 
+    const [userProfile, setUserProfile] = React.useState(null);
+
+    async function getUserProfile(setUserProfile) {
+        const profile = await fetch("/api/profile", {
+            method: "GET",
+            credentials: "include",
+        })
+            .then((resp) => resp.json())
+            .catch((e) => console.log(`error ${e.message}`));
+        setUserProfile(profile);
+    }
+
+    React.useEffect(() => {
+        getUserProfile(setUserProfile);
+    }, []);
+
     const handleUserButtonClick = (event) => {
-        const { user } = props.children.props;
-        if (!user) {
+        if (!userProfile) {
             router.push(`/login${router.asPath}`);
         }
     };

--- a/src/contexts/userProfile.js
+++ b/src/contexts/userProfile.js
@@ -2,6 +2,12 @@ import React from "react";
 
 const UserProfileContext = React.createContext();
 
+/**
+ * A hook that returns state for obtaining and updating the client-side copy
+ * of the user profile information. The user profile information should only
+ * be set in one React component. The information can be read from any React
+ * component.
+ */
 function useUserProfile() {
     const context = React.useContext(UserProfileContext);
     if (!context) {
@@ -12,6 +18,16 @@ function useUserProfile() {
     return context;
 }
 
+/**
+ * A React component that wraps its descendants in user profile context
+ * providers, allowing them to obtain information about the authenticated
+ * user. This hook does not actually retrieve the user profile information
+ * from the server. Exactly one of the descendant components should make a
+ * call to the `/api/profile` endpoint in order to obtain the user profile
+ * information and store it using the `setUserProfile` function.
+ *
+ * @param {object} props the React component properties.
+ */
 function UserProfileProvider(props) {
     const [userProfile, setUserProfile] = React.useState(null);
     const value = React.useMemo(() => [userProfile, setUserProfile], [

--- a/src/contexts/userProfile.js
+++ b/src/contexts/userProfile.js
@@ -1,0 +1,23 @@
+import React from "react";
+
+const UserProfileContext = React.createContext();
+
+function useUserProfile() {
+    const context = React.useContext(UserProfileContext);
+    if (!context) {
+        throw new Error(
+            `useUserProfile must be used within a UserProfileProvider`
+        );
+    }
+    return context;
+}
+
+function UserProfileProvider(props) {
+    const [userProfile, setUserProfile] = React.useState(null);
+    const value = React.useMemo(() => [userProfile, setUserProfile], [
+        userProfile,
+    ]);
+    return <UserProfileContext.Provider value={value} {...props} />;
+}
+
+export { UserProfileProvider, useUserProfile };

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -3,6 +3,7 @@ import CyverseAppBar from "../components/appBar/CyVerseAppBar";
 import theme from "../components/theme/default";
 import { ThemeProvider } from "@material-ui/core/styles";
 import { UploadTrackingProvider } from "../contexts/uploadTracking";
+import { UserProfileProvider } from "../contexts/userProfile";
 
 function MyApp({ Component, pageProps }) {
     React.useEffect(() => {
@@ -13,11 +14,13 @@ function MyApp({ Component, pageProps }) {
     }, []);
     return (
         <ThemeProvider theme={theme}>
-            <UploadTrackingProvider>
-                <CyverseAppBar>
-                    <Component {...pageProps} />
-                </CyverseAppBar>
-            </UploadTrackingProvider>
+            <UserProfileProvider>
+                <UploadTrackingProvider>
+                    <CyverseAppBar>
+                        <Component {...pageProps} />
+                    </CyverseAppBar>
+                </UploadTrackingProvider>
+            </UserProfileProvider>
         </ThemeProvider>
     );
 }

--- a/src/server/apiRouter.js
+++ b/src/server/apiRouter.js
@@ -88,7 +88,10 @@ export default function apiRouter() {
     logger.info("adding the /api/profile handler");
     api.get("/profile", (req, res) => {
         if (req.user) {
-            res.json({ ...req.user.profile, username: req.user.id });
+            res.json({
+                id: req.user.profile.id,
+                attributes: req.user.profile.attributes,
+            });
         } else {
             res.json(null);
         }

--- a/src/server/apiRouter.js
+++ b/src/server/apiRouter.js
@@ -31,7 +31,7 @@ const terrain = ({ method, url, pathname, headers }) => {
     };
 };
 
-export default function terrainRouter() {
+export default function apiRouter() {
     logger.info("creating the api router");
     const api = express.Router();
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -7,7 +7,7 @@ import { ensureLoggedIn } from "connect-ensure-login";
 
 import * as config from "./configuration";
 import * as authStrategy from "./authStrategy";
-import terrainRouter from "./terrainRouter";
+import apiRouter from "./apiRouter";
 
 import logger, { errorLogger, requestLogger } from "./logging";
 
@@ -82,7 +82,7 @@ app.prepare()
         });
 
         logger.info("adding the api router to the express server");
-        server.use("/api", terrainRouter());
+        server.use("/api", apiRouter());
 
         //map root to Dashboard
         server.get("/", (req, res) => {

--- a/src/server/terrainRouter.js
+++ b/src/server/terrainRouter.js
@@ -87,7 +87,6 @@ export default function terrainRouter() {
 
     logger.info("adding the /api/profile handler");
     api.get("/profile", (req, res) => {
-        console.log(req.user);
         if (req.user) {
             res.json({ ...req.user.profile, username: req.user.id });
         } else {

--- a/src/server/terrainRouter.js
+++ b/src/server/terrainRouter.js
@@ -85,5 +85,15 @@ export default function terrainRouter() {
         terrain({ method: "GET", pathname: "/secured/filesystem/root" })
     );
 
+    logger.info("adding the /api/profile handler");
+    api.get("/profile", (req, res) => {
+        console.log(req.user);
+        if (req.user) {
+            res.json({ ...req.user.profile, username: req.user.id });
+        } else {
+            res.json(null);
+        }
+    });
+
     return api;
 }


### PR DESCRIPTION
The motivation for this change is to allow the client-side code to alter its appearance depending on whether or not the user is currently authenticated, and the groups that the user is in. The profile that is returned will be `null` if the user isn't authenticated. Otherwise, it will be an object containing the following members:

```json
{
    "attributes": {
        "email": "username@domain.org",
        "entitlement": [ "group1", "group2", "group3" ],
        "firstName": "User's First Name",
        "lastName": "User's Last Name",
        "name": "User's Full Name",
    },
    "id": "username"
}
```

The `entitlement` attribute contains the list of LDAP groups that the user belongs to. The client-side code may choose to alter its appearance based on the groups that the user belongs to. For example, if the user belongs to one of the administrative groups, additional UI components might be displayed.

The `CyVerseAppBar` component is currently responsible for retrieving the user profile information and storing it in the user profile context. Other components can then use the `useUserProfile` hook to retrieve the user profile information:

```javascript
import { useUserProfile } from "/path/to/context/userProfile.js";

function SomeReactComponent(props) {
    // ...
    const [userProfile] = useUserProfile();
    console.log(userProfile);
    // ...
}
```