### PR TITLE
CORE-940 User can customize data columns

### DIFF
--- a/src/__tests__/__snapshots__/data.js.snap
+++ b/src/__tests__/__snapshots__/data.js.snap
@@ -86,7 +86,7 @@ exports[`Data Table View renders 1`] = `
         <th
           aria-sort={null}
           className="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-stickyHeader"
-          id="tableView.listingTable."
+          id="tableView.listingTable.checkbox"
           scope="col"
         >
           
@@ -94,7 +94,7 @@ exports[`Data Table View renders 1`] = `
         <th
           aria-sort={null}
           className="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-stickyHeader"
-          id="tableView.listingTable."
+          id="tableView.listingTable.name"
           scope="col"
         >
           <span
@@ -135,13 +135,15 @@ exports[`Data Table View renders 1`] = `
         <th
           aria-sort={null}
           className="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-stickyHeader"
-          id="tableView.listingTable."
+          id="tableView.listingTable.dotMenu"
           scope="col"
         >
-          <span
-            aria-describedby={null}
-            aria-disabled={false}
-            className="MuiButtonBase-root MuiTableSortLabel-root"
+          <button
+            aria-controls="tableView.listingTable.customCols"
+            aria-haspopup="true"
+            aria-label="Customize table columns"
+            className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+            disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
             onDragLeave={[Function]}
@@ -150,118 +152,33 @@ exports[`Data Table View renders 1`] = `
             onKeyUp={[Function]}
             onMouseDown={[Function]}
             onMouseLeave={[Function]}
-            onMouseOver={[Function]}
             onMouseUp={[Function]}
             onTouchEnd={[Function]}
             onTouchMove={[Function]}
             onTouchStart={[Function]}
-            role="button"
             tabIndex={0}
-            title={null}
+            type="button"
           >
-            Size
-            <svg
-              aria-hidden="true"
-              className="MuiSvgIcon-root MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc"
-              focusable="false"
-              role="presentation"
-              viewBox="0 0 24 24"
+            <span
+              className="MuiIconButton-label"
             >
