### PR TITLE
Data view dynamic routing fix

### DIFF
--- a/src/components/data/utils.js
+++ b/src/components/data/utils.js
@@ -18,26 +18,4 @@ function getEncodedPath(path) {
     return encodedPath;
 }
 
-/**
- *  Get storage id from router path
- *
- *  Sample path: /data/ds/iplant/home/ipcdev
- *
- * @param {string} pathname - path from the router
- * @returns {string|*} storage id
- */
-function getStorageIdFromPath(pathname) {
-    if (!pathname) {
-        return "";
-    }
-
-    const paths = pathname.split(constants.PATH_SEPARATOR);
-    if (paths.length > 2) {
-        return paths[2];
-    } else {
-        // Default to data store.  Needed if user navigates to just /data.
-        return "ds";
-    }
-}
-
-export { getEncodedPath, getStorageIdFromPath };
+export { getEncodedPath };

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,6 +6,7 @@ export default {
     SHARED_WITH_ME: "Shared With Me",
     COMMUNITY_DATA: "Community Data",
     TRASH: "Trash",
+    DATA_STORE_STORAGE_ID: "ds",
     PATH_SEPARATOR: "/",
     APPS_UNDER_DEV: "Apps under development",
     FAV_APPS: "Favorite Apps",

--- a/src/pages/data/ds/[...pathItems].js
+++ b/src/pages/data/ds/[...pathItems].js
@@ -34,12 +34,16 @@ export default function DataStore() {
 
     let path = "";
     if (pathItems && pathItems.length > 0) {
-        path = constants.PATH_SEPARATOR + pathItems.join(constants.PATH_SEPARATOR);
+        path =
+            constants.PATH_SEPARATOR + pathItems.join(constants.PATH_SEPARATOR);
     }
 
     const handlePathChange = (path) => {
         const encodedPath = getEncodedPath(path);
-        router.push(`${baseRoutingPath}${dynamicPathName}`, `${baseRoutingPath}${encodedPath}`);
+        router.push(
+            `${baseRoutingPath}${dynamicPathName}`,
+            `${baseRoutingPath}${encodedPath}`
+        );
     };
 
     return (

--- a/src/pages/data/ds/[...pathItems].js
+++ b/src/pages/data/ds/[...pathItems].js
@@ -6,7 +6,6 @@
 import React from "react";
 import { useRouter } from "next/router";
 import Listing from "../../../components/data/listing/Listing";
-import constants from "../../../constants";
 import { getEncodedPath } from "../../../components/data/utils";
 
 /**
@@ -26,17 +25,12 @@ const dynamicPathName = "/[...pathItems]";
  */
 export default function DataStore() {
     const router = useRouter();
-    const pathItems = router?.query?.pathItems;
     const routerPathname = router.pathname;
+    const fullPath = router.asPath;
     // Remove the dynamic part of the path if it's there
     // (it won't be there if user navigates directly to /data/ds)
     const baseRoutingPath = routerPathname.replace(dynamicPathName, "");
-
-    let path = "";
-    if (pathItems && pathItems.length > 0) {
-        path =
-            constants.PATH_SEPARATOR + pathItems.join(constants.PATH_SEPARATOR);
-    }
+    const path = fullPath.replace(baseRoutingPath, "");
 
     const handlePathChange = (path) => {
         const encodedPath = getEncodedPath(path);

--- a/src/pages/data/ds/[...pathItems].js
+++ b/src/pages/data/ds/[...pathItems].js
@@ -1,5 +1,5 @@
 /**
- * @author sriram
+ * @author sriram, aramsey
  *
  */
 
@@ -7,23 +7,39 @@ import React from "react";
 import { useRouter } from "next/router";
 import Listing from "../../../components/data/listing/Listing";
 import constants from "../../../constants";
-import { getRoutingPath } from "../index";
+import { getEncodedPath, getStorageIdFromPath } from "../../../components/data/utils";
+import NavigationConstants from "../../../common/NavigationConstants";
+
+/**
+ * compute routing path from selected storage and path
+ *
+ * @param {string} routerPathname - pathname returned by the nextjs router object
+ * @returns {string} - routing path to be used by the nextjs router
+ */
+function getBasePath(routerPathname) {
+    const storageId = getStorageIdFromPath(routerPathname);
+    return `${constants.PATH_SEPARATOR}${NavigationConstants.DATA}${
+        constants.PATH_SEPARATOR
+    }${storageId}`;
+}
 
 /**
  *
- * Handle routing to /data/ds/*
+ * Handle routing to /data/ds/pathInDataStore
  *
  */
 export default function DataStore() {
     const router = useRouter();
     const pathItems = router?.query?.pathItems;
-    let path = constants.PATH_SEPARATOR;
+    let path = "";
     if (pathItems && pathItems.length > 0) {
-        path = path + pathItems.join(constants.PATH_SEPARATOR);
+        path = constants.PATH_SEPARATOR + pathItems.join(constants.PATH_SEPARATOR);
     }
 
     const handlePathChange = (path) => {
-        router.push(getRoutingPath(router.pathname, path));
+        const basePath = getBasePath(router.pathname);
+        const encodedPath = getEncodedPath(path);
+        router.push(`${basePath}/[...pathItems]`, `${basePath}${encodedPath}`);
     };
 
     return (

--- a/src/pages/data/ds/[...pathItems].js
+++ b/src/pages/data/ds/[...pathItems].js
@@ -7,21 +7,17 @@ import React from "react";
 import { useRouter } from "next/router";
 import Listing from "../../../components/data/listing/Listing";
 import constants from "../../../constants";
-import { getEncodedPath, getStorageIdFromPath } from "../../../components/data/utils";
-import NavigationConstants from "../../../common/NavigationConstants";
+import { getEncodedPath } from "../../../components/data/utils";
 
 /**
- * compute routing path from selected storage and path
+ * This variable value needs to match the name of this file for the routing to work
+ * properly without doing a hard refresh.
  *
- * @param {string} routerPathname - pathname returned by the nextjs router object
- * @returns {string} - routing path to be used by the nextjs router
+ * See https://nextjs.org/docs/api-reference/next/router#usage and
+ * https://nextjs.org/docs/api-reference/next/link#dynamic-routes
+ * @type {string}
  */
-function getBasePath(routerPathname) {
-    const storageId = getStorageIdFromPath(routerPathname);
-    return `${constants.PATH_SEPARATOR}${NavigationConstants.DATA}${
-        constants.PATH_SEPARATOR
-    }${storageId}`;
-}
+const dynamicPathName = "/[...pathItems]";
 
 /**
  *
@@ -31,15 +27,19 @@ function getBasePath(routerPathname) {
 export default function DataStore() {
     const router = useRouter();
     const pathItems = router?.query?.pathItems;
+    const routerPathname = router.pathname;
+    // Remove the dynamic part of the path if it's there
+    // (it won't be there if user navigates directly to /data/ds)
+    const baseRoutingPath = routerPathname.replace(dynamicPathName, "");
+
     let path = "";
     if (pathItems && pathItems.length > 0) {
         path = constants.PATH_SEPARATOR + pathItems.join(constants.PATH_SEPARATOR);
     }
 
     const handlePathChange = (path) => {
-        const basePath = getBasePath(router.pathname);
         const encodedPath = getEncodedPath(path);
-        router.push(`${basePath}/[...pathItems]`, `${basePath}${encodedPath}`);
+        router.push(`${baseRoutingPath}${dynamicPathName}`, `${baseRoutingPath}${encodedPath}`);
     };
 
     return (

--- a/src/pages/data/ds/index.js
+++ b/src/pages/data/ds/index.js
@@ -12,7 +12,5 @@ import DataStore from "./[...pathItems]";
  * Go directly to the dynamic path
  */
 export default function Data() {
-    return (
-        <DataStore/>
-    );
+    return <DataStore />;
 }

--- a/src/pages/data/ds/index.js
+++ b/src/pages/data/ds/index.js
@@ -9,6 +9,7 @@ import DataStore from "./[...pathItems]";
  *
  * Handle default routing to /data/ds
  *
+ * Go directly to the dynamic path
  */
 export default function Data() {
     return (

--- a/src/pages/data/ds/index.js
+++ b/src/pages/data/ds/index.js
@@ -1,11 +1,9 @@
 /**
  *
- * @author sriram
+ * @author sriram, aramsey
  */
 import React from "react";
-import { useRouter } from "next/router";
-import Listing from "../../../components/data/listing/Listing";
-import { getRoutingPath } from "../index";
+import DataStore from "./[...pathItems]";
 
 /**
  *
@@ -13,11 +11,7 @@ import { getRoutingPath } from "../index";
  *
  */
 export default function Data() {
-    const router = useRouter();
-    const handlePathChange = (path) => {
-        router.push(getRoutingPath(router.pathname, path));
-    };
     return (
-        <Listing path="" handlePathChange={handlePathChange} baseId="data" />
+        <DataStore/>
     );
 }

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -15,10 +15,8 @@ export default function Data() {
     const router = useRouter();
 
     useEffect(() => {
-        router.push(`${router.pathname}/ds`)
-    }, [router])
+        router.push(`${router.pathname}/ds`);
+    }, [router]);
 
-    return (
-        <Fragment/>
-    );
+    return <Fragment />;
 }

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -5,6 +5,8 @@
 import React, { Fragment, useEffect } from "react";
 import { useRouter } from "next/router";
 
+import constants from "../../constants";
+
 /**
  *
  * Handle default routing to /data
@@ -15,7 +17,9 @@ export default function Data() {
     const router = useRouter();
 
     useEffect(() => {
-        router.push(`${router.pathname}/ds`);
+        router.push(
+            `${router.pathname}${constants.PATH_SEPARATOR}${constants.DATA_STORE_STORAGE_ID}`
+        );
     }, [router]);
 
     return <Fragment />;

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -2,16 +2,23 @@
  *
  * @author sriram, aramsey
  */
-import React from "react";
-import DataStore from "./ds/[...pathItems]";
+import React, { Fragment, useEffect } from "react";
+import { useRouter } from "next/router";
 
 /**
  *
  * Handle default routing to /data
  *
+ * By default, redirect to the base path for the data store
  */
 export default function Data() {
+    const router = useRouter();
+
+    useEffect(() => {
+        router.push(`${router.pathname}/ds`)
+    }, [router])
+
     return (
-        <DataStore/>
+        <Fragment/>
     );
 }

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -1,30 +1,9 @@
 /**
  *
- * @author sriram
+ * @author sriram, aramsey
  */
 import React from "react";
-import { useRouter } from "next/router";
-import Listing from "../../components/data/listing/Listing";
-import NavigationConstants from "../../common/NavigationConstants";
-import constants from "../../constants";
-import {
-    getEncodedPath,
-    getStorageIdFromPath,
-} from "../../components/data/utils";
-
-/**
- * compute routing path from selected storage and path
- *
- * @param {string} routerPathname - pathname returned by the nextjs router object
- * @param {string} selectedPath - user selected path
- * @returns {string} - routing path to be used by the nextjs router
- */
-function getRoutingPath(routerPathname, selectedPath) {
-    const storageId = getStorageIdFromPath(routerPathname);
-    return `${constants.PATH_SEPARATOR}${NavigationConstants.DATA}${
-        constants.PATH_SEPARATOR
-    }${storageId}${getEncodedPath(selectedPath)}`;
-}
+import DataStore from "./ds/[...pathItems]";
 
 /**
  *
@@ -32,14 +11,7 @@ function getRoutingPath(routerPathname, selectedPath) {
  *
  */
 export default function Data() {
-    const router = useRouter();
-    const handlePathChange = (path) => {
-        router.push(getRoutingPath(router.pathname, path));
-    };
-
     return (
-        <Listing path="" handlePathChange={handlePathChange} baseId="data" />
+        <DataStore/>
     );
 }
-
-export { getRoutingPath };


### PR DESCRIPTION
I did two things in this PR:
* The first commit has the least amount of changes needed to get the dynamic routing to work.  The main thing was specifying both the dynamic URL or `href` and also the `as` similar to [here](https://nextjs.org/docs/api-reference/next/link#dynamic-routes) but for `next/router` instead of `next/link`. I also simplified things so that we don't have to maintain roughly the same logic in 3 different files (`index`, `/ds/index/`, and `/ds/[...pathItems]`)
* The second commit, after understanding how the routing works a little better, I simplified the logic for figuring out the entire URL path (as in `/data/ds/pathToFile`).  Instead of having logic to figure out the storage ID and then build the full URL, we're making sure no matter how the user gets to the listing, that the pathing in nextjs is complete and just using that.