### PR TITLE
Add @next/bundle-analyzer in a non-ad-hoc way

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,14 @@
 const config = require("config");
 
-module.exports = {
+const withBundleAnalyzer = require("@next/bundle-analyzer")({
+    enabled: process.env.ANALYZE === "true",
+});
+
+module.exports = withBundleAnalyzer({
     env: {
         INTERCOM_APP_ID: config.get("intercom.app_id"),
         INTERCOM_ENABLED: config.get("intercom.enabled"),
         INTERCOM_COMPANY_ID: config.get("intercom.company_id"),
         INTERCOM_COMPANY_NAME: config.get("intercom.company_name"),
     },
-};
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1959,6 +1959,14 @@
                 "glob-to-regexp": "^0.3.0"
             }
         },
+        "@next/bundle-analyzer": {
+            "version": "9.4.0",
+            "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-9.4.0.tgz",
+            "integrity": "sha512-0BbWf08re/EDnxkbYLLBAiZYGtRN2HMtZb1/aMppBgJqFxJRHXPRZ8CltW1Og+ZYBx3+cgcx52BeVUzDtSnmsQ==",
+            "requires": {
+                "webpack-bundle-analyzer": "3.6.1"
+            }
+        },
         "@next/react-dev-overlay": {
             "version": "9.4.0",
             "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-9.4.0.tgz",
@@ -6272,6 +6280,17 @@
                 "tweetnacl": "^0.14.3"
             }
         },
+        "bfj": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.2.tgz",
+            "integrity": "sha512-BmBJa4Lip6BPRINSZ0BPEIfB1wUY/9rwbwvIHQA1KjX9om29B6id0wnWXq7m3bn5JrUVjeOTnVuhPT1FiHwPGw==",
+            "requires": {
+                "bluebird": "^3.5.5",
+                "check-types": "^8.0.3",
+                "hoopy": "^0.1.4",
+                "tryer": "^1.0.1"
+            }
+        },
         "big.js": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -6892,6 +6911,11 @@
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
             "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+        },
+        "check-types": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/check-types/-/check-types-8.0.3.tgz",
+            "integrity": "sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ=="
         },
         "chokidar": {
             "version": "3.4.0",
@@ -8760,8 +8784,7 @@
         "ejs": {
             "version": "2.7.4",
             "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-            "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
-            "dev": true
+            "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
         },
         "electron-to-chromium": {
             "version": "1.3.435",
@@ -10915,6 +10938,11 @@
             "requires": {
                 "parse-passwd": "^1.0.0"
             }
+        },
+        "hoopy": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
+            "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ=="
         },
         "hosted-git-info": {
             "version": "2.8.8",
@@ -15498,6 +15526,11 @@
             "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
             "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
             "dev": true
+        },
+        "opener": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
+            "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA=="
         },
         "opn": {
             "version": "5.5.0",
@@ -20749,6 +20782,11 @@
             "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
             "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
         },
+        "tryer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
+            "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
+        },
         "ts-dedent": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-1.1.1.tgz",
@@ -21591,6 +21629,46 @@
                         "terser": "^4.1.2",
                         "webpack-sources": "^1.4.0",
                         "worker-farm": "^1.7.0"
+                    }
+                }
+            }
+        },
+        "webpack-bundle-analyzer": {
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.6.1.tgz",
+            "integrity": "sha512-Nfd8HDwfSx1xBwC+P8QMGvHAOITxNBSvu/J/mCJvOwv+G4VWkU7zir9SSenTtyCi0LnVtmsc7G5SZo1uV+bxRw==",
+            "requires": {
+                "acorn": "^7.1.1",
+                "acorn-walk": "^7.1.1",
+                "bfj": "^6.1.1",
+                "chalk": "^2.4.1",
+                "commander": "^2.18.0",
+                "ejs": "^2.6.1",
+                "express": "^4.16.3",
+                "filesize": "^3.6.1",
+                "gzip-size": "^5.0.0",
+                "lodash": "^4.17.15",
+                "mkdirp": "^0.5.1",
+                "opener": "^1.5.1",
+                "ws": "^6.0.0"
+            },
+            "dependencies": {
+                "acorn-walk": {
+                    "version": "7.1.1",
+                    "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
+                    "integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ=="
+                },
+                "filesize": {
+                    "version": "3.6.1",
+                    "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
+                    "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg=="
+                },
+                "ws": {
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+                    "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+                    "requires": {
+                        "async-limiter": "~1.0.0"
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "@material-ui/core": "^4.9.13",
         "@material-ui/icons": "^4.9.1",
         "@material-ui/lab": "^4.0.0-alpha.52",
+        "@next/bundle-analyzer": "^9.4.0",
         "amqplib": "^0.5.5",
         "axios": "^0.19.2",
         "bowser": "^2.9.0",


### PR DESCRIPTION
A small thing, but still probably nice to have outside my local copy. Means that if you run a next build with `ANALYZE=true` as an environment variable, you'll get an analysis of the webpack bundles (server & client both, though client is the more important one for us usually).