### PR TITLE
CORE-868: optional authentication

### DIFF
--- a/src/server/api/router.js
+++ b/src/server/api/router.js
@@ -29,7 +29,7 @@ export default function apiRouter() {
         auth.authnTokenMiddleware,
         terrainHandler({
             method: "GET",
-            pathname: "/secured/filesystem/paged-directory",
+            pathname: "/filesystem/paged-directory",
         })
     );
 

--- a/src/server/api/terrain.js
+++ b/src/server/api/terrain.js
@@ -73,12 +73,14 @@ export const call = (
 
     logger.info(`TERRAIN ${userID} ${method} ${apiURL.href}`);
 
+    const buildRequestOptionHeaders = () => {
+        return accessToken ? { Authorization: `Bearer ${accessToken}` } : {};
+    };
+
     let requestOptions = {
         method,
         credentials: "include",
-        headers: {
-            Authorization: `Bearer ${accessToken}`,
-        },
+        headers: buildRequestOptionHeaders(),
     };
 
     if (!["GET", "HEAD"].includes(method)) {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -84,7 +84,7 @@ app.prepare()
             app.render(req, res, "/dashboard", undefined);
         });
 
-        server.get("*", keycloakClient.checkSso(), (req, res) => {
+        server.get("*", (req, res) => {
             return nextHandler(req, res);
         });
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -73,7 +73,7 @@ app.prepare()
         });
 
         logger.info("adding the api router to the express server");
-        server.use("/api", keycloakClient.checkSso(), apiRouter());
+        server.use("/api", apiRouter());
 
         logger.info(
             "adding the next.js fallthrough handler to the express server."
@@ -82,6 +82,12 @@ app.prepare()
         //map root to Dashboard
         server.get("/", keycloakClient.checkSso(), (req, res) => {
             app.render(req, res, "/dashboard", undefined);
+        });
+
+        // URL paths that might appear in the browser address bar should match this route.
+        const userRouteRegexp = /^\/(dashboard|data|apps|analyses|more)/;
+        server.get(userRouteRegexp, keycloakClient.checkSso(), (req, res) => {
+            return nextHandler(req, res);
         });
 
         server.get("*", (req, res) => {


### PR DESCRIPTION
The optional authentication bits that were in place weren't working for API calls, and were causing unnecessary redirects to Keycloak for things such as HMR requests. This PR makes the following changes:

- Removes the SSO check from the primary `/api` route handler. This check was blocking unauthenticated requests from actually getting to the API endpoints because HTTP calls from within Javascript don't automatically follow redirects. It wasn't actually detecting SSO sessions when the user hadn't logged into Sonora yet for the same reason.
- Removes the SSO check from the catch-all route handler. This check was working, but it was also causing unnecessary redirects to Keycloak when the user wasn't logged yet.
- Adds a route handler for URL paths that may appear in the browser address bar. This handler does perform the SSO check so that we can detect when a user has an SSO session with Keycloak without forcing too many redirects.
- Updates the general Terrain call endpoint so that it only includes the `Authorization` header if an access token is actually available. This is necessary for calls to optionally authenticated endpoints in Terrain to work.
- Switches from the authenticated directory listing endpoint in Terrain to its optionally authenticated counterpart.

Please let me know if I've missed any URL paths that may appear in the browser address bar. I think I caught most of them, but there may be some that I'm missing.
