### PR TITLE
Migrate data navigation roots to context

### DIFF
--- a/src/contexts/dataRoots.js
+++ b/src/contexts/dataRoots.js
@@ -1,0 +1,30 @@
+/**
+ * @author aramsey
+ *
+ * A context specifically for setting and caching the user's data store filesystem roots (such as their
+ * home directory, trash path, etc.)
+ */
+import React, { createContext, useContext } from "react";
+
+const DataRootsContext = createContext();
+
+function useDataRoots() {
+    const context = useContext(DataRootsContext);
+    if (!context) {
+        throw new Error(`useDataRoots must be used within a DataRootsProvider`);
+    }
+    return context;
+}
+
+function DataRootsProvider(props) {
+    const [roots, setRoots] = React.useState({});
+    const value = React.useMemo(() => [roots, setRoots], [roots]);
+
+    return (
+        <DataRootsContext.Provider value={value}>
+            {props.children}
+        </DataRootsContext.Provider>
+    );
+}
+
+export { DataRootsProvider, useDataRoots };

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -23,6 +23,7 @@ import { UploadTrackingProvider } from "../contexts/uploadTracking";
 import { UserProfileProvider } from "../contexts/userProfile";
 import { IntercomProvider } from "../contexts/intercom";
 import constants from "../constants";
+import { DataRootsProvider } from "../contexts/dataRoots";
 
 const setupIntercom = (intercomAppId) => {
     window.intercomSettings = {
@@ -115,16 +116,19 @@ function MyApp({
                     <UploadTrackingProvider>
                         <ReactQueryConfigProvider config={queryConfig}>
                             <CssBaseline />
-                            <CyverseAppBar>
-                                <Head>
-                                    <title>Discovery Environment</title>
-                                </Head>
-                                <ReactQueryDevtools initialIsOpen={false} />
-                                <Navigation activeView={pathname} />
-                                <PageSpacer />
-                                <Component {...pageProps} />
-                                <UploadManager />
-                            </CyverseAppBar>
+                            <DataRootsProvider>
+                                <CyverseAppBar>
+                                    <Head>
+                                        <title>Discovery Environment</title>
+                                    </Head>
+                                    <ReactQueryDevtools initialIsOpen={false} />
+                                    <Navigation activeView={pathname} />
+                                    <PageSpacer />
+
+                                    <Component {...pageProps} />
+                                    <UploadManager />
+                                </CyverseAppBar>
+                            </DataRootsProvider>
                         </ReactQueryConfigProvider>
                     </UploadTrackingProvider>
                 </UserProfileProvider>


### PR DESCRIPTION
This will allow the data roots query to be cached and prevent the DataNavigation component from rendering and not rendering between page changes between /data, /data/ds, and /data/ds/[...pathItems].