### PR TITLE
Switch to using build-time environment variables

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 const config = require("config");
 
 module.exports = {
-    serverRuntimeConfig: {
+    env: {
         INTERCOM_APP_ID: config.get("intercom.app_id"),
         INTERCOM_ENABLED: config.get("intercom.enabled"),
         INTERCOM_COMPANY_ID: config.get("intercom.company_id"),

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 
-import getConfig from "next/config";
 import Head from "next/head";
 import { useRouter } from "next/router";
 
@@ -63,23 +62,16 @@ const setupIntercom = (intercomAppId) => {
     }
 };
 
-function MyApp({
-    Component,
-    pageProps,
-    intercomAppId,
-    intercomEnabled,
-    companyId,
-    companyName,
-}) {
+function MyApp({ Component, pageProps }) {
     const router = useRouter();
     const pathname = router.pathname
         ? router.pathname.split(constants.PATH_SEPARATOR)[1]
         : NavigationConstants.DASHBOARD;
     const [intercomSettings, setIntercomSettings] = useState({
-        appId: intercomAppId,
-        enabled: intercomEnabled,
-        companyId: companyId,
-        companyName: companyName,
+        appId: process.env.INTERCOM_APP_ID,
+        enabled: process.env.INTERCOM_ENABLED,
+        companyId: process.env.INTERCOM_COMPANY_ID,
+        companyName: process.env.INTERCOM_COMPANY_NAME,
         unReadCount: 0,
     });
 
@@ -132,15 +124,5 @@ function MyApp({
         </ThemeProvider>
     );
 }
-
-MyApp.getInitialProps = async (ctx) => {
-    const { serverRuntimeConfig } = getConfig();
-    return {
-        intercomAppId: serverRuntimeConfig.INTERCOM_APP_ID,
-        intercomEnabled: serverRuntimeConfig.INTERCOM_ENABLED,
-        companyId: serverRuntimeConfig.INTERCOM_COMPANY_ID,
-        companyName: serverRuntimeConfig.INTERCOM_COMPANY_NAME,
-    };
-};
 
 export default MyApp;


### PR DESCRIPTION
The only issue with using `serverRuntimeConfig` in our next.config.js file, is that you have to use `getInitialProps` in order to have the client side of your application get access to those variables.  The hidden issue there is `getInitialProps` cannot be used in child components (see https://nextjs.org/docs/api-reference/data-fetching/getInitialProps#caveats). Our application is using a custom app (`_app`) in order to utilize a persistent layout between pages, so every page is actually a child component of `_app`.
nextjs currently recommends using build-time environment variables over runtime configuration as well (see https://nextjs.org/docs/api-reference/next.config.js/runtime-configuration)