### PR TITLE
Chromatic delay

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,9 +1,10 @@
 import React, { useEffect } from "react";
 import { withConsole } from "@storybook/addon-console";
-import { addDecorator, configure } from "@storybook/react";
+import { addDecorator, addParameters, configure } from "@storybook/react";
 import { CyVerseAnnouncer } from "@cyverse-de/ui-lib";
 import { ThemeProvider } from "@material-ui/core/styles";
 import theme from "../src/components/theme/default";
+import { AXIOS_DELAY } from "../stories/axiosMock";
 import {
     UserProfileProvider,
     useUserProfile,
@@ -48,5 +49,7 @@ addDecorator((storyFn) => (
 
 //redirect console error / logs / warns to action logger
 addDecorator((storyFn, context) => withConsole()(storyFn)(context));
+
+addParameters({ chromatic: { delay: AXIOS_DELAY + 500 } });
 
 configure(require.context("../stories", true, /\.stories\.js$/), module);

--- a/stories/apps/Listing.stories.js
+++ b/stories/apps/Listing.stories.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { mockAxios } from "../axiosMock";
+import { AXIOS_DELAY, mockAxios } from "../axiosMock";
 import { appDetails, appListing, categories } from "./AppMocks";
 import { UploadTrackingProvider } from "../../src/contexts/uploadTracking";
 import Listing from "../../src/components/apps/listing/Listing";
@@ -29,4 +29,10 @@ function ListingTest(props) {
 
 export const AppsListingTest = () => {
     return <ListingTest />;
+};
+
+AppsListingTest.story = {
+    parameters: {
+        chromatic: { delay: AXIOS_DELAY * 2 + 500 },
+    },
 };

--- a/stories/axiosMock.js
+++ b/stories/axiosMock.js
@@ -6,5 +6,8 @@
  */
 import axiosInstance from "../src/common/getAxios";
 import MockAdapter from "axios-mock-adapter";
-const mockAxios = new MockAdapter(axiosInstance, { delayResponse: 2000 });
-export { mockAxios };
+const AXIOS_DELAY = 2000;
+const mockAxios = new MockAdapter(axiosInstance, {
+    delayResponse: AXIOS_DELAY,
+});
+export { AXIOS_DELAY, mockAxios };

--- a/stories/data/DataNavigation.stories.js
+++ b/stories/data/DataNavigation.stories.js
@@ -10,6 +10,7 @@ export const DataNavigationTest = () => {
             path="/iplant/home/ipcdev/analyses/foo/barborkborkborkbarborkborkbork"
             baseId="navigation"
             handlePathChange={console.log}
+            handleDataNavError={console.log}
         />
     );
 };

--- a/stories/data/Header.stories.js
+++ b/stories/data/Header.stories.js
@@ -16,6 +16,8 @@ export const HeaderTest = () => {
                 onEditSelected={() => logger("Edit")}
                 onMetadataSelected={() => logger("Metadata")}
                 onDeleteSelected={() => logger("Delete")}
+                handleDataNavError={console.log}
+                handlePathChange={console.log}
             />
         </UploadTrackingProvider>
     );


### PR DESCRIPTION
Most of our snapshots in Chromatic are of loading skeletons.  This should wait until the fake axios calls have completed their delay (2 seconds) and then I added another half a second just to account for any animations/transitions (like fade in or slide in or whatever else used by MUI).  Hopefully with the wait in place, we'll stop seeing those really minor differences in components that didn't actually change as well.

Also I fixed some storybook errors about missing props.

[Chromatic Build](https://www.chromatic.com/build?appId=5ebad5c6b991d60022b1e72e&number=21)