-              <path
-                d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-              />
-            </svg>
-          </span>
-        </th>
-        <th
-          aria-sort={null}
-          className="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-stickyHeader"
-          id="tableView.listingTable."
-          scope="col"
-        >
-          <span
-            aria-describedby={null}
-            aria-disabled={false}
-            className="MuiButtonBase-root MuiTableSortLabel-root"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragLeave={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseOver={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            role="button"
-            tabIndex={0}
-            title={null}
-          >
-            Last Modified
-            <svg
-              aria-hidden="true"
-              className="MuiSvgIcon-root MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc"
-              focusable="false"
-              role="presentation"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-              />
-            </svg>
-          </span>
-        </th>
-        <th
-          aria-sort={null}
-          className="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-stickyHeader"
-          id="tableView.listingTable."
-          scope="col"
-        >
-          <span
-            aria-describedby={null}
-            aria-disabled={false}
-            className="MuiButtonBase-root MuiTableSortLabel-root"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragLeave={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseOver={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            role="button"
-            tabIndex={0}
-            title={null}
-          >
-            Date Submitted
-            <svg
-              aria-hidden="true"
-              className="MuiSvgIcon-root MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc"
-              focusable="false"
-              role="presentation"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-              />
-            </svg>
-          </span>
-        </th>
-        <th
-          aria-sort={null}
-          className="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-stickyHeader"
-          id="tableView.listingTable."
-          scope="col"
-        >
-          
+              <svg
+                aria-hidden="true"
+                className="MuiSvgIcon-root"
+                focusable="false"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.95 10.78c.03-.25.05-.51.05-.78s-.02-.53-.06-.78l1.69-1.32c.15-.12.19-.34.1-.51l-1.6-2.77c-.1-.18-.31-.24-.49-.18l-1.99.8c-.42-.32-.86-.58-1.35-.78L12 2.34c-.03-.2-.2-.34-.4-.34H8.4c-.2 0-.36.14-.39.34l-.3 2.12c-.49.2-.94.47-1.35.78l-1.99-.8c-.18-.07-.39 0-.49.18l-1.6 2.77c-.1.18-.06.39.1.51l1.69 1.32c-.04.25-.07.52-.07.78s.02.53.06.78L2.37 12.1c-.15.12-.19.34-.1.51l1.6 2.77c.1.18.31.24.49.18l1.99-.8c.42.32.86.58 1.35.78l.3 2.12c.04.2.2.34.4.34h3.2c.2 0 .37-.14.39-.34l.3-2.12c.49-.2.94-.47 1.35-.78l1.99.8c.18.07.39 0 .49-.18l1.6-2.77c.1-.18.06-.39-.1-.51l-1.67-1.32zM10 13c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3z"
+                  transform="scale(1.2, 1.2)"
+                />
+              </svg>
+            </span>
+            <span
+              className="MuiTouchRipple-root"
+            />
+          </button>
         </th>
       </tr>
     </thead>
@@ -347,7 +264,7 @@ exports[`Data Table View renders 1`] = `
           className="MuiTableCell-root MuiTableCell-body"
         >
           <span
-            className="makeStyles-dataLink-103"
+            className="makeStyles-dataLink-107"
             id="tableView.listingTable.analyses_qa-3.navigationLink"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -356,24 +273,6 @@ exports[`Data Table View renders 1`] = `
           >
             analyses_qa-3
           </span>
-        </td>
-        <td
-          aria-sort={null}
-          className="MuiTableCell-root MuiTableCell-body"
-        >
-          -
-        </td>
-        <td
-          aria-sort={null}
-          className="MuiTableCell-root MuiTableCell-body"
-        >
-          2016 Sep 20 20:27:57
-        </td>
-        <td
-          aria-sort={null}
-          className="MuiTableCell-root MuiTableCell-body"
-        >
-          -
         </td>
         <td
           aria-sort={null}
@@ -500,7 +399,7 @@ exports[`Data Table View renders 1`] = `
           className="MuiTableCell-root MuiTableCell-body"
         >
           <span
-            className="makeStyles-dataLink-103"
+            className="makeStyles-dataLink-107"
             id="tableView.listingTable.test.navigationLink"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -509,24 +408,6 @@ exports[`Data Table View renders 1`] = `
           >
             test
           </span>
-        </td>
-        <td
-          aria-sort={null}
-          className="MuiTableCell-root MuiTableCell-body"
-        >
-          -
-        </td>
-        <td
-          aria-sort={null}
-          className="MuiTableCell-root MuiTableCell-body"
-        >
-          2018 Jun 28 22:49:35
-        </td>
-        <td
-          aria-sort={null}
-          className="MuiTableCell-root MuiTableCell-body"
-        >
-          -
         </td>
         <td
           aria-sort={null}
@@ -653,7 +534,7 @@ exports[`Data Table View renders 1`] = `
           className="MuiTableCell-root MuiTableCell-body"
         >
           <span
-            className="makeStyles-dataLink-103"
+            className="makeStyles-dataLink-107"
             id="tableView.listingTable.CORE-8424.txt.navigationLink"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -662,24 +543,6 @@ exports[`Data Table View renders 1`] = `
           >
             CORE-8424.txt
           </span>
-        </td>
-        <td
-          aria-sort={null}
-          className="MuiTableCell-root MuiTableCell-body"
-        >
-          9 B
-        </td>
-        <td
-          aria-sort={null}
-          className="MuiTableCell-root MuiTableCell-body"
-        >
-          2017 Feb 08 00:03:33
-        </td>
-        <td
-          aria-sort={null}
-          className="MuiTableCell-root MuiTableCell-body"
-        >
-          -
         </td>
         <td
           aria-sort={null}
@@ -806,7 +669,7 @@ exports[`Data Table View renders 1`] = `
           className="MuiTableCell-root MuiTableCell-body"
         >
           <span
-            className="makeStyles-dataLink-103"
+            className="makeStyles-dataLink-107"
             id="tableView.listingTable.sample.csv.navigationLink"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -815,24 +678,6 @@ exports[`Data Table View renders 1`] = `
           >
             sample.csv
           </span>
-        </td>
-        <td
-          aria-sort={null}
-          className="MuiTableCell-root MuiTableCell-body"
-        >
-          15 B
-        </td>
-        <td
-          aria-sort={null}
-          className="MuiTableCell-root MuiTableCell-body"
-        >
-          2014 Oct 30 20:23:43
-        </td>
-        <td
-          aria-sort={null}
-          className="MuiTableCell-root MuiTableCell-body"
-        >
-          -
         </td>
         <td
           aria-sort={null}

--- a/src/components/data/ids.js
+++ b/src/components/data/ids.js
@@ -1,6 +1,7 @@
 export default {
     checkbox: "checkbox",
     COGE_MI: "cogeMenuItem",
+    CUSTOM_COLS: "customCols",
     DELETE: "delete",
     deleteMI: "delete",
     DETAILS_BTN: "detailsBtn",

--- a/src/components/data/listing/CustomizeColumns.js
+++ b/src/components/data/listing/CustomizeColumns.js
@@ -1,0 +1,105 @@
+/**
+ * @author aramsey
+ *
+ * A Menu component which allows users to select which columns
+ * they wish to have displayed in the Data view
+ */
+
+import React, { useState } from "react";
+
+import { build, formatMessage, withI18N } from "@cyverse-de/ui-lib";
+import { IconButton, ListItemIcon, Menu, MenuItem } from "@material-ui/core";
+import { Check, Settings } from "@material-ui/icons";
+import { injectIntl } from "react-intl";
+
+import ids from "../ids";
+import messages from "../messages";
+
+function CustomizeColumns(props) {
+    const {
+        baseId,
+        allTableColumns,
+        displayColumns,
+        setDisplayColumns,
+        intl,
+    } = props;
+
+    const [columnSettingEl, setColumnSettingEl] = useState(null);
+    const [columnSettingsOpen, setColumnSettingsOpen] = useState(false);
+
+    const getColumnIndex = (key) => {
+        return displayColumns.findIndex((colKey) => colKey === key);
+    };
+
+    const isDisplayColumn = (key) => {
+        return getColumnIndex(key) !== -1;
+    };
+
+    const handleColumnSettingClick = (event) => {
+        setColumnSettingEl(event.currentTarget);
+        setColumnSettingsOpen(true);
+    };
+
+    const handleColumnSettingClose = () => {
+        setColumnSettingsOpen(false);
+    };
+
+    const onColumnSelected = (selectedColumn) => {
+        const colIndex = getColumnIndex(selectedColumn.key);
+        const newDisplayColumns = [...displayColumns];
+        if (colIndex !== -1) {
+            // Remove column
+            newDisplayColumns.splice(colIndex, 1);
+            setDisplayColumns(newDisplayColumns);
+        } else {
+            // Add column
+            newDisplayColumns.splice(
+                displayColumns.length - 1,
+                0,
+                selectedColumn.key
+            );
+            setDisplayColumns(newDisplayColumns);
+        }
+    };
+
+    const menuId = build(baseId, ids.CUSTOM_COLS);
+
+    return (
+        <>
+            <IconButton
+                aria-label={formatMessage(intl, "ariaCustomCols")}
+                aria-controls={menuId}
+                aria-haspopup="true"
+                size="small"
+                onClick={handleColumnSettingClick}
+            >
+                <Settings />
+            </IconButton>
+            <Menu
+                id={menuId}
+                anchorEl={columnSettingEl}
+                open={columnSettingsOpen}
+                onClose={handleColumnSettingClose}
+            >
+                {allTableColumns.map((col) => (
+                    <MenuItem
+                        key={col.key}
+                        id={build(menuId, col.key)}
+                        onClick={() => {
+                            onColumnSelected(col);
+                        }}
+                    >
+                        {isDisplayColumn(col.key) && (
+                            <ListItemIcon>
+                                <Check />
+                            </ListItemIcon>
+                        )}
+                        {col.name}
+                    </MenuItem>
+                ))}
+            </Menu>
+        </>
+    );
+}
+
+export default withI18N(injectIntl(CustomizeColumns), messages);

--- a/src/components/data/listing/CustomizeColumns.js
+++ b/src/components/data/listing/CustomizeColumns.js
@@ -7,9 +7,9 @@
 
 import React, { useState } from "react";
 
-import { build, formatMessage, withI18N } from "@cyverse-de/ui-lib";
+import { build, DECheckbox, formatMessage, withI18N } from "@cyverse-de/ui-lib";
 import { IconButton, ListItemIcon, Menu, MenuItem } from "@material-ui/core";
-import { Check, Settings } from "@material-ui/icons";
+import { Settings } from "@material-ui/icons";
 import { injectIntl } from "react-intl";
 
 import ids from "../ids";
@@ -85,11 +85,14 @@ function CustomizeColumns(props) {
                             onColumnSelected(col);
                         }}
                     >
-                        {isDisplayColumn(col.key) && (
-                            <ListItemIcon>
-                                <Check />
-                            </ListItemIcon>
-                        )}
+                        <ListItemIcon>
+                            <DECheckbox
+                                checked={isDisplayColumn(col.key)}
+                                onChange={() => {
+                                    onColumnSelected(col);
+                                }}
+                            />
+                        </ListItemIcon>
                         {col.name}
                     </MenuItem>
                 ))}

--- a/src/components/data/listing/CustomizeColumns.js
+++ b/src/components/data/listing/CustomizeColumns.js
@@ -27,12 +27,8 @@ function CustomizeColumns(props) {
     const [columnSettingEl, setColumnSettingEl] = useState(null);
     const [columnSettingsOpen, setColumnSettingsOpen] = useState(false);
 
-    const getColumnIndex = (key) => {
-        return displayColumns.findIndex((colKey) => colKey === key);
-    };
-
     const isDisplayColumn = (key) => {
-        return getColumnIndex(key) !== -1;
+        return Boolean(displayColumns.find((colKey) => colKey === key));
     };
 
     const handleColumnSettingClick = (event) => {
@@ -45,14 +41,14 @@ function CustomizeColumns(props) {
     };
 
     const onColumnSelected = (selectedColumn) => {
-        const colIndex = getColumnIndex(selectedColumn.key);
-        const newDisplayColumns = [...displayColumns];
-        if (colIndex !== -1) {
+        if (isDisplayColumn(selectedColumn.key)) {
             // Remove column
-            newDisplayColumns.splice(colIndex, 1);
-            setDisplayColumns(newDisplayColumns);
+            setDisplayColumns(
+                displayColumns.filter((key) => key !== selectedColumn.key)
+            );
         } else {
             // Add column
+            const newDisplayColumns = [...displayColumns];
             newDisplayColumns.splice(
                 displayColumns.length - 1,
                 0,

--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -7,7 +7,7 @@
 import React, { useEffect, useState } from "react";
 
 import { formatMessage, withI18N } from "@cyverse-de/ui-lib";
-import { TablePagination, useMediaQuery, useTheme } from "@material-ui/core";
+import { TablePagination } from "@material-ui/core";
 
 import Header from "../Header";
 import messages from "../messages";
@@ -29,10 +29,7 @@ import constants from "../../../constants";
 import Drawer from "../details/Drawer";
 
 function Listing(props) {
-    const theme = useTheme();
     const router = useRouter();
-    const isMedium = useMediaQuery(theme.breakpoints.up("sm"));
-    const isLarge = useMediaQuery(theme.breakpoints.up("lg"));
     const uploadTracker = useUploadTrackingState();
     const [userProfile] = useUserProfile();
 
@@ -292,8 +289,6 @@ function Listing(props) {
                         path={path}
                         handlePathChange={handlePathChange}
                         listing={data?.listing}
-                        isMedium={isMedium}
-                        isLarge={isLarge}
                         baseId={baseId}
                         onDownloadSelected={onDownloadSelected}
                         onEditSelected={onEditSelected}

--- a/src/components/data/listing/TableView.js
+++ b/src/components/data/listing/TableView.js
@@ -251,7 +251,7 @@ function TableView(props) {
                         {(!listing || listing.length === 0) && !error && (
                             <EmptyTable
                                 message={getMessage("emptyDataListing")}
-                                numColumns={displayColumns.length}
+                                numColumns={displayColumns.length + 1} // extra for checkbox col
                             />
                         )}
                         {error && (

--- a/src/components/data/messages.js
+++ b/src/components/data/messages.js
@@ -2,6 +2,7 @@ export default {
     locales: "en-us",
     messages: {
         ariaCheckbox: "{label} checkbox",
+        ariaCustomCols: "Customize table columns",
         ariaTableListing: "{path} Data Table",
         browseLocal: "Browse Local",
         created: "Created",


### PR DESCRIPTION
For now, I've made it the default that only the checkbox, name, and dot menu show in the table view.  I removed the breakpoints because I figure users can set whatever columns make sense for their screen size as needed.  In another PR, I can probably update the default columns to check for a value stored in local storage so the setting persists.

Desktop view:
![image](https://user-images.githubusercontent.com/8909156/76805129-4137f700-679b-11ea-8a45-6f46497c422f.png)

Menu open:
![image](https://user-images.githubusercontent.com/8909156/77586908-2d2f7c00-6ea4-11ea-82b8-cdea906ec220.png)

Mobile view:
![image](https://user-images.githubusercontent.com/8909156/77586982-4b957780-6ea4-11ea-843a-5d942f721b1f.png)

Scrolling on mobile:
![customcolumns](https://user-images.githubusercontent.com/8909156/77586769-f48fa280-6ea3-11ea-8180-480de6b6ad1e.gif)
