### PR TITLE
Upload Queue Dialog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19113,6 +19113,11 @@
             "mime-types": "^2.1.12"
           }
         },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
         "tough-cookie": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -19120,6 +19125,13 @@
           "requires": {
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+              "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+            }
           }
         }
       }

--- a/src/components/data/UploadMenuBtn.js
+++ b/src/components/data/UploadMenuBtn.js
@@ -11,6 +11,8 @@ import { build, getMessage } from "@cyverse-de/ui-lib";
 import { Button, Hidden, makeStyles, Menu, MenuItem } from "@material-ui/core";
 import { Publish as UploadIcon } from "@material-ui/icons";
 
+import UploadDialog from "../uploads/dialog";
+
 import ids from "./ids";
 import styles from "./styles";
 
@@ -21,6 +23,7 @@ function UploadMenuBtn(props) {
     const classes = useStyles();
 
     const [uploadAnchor, setUploadAnchor] = useState(null);
+    const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
 
     const onUploadClose = () => {
         setUploadAnchor(null);
@@ -93,12 +96,17 @@ function UploadMenuBtn(props) {
                     id={build(uploadMenuId, ids.UPLOAD_QUEUE_MI)}
                     onClick={() => {
                         onUploadClose();
-                        console.log("View Upload Queue");
+                        setUploadDialogOpen(true);
                     }}
                 >
                     {getMessage("uploadQueue")}
                 </MenuItem>
             </Menu>
+
+            <UploadDialog
+                open={uploadDialogOpen}
+                handleClose={() => setUploadDialogOpen(false)}
+            />
         </>
     );
 }

--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -13,7 +13,8 @@ import Header from "../Header";
 import messages from "../messages";
 import TableView from "./TableView";
 import callApi from "../../../common/callApi";
-import UploadDropTarget from "./UploadDropTarget";
+import UploadDropTarget from "../../uploads/UploadDropTarget";
+import { useUploadTrackingState } from "../../../contexts/uploadTracking";
 
 import { camelcaseit } from "../../../common/functions";
 
@@ -21,6 +22,7 @@ function Listing(props) {
     const theme = useTheme();
     const isMedium = useMediaQuery(theme.breakpoints.up("sm"));
     const isLarge = useMediaQuery(theme.breakpoints.up("lg"));
+    const uploadTracker = useUploadTrackingState();
 
     const [isGridView, setGridView] = useState(false);
     const [order, setOrder] = useState("asc");
@@ -31,9 +33,17 @@ function Listing(props) {
     const [rowsPerPage, setRowsPerPage] = useState(25);
     const [loading, setLoading] = useState(false);
     const [data, setData] = useState({ total: 0, files: [], folders: [] });
-    const [uploadsCompleted, setUploadsCompleted] = useState(0);
 
     const { baseId, path, handlePathChange } = props;
+
+    // Used to force the data listing to refresh when uploads are completed.
+    const uploadsCompleted = uploadTracker.uploads.filter((upload) => {
+        return (
+            upload.parentPath === path &&
+            upload.hasUploaded &&
+            !upload.hasErrored
+        );
+    }).length;
 
     useEffect(() => {
         setSelected([]);
@@ -160,14 +170,7 @@ function Listing(props) {
 
     return (
         <>
-            <UploadDropTarget
-                path={path}
-                uploadCompletedCB={() =>
-                    setUploadsCompleted(
-                        (uploadsCompleted) => uploadsCompleted + 1 // prevents stale values in closures.
-                    )
-                }
-            >
+            <UploadDropTarget path={path}>
                 <Header
                     baseId={baseId}
                     isGridView={isGridView}

--- a/src/components/uploads/UploadDrop.js
+++ b/src/components/uploads/UploadDrop.js
@@ -85,9 +85,6 @@ const processDroppedFiles = async (transferItemList, itemsFn) => {
         .filter((f) => f.size > 0) // filter out 0-byte files and directories.
         .map((i) => ({ kind: KindFile, value: i }));
 
-    // Clear out any nulls from the list.
-    fileItems = fileItems.filter((i) => i !== null && i !== "undefined");
-
     // Set the new value of uploadItems, which should trigger a re-render.
     return itemsFn(fileItems);
 };

--- a/src/components/uploads/UploadDrop.js
+++ b/src/components/uploads/UploadDrop.js
@@ -3,7 +3,7 @@
  *
  * Contains the logic for handling files dropped into the file listing.
  *
- * @module UploadDrop
+ * @module uploads/UploadDrop
  */
 
 import UUID from "uuid/v4";

--- a/src/components/uploads/UploadDrop.js
+++ b/src/components/uploads/UploadDrop.js
@@ -76,10 +76,10 @@ export const trackUpload = (uploadFile, destinationPath, dispatch) => {
  */
 const processDroppedFiles = async (transferItemList, itemsFn) => {
     // TransferItemLists aren't actually arrays/lists in JS-land.
-    let allItems = convertDTIL(transferItemList);
+    const allItems = convertDTIL(transferItemList);
 
     // Get all of the files split out into their own list.
-    let fileItems = allItems
+    const fileItems = allItems
         .filter((i) => i.kind === "file")
         .map((i) => i.getAsFile())
         .filter((f) => f.size > 0) // filter out 0-byte files and directories.

--- a/src/components/uploads/UploadDropTarget.js
+++ b/src/components/uploads/UploadDropTarget.js
@@ -3,7 +3,7 @@
  *
  * Component that allows files to be uploaded when they are dropped on child components.
  *
- * @module UploadDropTarget
+ * @module uploads/UploadDropTarget
  */
 
 import React, { useState } from "react";

--- a/src/components/uploads/UploadDropTarget.js
+++ b/src/components/uploads/UploadDropTarget.js
@@ -7,8 +7,8 @@
  */
 
 import React, { useState } from "react";
-import processDroppedFiles, { startUpload } from "./UploadDrop";
-import { useUploadTrackingDispatch } from "../../../contexts/uploadTracking";
+import processDroppedFiles, { trackUpload } from "./UploadDrop";
+import { useUploadTrackingDispatch } from "../../contexts/uploadTracking";
 import PropTypes from "prop-types";
 
 /**
@@ -41,13 +41,11 @@ const setupEvent = (event) => {
 const UploadDropTarget = (props) => {
     const uploadDispatch = useUploadTrackingDispatch();
     const [dragCounter, setDragCounter] = useState(0);
-    const { children, path, uploadCompletedCB } = props;
+    const { children, path } = props;
 
-    const startAllUploads = (uploadFiles) =>
+    const trackAllUploads = (uploadFiles) =>
         uploadFiles.forEach((aFile) => {
-            startUpload(aFile.value, path, uploadDispatch, () => {
-                uploadCompletedCB(aFile.value, path);
-            });
+            trackUpload(aFile.value, path, uploadDispatch);
         });
 
     const handleDragOver = (event) => {
@@ -68,7 +66,7 @@ const UploadDropTarget = (props) => {
     const handleDragLeave = (event) => {
         setupEvent(event);
 
-        // See the comment in handleDragEnter() for why we're doing this.
+        // See the comment in handleDragIn() for why we're doing this.
         if (dragCounter > 0) {
             setDragCounter(dragCounter - 1);
         }
@@ -77,7 +75,7 @@ const UploadDropTarget = (props) => {
     const handleDrop = (event) => {
         setupEvent(event);
         setDragCounter(0);
-        processDroppedFiles(event.dataTransfer.items, startAllUploads);
+        processDroppedFiles(event.dataTransfer.items, trackAllUploads);
     };
 
     return (
@@ -98,7 +96,6 @@ const UploadDropTarget = (props) => {
 UploadDropTarget.propTypes = {
     children: PropTypes.object.isRequired,
     path: PropTypes.string.isRequired,
-    uploadCompletedCB: PropTypes.func.isRequired,
 };
 
 export default UploadDropTarget;

--- a/src/components/uploads/UploadDropTarget.js
+++ b/src/components/uploads/UploadDropTarget.js
@@ -66,7 +66,7 @@ const UploadDropTarget = (props) => {
     const handleDragLeave = (event) => {
         setupEvent(event);
 
-        // See the comment in handleDragIn() for why we're doing this.
+        // See the comment in handleDragEnter() for why we're doing this.
         if (dragCounter > 0) {
             setDragCounter(dragCounter - 1);
         }

--- a/src/components/uploads/api.js
+++ b/src/components/uploads/api.js
@@ -1,3 +1,11 @@
+/**
+ * @author johnworth
+ *
+ * Contains API interactions concerning uploads.
+ *
+ * @module uploads/api
+ */
+
 import { checkForError } from "../../common/callApi";
 
 import {

--- a/src/components/uploads/api.js
+++ b/src/components/uploads/api.js
@@ -1,0 +1,85 @@
+import { checkForError } from "../../common/callApi";
+
+import {
+    errorAction,
+    updateStatusAction,
+    setCancelFnAction,
+} from "../../contexts/uploadTracking";
+
+/**
+ * Starts a single upload.
+ *
+ * @param {Object} upload - An upload from the tracker.
+ * @param {string} destinationPath - The path to the directory the file should be uploaded to.
+ * @return null
+ */
+export const startUpload = (
+    upload,
+    destinationPath,
+    dispatch,
+    completedCB = () => {}
+) => {
+    const uploadFile = upload.file;
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    const formData = new FormData();
+    formData.append("file", uploadFile);
+
+    const cancelFn = () => {
+        controller.abort();
+    };
+
+    dispatch(
+        setCancelFnAction({
+            id: upload.id,
+            cancelFn: cancelFn,
+        })
+    );
+
+    dispatch(
+        updateStatusAction({
+            id: upload.id,
+            isUploading: true,
+            hasUploaded: false,
+        })
+    );
+
+    const endpoint = `/api/upload?dest=${destinationPath}`;
+    const method = "POST";
+
+    fetch(endpoint, {
+        method,
+        credentials: "include",
+        body: formData,
+        signal,
+    })
+        .then((resp) => checkForError(resp, { method, endpoint, headers: {} }))
+        .then((resp) => {
+            dispatch(
+                updateStatusAction({
+                    id: upload.id,
+                    hasUploaded: true,
+                    isUploading: false,
+                })
+            );
+
+            completedCB(upload.id);
+        })
+        .catch((e) => {
+            if (e.details) {
+                console.error(
+                    `${e.details.code} ${JSON.stringify(e.details.context)}`
+                );
+            } else {
+                console.error(e.message);
+            }
+
+            dispatch(
+                errorAction({
+                    id: upload.id,
+                    errorMessage: e.message,
+                })
+            );
+        });
+};

--- a/src/components/uploads/dialog/ids.js
+++ b/src/components/uploads/dialog/ids.js
@@ -1,0 +1,7 @@
+export default {
+    BASE: "uploadQueueDialog",
+    TITLE: "title",
+    LIST: "list",
+    CLOSE: "closeButton",
+    CLOSE_X: "closeXButton",
+};

--- a/src/components/uploads/dialog/index.js
+++ b/src/components/uploads/dialog/index.js
@@ -1,3 +1,10 @@
+/**
+ * @author johnworth
+ *
+ * A dialog displaying the tracked uploads.
+ *
+ * @module uploads/dialog
+ */
 import React from "react";
 
 import {

--- a/src/components/uploads/dialog/index.js
+++ b/src/components/uploads/dialog/index.js
@@ -78,6 +78,7 @@ const UploadDialog = ({ open, handleClose = () => {} }) => {
                     id={buildID(ids.BASE, ids.CLOSE)}
                     onClick={handleClose}
                     color="primary"
+                    aria-label="close"
                 >
                     {getMessage("close")}
                 </Button>

--- a/src/components/uploads/dialog/index.js
+++ b/src/components/uploads/dialog/index.js
@@ -61,7 +61,7 @@ const UploadDialog = ({ open, handleClose = () => {} }) => {
                 <DialogContentText>
                     {getMessage("help")}
                     <IconButton
-                        aria-label="close"
+                        aria-label={getMessage("closeAria")}
                         id={buildID(ids.BASE, ids.CLOSE_X)}
                         className={classes.closeDialog}
                         onClick={handleClose}
@@ -78,7 +78,7 @@ const UploadDialog = ({ open, handleClose = () => {} }) => {
                     id={buildID(ids.BASE, ids.CLOSE)}
                     onClick={handleClose}
                     color="primary"
-                    aria-label="close"
+                    aria-label={getMessage("closeAria")}
                 >
                     {getMessage("close")}
                 </Button>

--- a/src/components/uploads/dialog/index.js
+++ b/src/components/uploads/dialog/index.js
@@ -1,0 +1,82 @@
+import React from "react";
+
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    DialogTitle,
+    IconButton,
+    useMediaQuery,
+} from "@material-ui/core";
+
+import { Close as CloseIcon } from "@material-ui/icons";
+
+import { useTheme, makeStyles } from "@material-ui/styles";
+
+import { getMessage, withI18N, build as buildID } from "@cyverse-de/ui-lib";
+
+import UploadQueue from "../queue";
+
+import messages from "./messages";
+import ids from "./ids";
+
+const useStyles = makeStyles((theme) => ({
+    closeDialog: {
+        position: "absolute",
+        right: theme.spacing(1),
+        top: theme.spacing(1),
+        color: theme.palette.blueGrey,
+    },
+}));
+
+/**
+ * The upload dialog component that displays the list of uploads being tracked.
+ *
+ * @params {Object} props
+ * @params {boolean} props.open - Whether or not the dialog is open.
+ * @params {Object} props.handleClose - Callback that is executed when the dialog is closed.
+ * @returns {Object}
+ */
+const UploadDialog = ({ open, handleClose = () => {} }) => {
+    const classes = useStyles();
+    const theme = useTheme();
+    const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
+
+    return (
+        <Dialog fullScreen={fullScreen} open={open} onClose={handleClose}>
+            <DialogTitle id={buildID(ids.BASE, ids.TITLE)}>
+                {getMessage("title")}
+            </DialogTitle>
+
+            <DialogContent>
+                <DialogContentText>
+                    {getMessage("help")}
+                    <IconButton
+                        aria-label="close"
+                        id={buildID(ids.BASE, ids.CLOSE_X)}
+                        className={classes.closeDialog}
+                        onClick={handleClose}
+                    >
+                        <CloseIcon />
+                    </IconButton>
+                </DialogContentText>
+
+                <UploadQueue id={buildID(ids.BASE, ids.LIST)} />
+            </DialogContent>
+
+            <DialogActions>
+                <Button
+                    id={buildID(ids.BASE, ids.CLOSE)}
+                    onClick={handleClose}
+                    color="primary"
+                >
+                    {getMessage("close")}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default withI18N(UploadDialog, messages);

--- a/src/components/uploads/dialog/messages.js
+++ b/src/components/uploads/dialog/messages.js
@@ -3,6 +3,7 @@ export default {
     messages: {
         title: "Upload Queue",
         help: "The list of uploads running in this browser tab or window.",
+        closeAria: "close",
         close: "Close",
     },
 };

--- a/src/components/uploads/dialog/messages.js
+++ b/src/components/uploads/dialog/messages.js
@@ -1,0 +1,8 @@
+export default {
+    locales: "en-us",
+    messages: {
+        title: "Upload Queue",
+        help: "The list of uploads running in this browser tab or window.",
+        close: "Close",
+    },
+};

--- a/src/components/uploads/manager/constants.js
+++ b/src/components/uploads/manager/constants.js
@@ -1,0 +1,9 @@
+/**
+ * @author johnworth
+ *
+ * Constants for the upload manager.
+ *
+ * @module uploads/manager/constants
+ */
+
+export const MAX_RUNNING_UPLOADS = 3;

--- a/src/components/uploads/manager/index.js
+++ b/src/components/uploads/manager/index.js
@@ -1,0 +1,103 @@
+/**
+ * @author johnworth
+ *
+ * A component that pulls items out of the upload tracker and triggers them.
+ *
+ * @module UploadQueue
+ */
+import React, { useEffect } from "react";
+
+import {
+    useUploadTrackingState,
+    useUploadTrackingDispatch,
+} from "../../../contexts/uploadTracking";
+
+import { startUpload } from "../api";
+
+/**
+ * Returns true if the upload passed in is waiting to be uploaded.
+ *
+ * @params {Object} upload - An upload from the tracker.
+ * @returns {boolean}
+ */
+const uploadIsWaiting = (upload) =>
+    !upload.hasUploaded && !upload.hasErrored && !upload.isUploading;
+
+/**
+ * Returns true if the upload passed in is currently running.
+ *
+ * @params {Object} upload -An upload from the tracker.
+ * @returns {boolean}
+ */
+const uploadIsRunning = (upload) =>
+    upload.isUploading && !upload.hasUploaded && !upload.hasErrored;
+
+// adapted from https://codereview.stackexchange.com/a/162879
+
+/**
+ * Partitions the list of uploads into a trio of lists, one for uploads
+ * that are waiting to run, one for uploads that are currently running,
+ * and one for uploads that are in other states (probably errored).
+ *
+ * @params {Array<Object>} uploads - An array of uploads from the tracker.
+ * @returns {Array<Array<Object>>}
+ */
+const partitionUploads = (uploads) => {
+    const [waiting, running, other] = [0, 1, 2];
+
+    const uploadIndex = (upload) => {
+        if (uploadIsWaiting(upload)) return waiting;
+        if (uploadIsRunning(upload)) return running;
+        return other;
+    };
+
+    return uploads.reduce(
+        (acc, upload) => {
+            switch (uploadIndex(upload)) {
+                case waiting:
+                    acc[waiting].push(upload);
+                    break;
+                case running:
+                    acc[running].push(upload);
+                    break;
+                default:
+                    acc[other].push(upload);
+            }
+
+            return acc;
+        },
+        [[], [], []]
+    );
+};
+
+/**
+ * A component that is responsible for triggering the actual uploads of items
+ * in the tracker. Doesn't render anything, purely exists to trigger uploads.
+ *
+ * @returns {Object}
+ */
+export default function UploadManager() {
+    const tracker = useUploadTrackingState();
+    const dispatch = useUploadTrackingDispatch();
+
+    const [waiting, running] = partitionUploads(tracker.uploads);
+
+    // Controls starting the uploads.
+    useEffect(() => {
+        // Browser can technically do more than 3 uploads at once now, but
+        // we're limiting it here to prevent hammering our API too much.
+        if (
+            tracker.uploads.length > 0 &&
+            waiting.length > 0 &&
+            running.length < 3
+        ) {
+            waiting.forEach((upload, idx) => {
+                if (idx <= 2) {
+                    startUpload(upload, upload.parentPath, dispatch);
+                }
+            });
+        }
+    }, [tracker, waiting, running, dispatch]);
+
+    return <div id="upload-manager" />;
+}

--- a/src/components/uploads/manager/index.js
+++ b/src/components/uploads/manager/index.js
@@ -14,6 +14,8 @@ import {
 
 import { startUpload } from "../api";
 
+import { MAX_RUNNING_UPLOADS } from "./constants";
+
 /**
  * Returns true if the upload passed in is waiting to be uploaded.
  *
@@ -89,7 +91,7 @@ export default function UploadManager() {
         if (
             tracker.uploads.length > 0 &&
             waiting.length > 0 &&
-            running.length < 3
+            running.length < MAX_RUNNING_UPLOADS
         ) {
             waiting.forEach((upload, idx) => {
                 if (idx <= 2) {

--- a/src/components/uploads/manager/index.js
+++ b/src/components/uploads/manager/index.js
@@ -3,7 +3,7 @@
  *
  * A component that pulls items out of the upload tracker and triggers them.
  *
- * @module UploadQueue
+ * @module uploads/manager
  */
 import React, { useEffect } from "react";
 

--- a/src/components/uploads/queue/index.js
+++ b/src/components/uploads/queue/index.js
@@ -3,7 +3,7 @@
  *
  * A table populated from tracked uploads. Used in the UploadQueue.
  *
- * @module UploadQueue
+ * @module uploads/queue
  */
 
 import React from "react";

--- a/src/components/uploads/queue/index.js
+++ b/src/components/uploads/queue/index.js
@@ -37,6 +37,10 @@ import {
 
 import { useTheme, makeStyles } from "@material-ui/core/styles";
 
+import { getMessage, withI18N } from "@cyverse-de/ui-lib";
+
+import messages from "./messages";
+
 const useStyles = makeStyles((theme) => ({
     ellipsis: {
         overflow: "hidden",
@@ -121,7 +125,7 @@ const UploadItem = ({ upload, handleCancel }) => {
             <ListItemSecondaryAction>
                 <IconButton
                     edge="end"
-                    aria-label="cancel-upload"
+                    aria-label={getMessage("cancelUploadAria")}
                     onClick={(e) => handleCancel(e, upload)}
                 >
                     <CancelIcon />
@@ -137,7 +141,7 @@ const UploadItem = ({ upload, handleCancel }) => {
  *
  * @returns {Object}
  */
-export default function UploadList() {
+const UploadList = () => {
     const tracker = useUploadTrackingState();
     const dispatch = useUploadTrackingDispatch();
 
@@ -167,4 +171,6 @@ export default function UploadList() {
             ))}
         </List>
     );
-}
+};
+
+export default withI18N(UploadList, messages);

--- a/src/components/uploads/queue/index.js
+++ b/src/components/uploads/queue/index.js
@@ -1,0 +1,154 @@
+/**
+ * @author johnworth
+ *
+ * A table populated from tracked uploads. Used in the UploadQueue.
+ *
+ * @module UploadQueue
+ */
+
+import React from "react";
+
+import {
+    Avatar,
+    CircularProgress,
+    IconButton,
+    List,
+    ListItem,
+    ListItemAvatar,
+    ListItemSecondaryAction,
+    ListItemText,
+    useMediaQuery,
+} from "@material-ui/core";
+
+import {
+    CheckCircle as CheckCircleIcon,
+    Cancel as CancelIcon,
+    Error as ErrorIcon,
+    Description as DescriptionIcon,
+    Http as HttpIcon,
+} from "@material-ui/icons";
+
+import {
+    KindFile,
+    removeAction,
+    useUploadTrackingState,
+    useUploadTrackingDispatch,
+} from "../../../contexts/uploadTracking";
+
+import { useTheme } from "@material-ui/core/styles";
+
+/**
+ * Component for the upload status icon that chooses what to display based on the
+ * state of the upload.
+ *
+ * @params {Object} props
+ * @params {Object} props.upload - An upload from the upload tracker.
+ * @returns {Object}
+ */
+const UploadStatus = ({ upload }) => {
+    const theme = useTheme();
+
+    let statusIcon = <div />;
+
+    if (upload.isUploading) {
+        statusIcon = <CircularProgress size={20} />;
+    }
+
+    if (upload.hasUploaded) {
+        statusIcon = (
+            <CheckCircleIcon style={{ color: theme.palette.success.main }} />
+        );
+    }
+
+    if (upload.hasErrored) {
+        statusIcon = <ErrorIcon color="error" />;
+    }
+
+    return statusIcon;
+};
+
+/**
+ * Component for an item in the list of uploads.
+ *
+ * @params {Object} props
+ * @params {Object} props.upload - An upload from the upload tracker.
+ * @params {Object} props.handleCancel - A callback called when the cancel button is clicked.
+ * @returns {Object}
+ */
+const UploadItem = ({ upload, handleCancel }) => {
+    const theme = useTheme();
+    const isSmall = useMediaQuery(theme.breakpoints.down("sm"));
+
+    return (
+        <ListItem>
+            <ListItemAvatar>
+                <Avatar>
+                    {upload.kind === KindFile ? (
+                        <DescriptionIcon />
+                    ) : (
+                        <HttpIcon />
+                    )}
+                </Avatar>
+            </ListItemAvatar>
+
+            {isSmall ? (
+                <ListItemText primary={upload.filename} />
+            ) : (
+                <ListItemText
+                    primary={upload.filename}
+                    secondary={upload.parentPath}
+                />
+            )}
+
+            <UploadStatus upload={upload} />
+
+            <ListItemSecondaryAction>
+                <IconButton
+                    edge="end"
+                    aria-label="cancel-upload"
+                    onClick={(e) => handleCancel(e, upload)}
+                >
+                    <CancelIcon />
+                </IconButton>
+            </ListItemSecondaryAction>
+        </ListItem>
+    );
+};
+
+/**
+ * Default component that renders a list of uploads being tracked by the upload
+ * tracker.
+ *
+ * @returns {Object}
+ */
+export default function UploadList() {
+    const tracker = useUploadTrackingState();
+    const dispatch = useUploadTrackingDispatch();
+
+    const handleCancel = (event, upload) => {
+        event.stopPropagation();
+        event.preventDefault();
+
+        // Terminate the upload. For URL imports it will cancel the running job.
+        upload.cancelFn();
+
+        // Remove the upload from the tracker.
+        dispatch(
+            removeAction({
+                id: upload.id,
+            })
+        );
+    };
+
+    return (
+        <List dense={true}>
+            {tracker.uploads.map((upload) => (
+                <UploadItem
+                    key={upload.id}
+                    upload={upload}
+                    handleCancel={handleCancel}
+                />
+            ))}
+        </List>
+    );
+}

--- a/src/components/uploads/queue/index.js
+++ b/src/components/uploads/queue/index.js
@@ -35,7 +35,15 @@ import {
     useUploadTrackingDispatch,
 } from "../../../contexts/uploadTracking";
 
-import { useTheme } from "@material-ui/core/styles";
+import { useTheme, makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme) => ({
+    ellipsis: {
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        paddingRight: theme.spacing(1),
+    },
+}));
 
 /**
  * Component for the upload status icon that chooses what to display based on the
@@ -67,6 +75,12 @@ const UploadStatus = ({ upload }) => {
     return statusIcon;
 };
 
+const EllipsisField = ({ children }) => {
+    const classes = useStyles();
+
+    return <div className={classes.ellipsis}>{children}</div>;
+};
+
 /**
  * Component for an item in the list of uploads.
  *
@@ -92,10 +106,12 @@ const UploadItem = ({ upload, handleCancel }) => {
             </ListItemAvatar>
 
             {isSmall ? (
-                <ListItemText primary={upload.filename} />
+                <ListItemText
+                    primary={<EllipsisField>{upload.filename}</EllipsisField>}
+                />
             ) : (
                 <ListItemText
-                    primary={upload.filename}
+                    primary={<EllipsisField>{upload.filename}</EllipsisField>}
                     secondary={upload.parentPath}
                 />
             )}

--- a/src/components/uploads/queue/messages.js
+++ b/src/components/uploads/queue/messages.js
@@ -1,0 +1,6 @@
+export default {
+    locales: "en-us",
+    messages: {
+        cancelUploadAria: "cancel-upload",
+    },
+};

--- a/src/contexts/uploadTracking.js
+++ b/src/contexts/uploadTracking.js
@@ -6,7 +6,7 @@
  * - https://kentcdodds.com/blog/how-to-use-react-context-effectively
  * - https://reactjs.org/docs/hooks-reference.html#usereducer
  *
- * @module uploadTracking
+ * @module contexts/uploadTracking
  */
 
 import React from "react";

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -9,6 +9,7 @@ import { ThemeProvider } from "@material-ui/core/styles";
 import CyverseAppBar from "../components/layout/CyVerseAppBar";
 import Navigation from "../components/layout/Navigation";
 import NavigationConstants from "../components/layout/NavigationConstants";
+import UploadManager from "../components/uploads/manager";
 import theme from "../components/theme/default";
 
 import { UploadTrackingProvider } from "../contexts/uploadTracking";
@@ -81,6 +82,7 @@ function MyApp({ Component, pageProps, intercomAppId, intercomEnabled }) {
                         </Head>
                         <Navigation activeView={pathname} />
                         <Component {...pageProps} />
+                        <UploadManager />
                     </CyverseAppBar>
                 </UploadTrackingProvider>
             </UserProfileProvider>

--- a/stories/UploadDropTarget.stories.js
+++ b/stories/UploadDropTarget.stories.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import UploadDropTarget from "../src/components/data/listing/UploadDropTarget";
+import UploadDropTarget from "../src/components/uploads/UploadDropTarget";
 import {
     UploadTrackingProvider,
     useUploadTrackingState,

--- a/stories/UploadQueue.stories.js
+++ b/stories/UploadQueue.stories.js
@@ -1,0 +1,98 @@
+import React, { useState } from "react";
+import UUID from "uuid/v4";
+
+import {
+    UploadTrackingProvider,
+    useUploadTrackingDispatch,
+    addAction,
+} from "../src/contexts/uploadTracking";
+
+import { Button } from "@material-ui/core";
+
+import UploadDialog from "../src/components/uploads/dialog";
+
+export default {
+    title: "Uploads/UploadQueue",
+};
+
+const TestDispatch = () => {
+    const dispatch = useUploadTrackingDispatch();
+
+    const [hasRun, setHasRun] = useState(false);
+
+    if (!hasRun) {
+        dispatch(
+            addAction({
+                id: UUID(),
+                parentPath:
+                    "/iplant/home/ipcdev/test-0/foo/bar/baz/blippy/this/should/be/really/long",
+                filename: "fake-upload-0",
+                isUploading: true,
+                hasUploaded: false,
+                file: {
+                    name: "fake-upload-0",
+                },
+            })
+        );
+
+        dispatch(
+            addAction({
+                id: UUID(),
+                parentPath: "/iplant/home/ipcdev/test-1",
+                filename: "fake-upload-1",
+                isUploading: false,
+                hasUploaded: true,
+                file: {
+                    name: "fake-upload-1",
+                },
+            })
+        );
+
+        dispatch(
+            addAction({
+                id: UUID(),
+                parentPath: "/iplant/home/ipcdev/test-2",
+                filename: "fake-upload-2",
+                isUploading: false,
+                hasUploaded: false,
+                hasErrored: true,
+                errorMessage: "test error message",
+                file: {
+                    name: "fake-upload-2",
+                },
+            })
+        );
+
+        dispatch(
+            addAction({
+                id: UUID(),
+                parentPath: "/iplant/home/ipcdev/test-3",
+                filename: "fake-upload-3",
+                isUploading: false,
+                hasUploaded: false,
+                file: {
+                    name: "fake-upload-3",
+                },
+            })
+        );
+
+        setHasRun(true);
+    }
+
+    return <></>;
+};
+
+export const UploadQueueTest = () => {
+    const [open, setOpen] = useState(true);
+    const handleClose = () => setOpen(!open);
+
+    return (
+        <UploadTrackingProvider>
+            <Button onClick={() => setOpen(true)}>Open</Button>
+
+            <TestDispatch />
+
+            <UploadDialog open={open} handleClose={handleClose} />
+        </UploadTrackingProvider>
+    );
+};


### PR DESCRIPTION
Most of the upload-related components and code is contained in the `src/components/uploads` directory now. 

The `UploadManager` in `components/uploads/manager` is a non-visible component that accesses the upload tracking context and triggers the actual API calls. The `UploadManager` tag was added to `src/pages/_app.js` because we want the uploads to progress regardless of the page the user navigates to, as long as they keep the tab/window open.

The `UploadQueue` in `components/uploads/queue` renders a list of tracked uploads contained in the upload tracking context.

The `UploadDialog` in `components/uploads/dialog` renders a dialog containing an `UploadQueue`. It may eventually become an drawer of some sort, but that's not happening now. The `UploadDialog` is accessible through the Data Listing's Uploads Menu. A story was added to render the `UploadDialog`.

IDs and i18n should be in place.

The "dirty bit" to trigger a warning to the user has not been added. That will come in a later PR.

The errors indicated in the `Upload Dialog` do not have messages displayed as of yet. I'm guessing we're going to want that info in the `Alerts` page and popping up in snackbars, but AFAIK neither of those is available yet.

![Screen Shot 2020-02-27 at 2 56 41 PM](https://user-images.githubusercontent.com/49783/75490489-8c67a280-5971-11ea-9f10-3884b089fcac.png)

![Screen Shot 2020-02-27 at 2 57 22 PM](https://user-images.githubusercontent.com/49783/75490504-9093c000-5971-11ea-881a-0bc4b35e4477.png)

![Screen Shot 2020-02-27 at 3 20 35 PM](https://user-images.githubusercontent.com/49783/75492308-bff7fc00-5974-11ea-84ad-8d6ff0e6cd2d.png)

Mobile, from storybook:

![Screen Shot 2020-02-27 at 3 22 21 PM](https://user-images.githubusercontent.com/49783/75492435-04839780-5975-11ea-94c1-cb4b9d550505.png)





