### PR TITLE
Update data path routing and data view subcomponent organization

### DIFF
--- a/src/components/data/DataNavigation.js
+++ b/src/components/data/DataNavigation.js
@@ -74,6 +74,28 @@ function getPathItems(relativePath) {
 }
 
 /**
+ * Computes the path for routing.
+ *  * @example
+ * // returns "/iplant/home/ipctest/analyses"
+ * getPathItems("/iplant/home/ipctest","/analyses/wordcount/logs", 0);
+ * @param {string } root - CyVerse Data Store root path e.g: /iplant/home/ipctest
+ * @param {string} relativePath - relative path to CyVerse Data Store e.g: /analyses/wordcount/logs
+ * @param {number} selectedPathItemIndex - index of the selected path item
+ * @returns {string} - path to be used by the nextjs router
+ */
+function pathToRoute(root, relativePath, selectedPathItemIndex) {
+    const relativePathItems = getPathItems(relativePath);
+    const reducer = (accumulator, currentVal, idx) => {
+        if (idx <= selectedPathItemIndex) {
+            return accumulator + constants.PATH_SEPARATOR + currentVal;
+        }
+        return accumulator;
+    };
+    const routerPath = relativePathItems.reduce(reducer);
+    return `${root}${constants.PATH_SEPARATOR}${routerPath}`;
+}
+
+/**
  * Get relative path to CyVerse Data Store path.
  * Note: - Swapping community data path check and shared with me path check will result in incorrect
  * relative path since their path overlaps
@@ -111,6 +133,7 @@ function getRelativePath(
 }
 
 function FolderSelectorMenu({
+    root,
     path,
     handlePathChange,
     userHomePath,
@@ -150,7 +173,7 @@ function FolderSelectorMenu({
             sharedWithMePath,
             communityDataPath
         );
-        handlePathChange(`${relativePath}${constants.PATH_SEPARATOR}${index}`);
+        handlePathChange(pathToRoute(root, relativePath, index));
     };
 
     const handleClose = () => {
@@ -246,6 +269,7 @@ function FolderSelectorMenu({
 }
 
 function BreadCrumb({
+    root,
     path,
     handlePathChange,
     userHomePath,
@@ -268,7 +292,7 @@ function BreadCrumb({
         event.preventDefault();
         const relativePathItems = getPathItems(relativePath);
         const index = relativePathItems.indexOf(crumb);
-        handlePathChange(`${relativePath}${constants.PATH_SEPARATOR}${index}`);
+        handlePathChange(pathToRoute(root, relativePath, index));
     };
 
     return (
@@ -502,6 +526,7 @@ function DataNavigation(props) {
                 {path ? (
                     <BreadCrumb
                         baseId={dataNavId}
+                        root={dataRoots[selectedIndex].path}
                         path={path}
                         handlePathChange={handlePathChange}
                         userHomePath={userHomePath}
@@ -518,6 +543,7 @@ function DataNavigation(props) {
                 {path ? (
                     <FolderSelectorMenu
                         baseId={dataNavId}
+                        root={dataRoots[selectedIndex].path}
                         path={path}
                         handlePathChange={handlePathChange}
                         userHomePath={userHomePath}

--- a/src/components/data/Header.js
+++ b/src/components/data/Header.js
@@ -38,8 +38,6 @@ function Header(props) {
     const classes = useStyles();
     const {
         baseId,
-        path,
-        error,
         isGridView,
         toggleDisplay,
         onDownloadSelected,
@@ -49,102 +47,83 @@ function Header(props) {
         detailsEnabled,
         onDetailsSelected,
         intl,
-        dataRoots,
-        userHomePath,
-        userTrashPath,
-        sharedWithMePath,
-        communityDataPath,
     } = props;
 
     let headerId = build(baseId, ids.HEADER);
 
     return (
-        <>
-            <Toolbar variant="dense">
-                <DataNavigation
-                    path={path}
-                    error={error}
-                    baseId={baseId}
-                    dataRoots={dataRoots}
-                    userHomePath={userHomePath}
-                    userTrashPath={userTrashPath}
-                    sharedWithMePath={sharedWithMePath}
-                    communityDataPath={communityDataPath}
-                />
-            </Toolbar>
-            <Toolbar
-                variant="dense"
-                classes={{ root: classes.toolbar }}
-                id={headerId}
-            >
-                {isGridView && (
-                    <Tooltip
-                        id={build(headerId, ids.TABLE_VIEW_BTN, ids.TOOLTIP)}
-                        title={getMessage("tableView")}
-                        aria-label={formatMessage(intl, "tableView")}
+        <Toolbar
+            variant="dense"
+            classes={{ root: classes.toolbar }}
+            id={headerId}
+        >
+            {isGridView && (
+                <Tooltip
+                    id={build(headerId, ids.TABLE_VIEW_BTN, ids.TOOLTIP)}
+                    title={getMessage("tableView")}
+                    aria-label={formatMessage(intl, "tableView")}
+                >
+                    <IconButton
+                        id={build(headerId, ids.TABLE_VIEW_BTN)}
+                        edge="start"
+                        className={classes.menuButton}
+                        onClick={() => toggleDisplay()}
                     >
-                        <IconButton
-                            id={build(headerId, ids.TABLE_VIEW_BTN)}
-                            edge="start"
-                            className={classes.menuButton}
-                            onClick={() => toggleDisplay()}
-                        >
-                            <TableIcon />
-                        </IconButton>
-                    </Tooltip>
-                )}
-                {!isGridView && (
-                    <Tooltip
-                        id={build(headerId, ids.GRID_VIEW_BTN, ids.TOOLTIP)}
-                        title={getMessage("gridView")}
-                        aria-label={formatMessage(intl, "gridView")}
+                        <TableIcon />
+                    </IconButton>
+                </Tooltip>
+            )}
+            {!isGridView && (
+                <Tooltip
+                    id={build(headerId, ids.GRID_VIEW_BTN, ids.TOOLTIP)}
+                    title={getMessage("gridView")}
+                    aria-label={formatMessage(intl, "gridView")}
+                >
+                    <IconButton
+                        id={build(headerId, ids.GRID_VIEW_BTN)}
+                        edge="start"
+                        className={classes.menuButton}
+                        onClick={() => toggleDisplay()}
                     >
-                        <IconButton
-                            id={build(headerId, ids.GRID_VIEW_BTN)}
-                            edge="start"
-                            className={classes.menuButton}
-                            onClick={() => toggleDisplay()}
-                        >
-                            <GridIcon />
-                        </IconButton>
-                    </Tooltip>
-                )}
-                <div className={classes.divider} />
-                {detailsEnabled && (
-                    <Button
-                        id={build(headerId, ids.DETAILS_BTN)}
-                        variant="contained"
-                        disableElevation
-                        color="primary"
-                        className={classes.button}
-                        onClick={onDetailsSelected}
-                    >
-                        <Info className={classes.buttonIcon} />
-                        <Hidden xsDown>{getMessage("details")}</Hidden>
-                    </Button>
-                )}
-                <UploadMenuBtn baseId={headerId} />
+                        <GridIcon />
+                    </IconButton>
+                </Tooltip>
+            )}
+            <div className={classes.divider} />
+            {detailsEnabled && (
                 <Button
-                    id={build(headerId, ids.SHARE_BTN)}
+                    id={build(headerId, ids.DETAILS_BTN)}
                     variant="contained"
                     disableElevation
                     color="primary"
                     className={classes.button}
-                    onClick={() => console.log("Share")}
+                    onClick={onDetailsSelected}
                 >
-                    <Share className={classes.buttonIcon} />
-                    <Hidden xsDown>{getMessage("share")}</Hidden>
+                    <Info className={classes.buttonIcon} />
+                    <Hidden xsDown>{getMessage("details")}</Hidden>
                 </Button>
-                <DataDotMenu
-                    baseId={headerId}
-                    onDownloadSelected={onDownloadSelected}
-                    onEditSelected={onEditSelected}
-                    onMetadataSelected={onMetadataSelected}
-                    onDeleteSelected={onDeleteSelected}
-                    ButtonProps={{ className: classes.whiteDotMenu }}
-                />
-            </Toolbar>
-        </>
+            )}
+            <UploadMenuBtn baseId={headerId} />
+            <Button
+                id={build(headerId, ids.SHARE_BTN)}
+                variant="contained"
+                disableElevation
+                color="primary"
+                className={classes.button}
+                onClick={() => console.log("Share")}
+            >
+                <Share className={classes.buttonIcon} />
+                <Hidden xsDown>{getMessage("share")}</Hidden>
+            </Button>
+            <DataDotMenu
+                baseId={headerId}
+                onDownloadSelected={onDownloadSelected}
+                onEditSelected={onEditSelected}
+                onMetadataSelected={onMetadataSelected}
+                onDeleteSelected={onDeleteSelected}
+                ButtonProps={{ className: classes.whiteDotMenu }}
+            />
+        </Toolbar>
     );
 }
 

--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -6,13 +6,8 @@
  */
 import React, { useEffect, useState } from "react";
 
-import { formatMessage, withI18N } from "@cyverse-de/ui-lib";
-import { TablePagination } from "@material-ui/core";
-import HomeIcon from "@material-ui/icons/Home";
-import FolderSharedIcon from "@material-ui/icons/FolderShared";
-import GroupIcon from "@material-ui/icons/Group";
-import DeleteIcon from "@material-ui/icons/Delete";
-import { useRouter } from "next/router";
+import { withI18N } from "@cyverse-de/ui-lib";
+import { TablePagination, Toolbar } from "@material-ui/core";
 import { injectIntl } from "react-intl";
 
 import Header from "../Header";
@@ -21,20 +16,15 @@ import TableView from "./TableView";
 import UploadDropTarget from "../../uploads/UploadDropTarget";
 import { useUploadTrackingState } from "../../../contexts/uploadTracking";
 import { camelcaseit } from "../../../common/functions";
-import NavigationConstants from "../../../common/NavigationConstants";
-import { useUserProfile } from "../../../contexts/userProfile";
-import constants from "../../../constants";
 import Drawer from "../details/Drawer";
 import {
-    getFilesystemRoots,
     getInfoTypes,
     getPagedListing,
 } from "../../endpoints/Filesystem";
+import DataNavigation from "../DataNavigation";
 
 function Listing(props) {
-    const router = useRouter();
     const uploadTracker = useUploadTrackingState();
-    const [userProfile] = useUserProfile();
 
     const [isGridView, setGridView] = useState(false);
     const [order, setOrder] = useState("asc");
@@ -51,12 +41,7 @@ function Listing(props) {
     const [detailsResource, setDetailsResource] = useState(null);
     const [infoTypes, setInfoTypes] = useState([]);
 
-    const [dataRoots, setDataRoots] = useState([]);
-    const [userHomePath, setUserHomePath] = useState("");
-    const [userTrashPath, setUserTrashPath] = useState("");
-    const [sharedWithMePath, setSharedWithMePath] = useState("");
-    const [communityDataPath, setCommunityDataPath] = useState("");
-    const { baseId, path, handlePathChange, intl } = props;
+    const { baseId, path, handlePathChange } = props;
 
     // Used to force the data listing to refresh when uploads are completed.
     const uploadsCompleted = uploadTracker.uploads.filter((upload) => {
@@ -96,38 +81,6 @@ function Listing(props) {
             );
         }
     }, [path, rowsPerPage, orderBy, order, page, uploadsCompleted]);
-
-    useEffect(() => {
-        getFilesystemRoots().then((respData) => {
-            if (respData && userProfile) {
-                const respRoots = respData.roots;
-                const home = respRoots.find(
-                    (root) => root.label === userProfile.id
-                );
-                home.icon = <HomeIcon />;
-                const sharedWithMe = respRoots.find(
-                    (root) => root.label === constants.SHARED_WITH_ME
-                );
-                setSharedWithMePath(sharedWithMe.path);
-                sharedWithMe.icon = <FolderSharedIcon />;
-                const communityData = respRoots.find(
-                    (root) => root.label === constants.COMMUNITY_DATA
-                );
-                setCommunityDataPath(communityData.path);
-                communityData.icon = <GroupIcon />;
-                const trash = respRoots.find(
-                    (root) => root.label === formatMessage(intl, "trash")
-                );
-                trash.icon = <DeleteIcon />;
-
-                const basePaths = respData["base-paths"];
-                setUserHomePath(basePaths["user_home_path"]);
-                setUserTrashPath(basePaths["user_trash_path"]);
-                setDataRoots([home, sharedWithMe, communityData, trash]);
-            }
-            setError("");
-        });
-    }, [path, intl, userProfile]);
 
     useEffect(() => {
         getInfoTypes().then((resp) => {
@@ -240,15 +193,6 @@ function Listing(props) {
         setPage(0);
     };
 
-    //route to default path
-    if (dataRoots.length > 0 && (!error || error.length === 0) && !path) {
-        router.push(
-            encodeURI(
-                `${constants.PATH_SEPARATOR}${NavigationConstants.DATA}${constants.PATH_SEPARATOR}ds${dataRoots[0].path}`
-            )
-        );
-    }
-
     const onDetailsSelected = () => {
         setDetailsOpen(true);
         const selectedId = selected[0];
@@ -262,21 +206,20 @@ function Listing(props) {
     return (
         <>
             <UploadDropTarget path={path}>
+                <Toolbar variant="dense">
+                    <DataNavigation
+                        path={path}
+                        baseId={baseId}
+                    />
+                </Toolbar>
                 <Header
                     baseId={baseId}
                     isGridView={isGridView}
                     toggleDisplay={toggleDisplay}
-                    path={path}
-                    error={error}
                     onDownloadSelected={onDownloadSelected}
                     onEditSelected={onEditSelected}
                     onMetadataSelected={onMetadataSelected}
                     onDeleteSelected={onDeleteSelected}
-                    dataRoots={dataRoots}
-                    userHomePath={userHomePath}
-                    userTrashPath={userTrashPath}
-                    sharedWithMePath={sharedWithMePath}
-                    communityDataPath={communityDataPath}
                     detailsEnabled={detailsEnabled}
                     onDetailsSelected={onDetailsSelected}
                 />

--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -17,10 +17,7 @@ import UploadDropTarget from "../../uploads/UploadDropTarget";
 import { useUploadTrackingState } from "../../../contexts/uploadTracking";
 import { camelcaseit } from "../../../common/functions";
 import Drawer from "../details/Drawer";
-import {
-    getInfoTypes,
-    getPagedListing,
-} from "../../endpoints/Filesystem";
+import { getInfoTypes, getPagedListing } from "../../endpoints/Filesystem";
 import DataNavigation from "../DataNavigation";
 
 function Listing(props) {
@@ -209,6 +206,7 @@ function Listing(props) {
                 <Toolbar variant="dense">
                     <DataNavigation
                         path={path}
+                        handlePathChange={handlePathChange}
                         baseId={baseId}
                     />
                 </Toolbar>

--- a/src/components/data/messages.js
+++ b/src/components/data/messages.js
@@ -34,7 +34,6 @@ export default {
         write: "Write",
         upload: "Upload",
         uploadQueue: "View Upload Queue",
-        trash: "Trash",
         sharedWithMe: "Shared With Me",
         communityData: "Community Data",
         myData: "My Data",

--- a/src/components/data/utils.js
+++ b/src/components/data/utils.js
@@ -21,6 +21,8 @@ function getEncodedPath(path) {
 /**
  *  Get storage id from router path
  *
+ *  Sample path: /data/ds/iplant/home/ipcdev
+ *
  * @param {string} pathname - path from the router
  * @returns {string|*} storage id
  */
@@ -28,7 +30,14 @@ function getStorageIdFromPath(pathname) {
     if (!pathname) {
         return "";
     }
-    return pathname.split(constants.PATH_SEPARATOR)[2];
+
+    const paths = pathname.split(constants.PATH_SEPARATOR);
+    if (paths.length > 2) {
+        return paths[2];
+    } else {
+        // Default to data store.  Needed if user navigates to just /data.
+        return "ds";
+    }
 }
 
 export { getEncodedPath, getStorageIdFromPath };

--- a/src/components/endpoints/Filesystem.js
+++ b/src/components/endpoints/Filesystem.js
@@ -42,3 +42,41 @@ export const updateInfoType = (path, infoType) => {
         },
     });
 };
+
+/**
+ * Get a paged directory listing
+ * @param path - The resource path
+ * @param rowsPerPage - The number of rows per page
+ * @param orderBy - A column to order items by
+ * @param order - Ascending or Descending
+ * @param page - The page number or offset
+ * @returns {Promise<any>}
+ */
+export const getPagedListing = (path, rowsPerPage, orderBy, order, page) => {
+    return callApi({
+        endpoint: `/api/filesystem/paged-directory?path=${encodeURIComponent(
+            path
+        )}&limit=${rowsPerPage}&sort-col=${orderBy}&sort-dir=${order}&offset=${rowsPerPage *
+        page}`,
+    });
+};
+
+/**
+ * Get the list of directory roots available to a user
+ * @returns {Promise<any>}
+ */
+export const getFilesystemRoots = () => {
+    return callApi({
+        endpoint: `/api/filesystem/root`,
+    });
+};
+
+/**
+ * Get a list of all accepted info types
+ * @returns {Promise<any>}
+ */
+export const getInfoTypes = () => {
+    return callApi({
+        endpoint: `/api/filetypes/type-list`,
+    });
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,5 +5,6 @@ export default {
     CYVERSE_URL: "https://cyverse.org/discovery-environment",
     SHARED_WITH_ME: "Shared With Me",
     COMMUNITY_DATA: "Community Data",
+    TRASH: "Trash",
     PATH_SEPARATOR: "/",
 };


### PR DESCRIPTION
I ended up making a few key changes:
* Move the last couple of queries in the Listing file out into functions in the endpoints folder
* Move DataNavigation out of the Header component and into the Listing component
* Move the data roots query from the Listing component into the DataNavigation component directly
* Update DataNavigation to not use router directly

Eventually I want to add a new component called DataView where everything (Upload, Breadcrumb, Header, Listing, Details Drawer) goes.  Right now, everything is getting added to the Listing component which I feel will bite us later on.

All of these changes should help us to 1) make the entire data view reusable (whether in a dialog or within a split 50/50 page) and 2) get the data view ready for using react-query.