### PR TITLE
Dashboard Updates

### DIFF
--- a/src/components/dashboard/constants.js
+++ b/src/components/dashboard/constants.js
@@ -23,3 +23,5 @@ export const USER_SUFFIX = "@iplantcollaborative.org";
 export const CYVERSE = "CyVerse";
 export const DESC_MAX_LENGTH = 140;
 export const TITLE_MAX_LENGTH = 31;
+export const TITLE_MAX_LENGTH_SMALL = 25;
+export const SUBHEADER_MAX_LENGTH_SMALL = 39;

--- a/src/components/dashboard/constants.js
+++ b/src/components/dashboard/constants.js
@@ -6,6 +6,8 @@
  * @module dashboard/constants
  */
 
+import meta from "../../constants";
+
 export const KIND_ANALYSES = "analyses";
 export const KIND_APPS = "apps";
 export const KIND_FEEDS = "feeds";
@@ -19,7 +21,7 @@ export const SECTION_NEWS = "news";
 export const SECTION_EVENTS = "events";
 export const SECTION_ITEM_LIMIT = 8;
 
-export const USER_SUFFIX = "@iplantcollaborative.org";
+export const USER_SUFFIX = `@${meta.IPLANT}.org`;
 export const CYVERSE = "CyVerse";
 export const DESC_MAX_LENGTH = 140;
 export const TITLE_MAX_LENGTH = 31;

--- a/src/components/dashboard/constants.js
+++ b/src/components/dashboard/constants.js
@@ -9,6 +9,7 @@
 export const KIND_ANALYSES = "analyses";
 export const KIND_APPS = "apps";
 export const KIND_FEEDS = "feeds";
+export const KIND_EVENTS = "events";
 
 export const SECTION_RECENT = "recent";
 export const SECTION_RUNNING = "running";
@@ -21,4 +22,4 @@ export const SECTION_ITEM_LIMIT = 8;
 export const USER_SUFFIX = "@iplantcollaborative.org";
 export const CYVERSE = "CyVerse";
 export const DESC_MAX_LENGTH = 140;
-export const TITLE_MAX_LENGTH = 36;
+export const TITLE_MAX_LENGTH = 31;

--- a/src/components/dashboard/constants.js
+++ b/src/components/dashboard/constants.js
@@ -21,3 +21,4 @@ export const SECTION_ITEM_LIMIT = 8;
 export const USER_SUFFIX = "@iplantcollaborative.org";
 export const CYVERSE = "CyVerse";
 export const DESC_MAX_LENGTH = 140;
+export const TITLE_MAX_LENGTH = 36;

--- a/src/components/dashboard/index.js
+++ b/src/components/dashboard/index.js
@@ -424,7 +424,7 @@ export const DashboardItem = (props) => {
                 }}
             >
                 <Typography color="textSecondary" variant="body2" component="p">
-                    {description}
+                    {description || getMessage("noDescriptionProvided")}
                 </Typography>
             </CardContent>
 

--- a/src/components/dashboard/index.js
+++ b/src/components/dashboard/index.js
@@ -17,7 +17,10 @@ import {
     CardHeader,
     Divider,
     Typography,
+    Avatar,
 } from "@material-ui/core";
+
+import { Apps, BarChart, Event, RssFeed } from "@material-ui/icons";
 
 import { Skeleton } from "@material-ui/lab";
 
@@ -106,6 +109,17 @@ const useStyles = makeStyles((theme) => ({
     actionsRoot: {
         marginLeft: "auto",
     },
+    avatar: {
+        background: theme.palette.white,
+        color: theme.palette.gray,
+    },
+    cardHeaderRoot: {
+        background: theme.palette.primary.main,
+        marginBottom: theme.spacing(2),
+    },
+    cardHeaderText: {
+        color: theme.palette.primary.contrastText,
+    },
 }));
 
 const getOrigination = (kind, content) => {
@@ -137,6 +151,27 @@ const getOrigination = (kind, content) => {
         origination,
         formatDate(date ? new Date(date).valueOf() : new Date().valueOf()),
     ];
+};
+
+const getIcon = (kind, section) => {
+    let retval;
+    switch (kind) {
+        case constants.KIND_ANALYSES:
+            retval = <BarChart />;
+            break;
+        case constants.KIND_APPS:
+            retval = <Apps />;
+            break;
+        case constants.KIND_FEEDS:
+            retval = <RssFeed />;
+            break;
+        case constants.KIND_EVENTS:
+            retval = <Event />;
+            break;
+        default:
+            retval = <Apps />;
+    }
+    return retval;
 };
 
 const cleanUsername = (username) => {
@@ -197,17 +232,23 @@ export const DashboardItem = (props) => {
             elevation={4}
         >
             <CardHeader
-                title={
-                    <Typography noWrap variant="h6">
-                        {cleanTitle(content.name)}
-                    </Typography>
+                avatar={
+                    <Avatar className={classes.avatar}>{getIcon(kind)}</Avatar>
                 }
+                classes={{ root: classes.cardHeaderRoot }}
+                title={cleanTitle(content.name)}
+                titleTypographyProps={{
+                    noWrap: true,
+                    variant: "h6",
+                    color: "primary",
+                    classes: { colorPrimary: classes.cardHeaderText },
+                }}
                 subheader={
                     <Typography
-                        // classes={{ root: classes.subtitle }}
                         noWrap
                         color="textSecondary"
                         variant="subtitle2"
+                        classes={{ colorTextSecondary: classes.cardHeaderText }}
                     >
                         {origination} {`${user} on ${date}`}
                     </Typography>
@@ -338,7 +379,7 @@ const Dashboard = () => {
             makeID(ids.SECTION_NEWS),
         ],
         [
-            constants.KIND_FEEDS,
+            constants.KIND_EVENTS,
             constants.SECTION_EVENTS,
             getMessage("eventsFeed"),
             makeID(ids.SECTION_EVENTS),

--- a/src/components/dashboard/index.js
+++ b/src/components/dashboard/index.js
@@ -6,6 +6,7 @@
  * @module dashboard
  */
 import React from "react";
+import clsx from "clsx";
 import { useQuery } from "react-query";
 
 import { makeStyles } from "@material-ui/styles";
@@ -20,7 +21,14 @@ import {
     Avatar,
 } from "@material-ui/core";
 
-import { Apps, BarChart, Event, RssFeed } from "@material-ui/icons";
+import {
+    Apps,
+    BarChart,
+    Event,
+    RssFeed,
+    OpenInNew,
+    OpenInBrowser,
+} from "@material-ui/icons";
 
 import { Skeleton } from "@material-ui/lab";
 
@@ -113,9 +121,42 @@ const useStyles = makeStyles((theme) => ({
         background: theme.palette.white,
         color: theme.palette.gray,
     },
-    cardHeaderRoot: {
+    cardHeaderDefault: {
         background: theme.palette.primary.main,
         marginBottom: theme.spacing(2),
+    },
+    cardHeaderDefaultAvatar: {
+        color: theme.palette.primary.main,
+    },
+    cardHeaderEvents: {
+        background: theme.palette.violet,
+    },
+    cardHeaderEventsAvatar: {
+        color: theme.palette.violet,
+    },
+    cardHeaderNews: {
+        background: theme.palette.indigo,
+    },
+    cardHeaderNewsAvatar: {
+        color: theme.palette.indigo,
+    },
+    cardHeaderPublic: {
+        background: theme.palette.darkNavy,
+    },
+    cardHeaderPublicAvatar: {
+        color: theme.palette.darkNavy,
+    },
+    cardHeaderRecent: {
+        background: theme.palette.navy,
+    },
+    cardHeaderRecentAvatar: {
+        color: theme.palette.navy,
+    },
+    cardHeaderRecentlyAdded: {
+        background: theme.palette.gold,
+    },
+    cardHeaderRecentlyAddedAvatar: {
+        color: theme.palette.gold,
     },
     cardHeaderText: {
         color: theme.palette.primary.contrastText,
@@ -153,23 +194,92 @@ const getOrigination = (kind, content) => {
     ];
 };
 
-const getIcon = (kind, section) => {
+const getAvatarIcon = (kind, colorClass) => {
     let retval;
     switch (kind) {
         case constants.KIND_ANALYSES:
-            retval = <BarChart />;
+            retval = (
+                <BarChart
+                    color="primary"
+                    classes={{ colorPrimary: colorClass }}
+                />
+            );
             break;
         case constants.KIND_APPS:
-            retval = <Apps />;
+            retval = (
+                <Apps color="primary" classes={{ colorPrimary: colorClass }} />
+            );
             break;
         case constants.KIND_FEEDS:
-            retval = <RssFeed />;
+            retval = (
+                <RssFeed
+                    color="primary"
+                    classes={{ colorPrimary: colorClass }}
+                />
+            );
             break;
         case constants.KIND_EVENTS:
-            retval = <Event />;
+            retval = (
+                <Event color="primary" classes={{ colorPrimary: colorClass }} />
+            );
             break;
         default:
-            retval = <Apps />;
+            retval = (
+                <Apps color="primary" classes={{ colorPrimary: colorClass }} />
+            );
+    }
+    return retval;
+};
+
+const getSectionClass = (section, classes) => {
+    let header;
+    let avatar;
+    switch (section) {
+        case constants.SECTION_EVENTS:
+            header = classes.cardHeaderEvents;
+            avatar = classes.cardHeaderEventsAvatar;
+            break;
+        case constants.SECTION_NEWS:
+            header = classes.cardHeaderNews;
+            avatar = classes.cardHeaderNewsAvatar;
+            break;
+        case constants.SECTION_PUBLIC:
+            header = classes.cardHeaderPublic;
+            avatar = classes.cardHeaderPublicAvatar;
+            break;
+        case constants.SECTION_RECENT:
+            header = classes.cardHeaderRecent;
+            avatar = classes.cardHeaderRecentAvatar;
+            break;
+        case constants.SECTION_RECENTLY_ADDED:
+            header = classes.cardHeaderRecentlyAdded;
+            avatar = classes.cardHeaderRecentlyAddedAvatar;
+            break;
+        default:
+            header = classes.cardHeaderDefault;
+            avatar = classes.cardHeaderDefaultAvatar;
+            break;
+    }
+    return [header, avatar];
+};
+
+const getLinkIcon = (kind) => {
+    let retval;
+    switch (kind) {
+        case constants.KIND_ANALYSES:
+            retval = <OpenInBrowser />;
+            break;
+        case constants.KIND_APPS:
+            retval = <OpenInBrowser />;
+            break;
+        case constants.KIND_FEEDS:
+            retval = <OpenInNew />;
+            break;
+        case constants.KIND_EVENTS:
+            retval = <OpenInNew />;
+            break;
+        default:
+            retval = <OpenInNew />;
     }
     return retval;
 };
@@ -218,12 +328,14 @@ const cleanTitle = (title) => {
  */
 export const DashboardItem = (props) => {
     const classes = useStyles();
-    const { kind, content } = props;
+    const { kind, content, section } = props;
     const cardID = buildID(kind, content.id);
 
     const description = cleanDescription(content.description);
     const [origination, date] = getOrigination(kind, content);
     const user = cleanUsername(content.username);
+    const [headerClass, avatarClass] = getSectionClass(section, classes);
+    const rootClass = clsx(classes.cardHeaderDefault, headerClass);
 
     return (
         <Card
@@ -233,9 +345,11 @@ export const DashboardItem = (props) => {
         >
             <CardHeader
                 avatar={
-                    <Avatar className={classes.avatar}>{getIcon(kind)}</Avatar>
+                    <Avatar className={classes.avatar}>
+                        {getAvatarIcon(kind, avatarClass)}
+                    </Avatar>
                 }
-                classes={{ root: classes.cardHeaderRoot }}
+                classes={{ root: rootClass }}
                 title={cleanTitle(content.name)}
                 titleTypographyProps={{
                     noWrap: true,
@@ -274,6 +388,10 @@ export const DashboardItem = (props) => {
                     target="_blank"
                     rel="noopener noreferrer"
                     color="primary"
+                    size="small"
+                    startIcon={getLinkIcon(kind)}
+                    variant="contained"
+                    classes={{ containedPrimary: headerClass }}
                 >
                     {getMessage("open")}
                 </Button>
@@ -282,7 +400,7 @@ export const DashboardItem = (props) => {
     );
 };
 
-const DashboardSection = ({ name, kind, items, id }) => {
+const DashboardSection = ({ name, kind, items, id, section }) => {
     const classes = useStyles();
 
     return (
@@ -301,7 +419,12 @@ const DashboardSection = ({ name, kind, items, id }) => {
 
             <div className={classes.sectionItems}>
                 {items.map((item) => (
-                    <DashboardItem kind={kind} content={item} key={item.id} />
+                    <DashboardItem
+                        kind={kind}
+                        content={item}
+                        key={item.id}
+                        section={section}
+                    />
                 ))}
             </div>
         </div>
@@ -409,6 +532,7 @@ const Dashboard = () => {
                                 key={`${kind}-${section}`}
                                 items={data[kind][section]}
                                 name={label}
+                                section={section}
                             />
                         );
                     })

--- a/src/components/dashboard/index.js
+++ b/src/components/dashboard/index.js
@@ -325,10 +325,10 @@ const cleanUsername = (username) => {
     return user;
 };
 
-const cleanField = (field, comparitor) => {
+const cleanField = (field, comparator) => {
     let retval;
-    if (field.length > comparitor) {
-        retval = field.slice(0, comparitor) + "...";
+    if (field.length > comparator) {
+        retval = field.slice(0, comparator) + "...";
     } else {
         retval = field;
     }
@@ -339,15 +339,15 @@ const cleanDescription = (description) =>
     cleanField(description, constants.DESC_MAX_LENGTH);
 
 const cleanTitle = (title, isLarge = true) => {
-    let comparitor;
+    let comparator;
 
     if (isLarge) {
-        comparitor = constants.TITLE_MAX_LENGTH;
+        comparator = constants.TITLE_MAX_LENGTH;
     } else {
-        comparitor = constants.TITLE_MAX_LENGTH_SMALL;
+        comparator = constants.TITLE_MAX_LENGTH_SMALL;
     }
 
-    return cleanField(title, comparitor);
+    return cleanField(title, comparator);
 };
 
 const cleanSubheader = (subheader, isLarge = true) => {

--- a/src/components/dashboard/index.js
+++ b/src/components/dashboard/index.js
@@ -6,6 +6,7 @@
  * @module dashboard
  */
 import React from "react";
+import { useRouter } from "next/router";
 import clsx from "clsx";
 import { useQuery } from "react-query";
 
@@ -284,6 +285,21 @@ const getLinkIcon = (kind) => {
     return retval;
 };
 
+const getLinkTarget = (kind, content) => {
+    let target;
+    switch (kind) {
+        case constants.KIND_APPS:
+            target = `/apps/${content.id}/details`;
+            break;
+        case constants.KIND_ANALYSES:
+            target = `/analyses/${content.id}/details`;
+            break;
+        default:
+            target = content.link;
+    }
+    return target;
+};
+
 const cleanUsername = (username) => {
     let user;
     if (username) {
@@ -316,6 +332,40 @@ const cleanTitle = (title) => {
         retval = title;
     }
     return retval;
+};
+
+const DashboardLink = ({ kind, content, headerClass }) => {
+    const router = useRouter();
+    const isNewTab =
+        kind === constants.KIND_EVENTS || kind === constants.KIND_FEEDS;
+    const target = getLinkTarget(kind, content);
+    const icon = getLinkIcon(kind);
+
+    return isNewTab ? (
+        <Button
+            href={target}
+            target="_blank"
+            rel="noopener noreferrer"
+            color="primary"
+            size="small"
+            startIcon={icon}
+            variant="contained"
+            classes={{ containedPrimary: headerClass }}
+        >
+            {getMessage("open")}
+        </Button>
+    ) : (
+        <Button
+            color="primary"
+            size="small"
+            startIcon={icon}
+            variant="contained"
+            classes={{ containedPrimary: headerClass }}
+            onClick={(_) => router.push(target)}
+        >
+            {getMessage("open")}
+        </Button>
+    );
 };
 
 /**
@@ -383,18 +433,11 @@ export const DashboardItem = (props) => {
                     root: classes.actionsRoot,
                 }}
             >
-                <Button
-                    href={content.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    color="primary"
-                    size="small"
-                    startIcon={getLinkIcon(kind)}
-                    variant="contained"
-                    classes={{ containedPrimary: headerClass }}
-                >
-                    {getMessage("open")}
-                </Button>
+                <DashboardLink
+                    kind={kind}
+                    content={content}
+                    headerClass={headerClass}
+                />
             </CardActions>
         </Card>
     );

--- a/src/components/dashboard/index.js
+++ b/src/components/dashboard/index.js
@@ -585,36 +585,44 @@ const Dashboard = ({ intl }) => {
         ],
     ];
 
+    const filteredSections = data
+        ? sections
+              .filter(
+                  ([kind, section, _label]) =>
+                      data.hasOwnProperty(kind) &&
+                      data[kind].hasOwnProperty(section)
+              )
+              .filter(
+                  ([kind, section, _label]) => data[kind][section].length > 0
+              )
+              .map(([kind, section, label, sectionID]) => {
+                  return (
+                      <DashboardSection
+                          id={sectionID}
+                          kind={kind}
+                          key={`${kind}-${section}`}
+                          items={data[kind][section]}
+                          name={label}
+                          section={section}
+                          intl={intl}
+                      />
+                  );
+              })
+        : [];
+
+    let componentContent;
+
+    if (filteredSections.length > 0) {
+        componentContent = filteredSections;
+    } else {
+        componentContent = (
+            <Typography color="textSecondary">No content found.</Typography>
+        );
+    }
+
     return (
         <div id={makeID(ids.ROOT)} className={classes.gridRoot}>
-            {isLoading ? (
-                <DashboardSkeleton />
-            ) : (
-                sections
-                    .filter(
-                        ([kind, section, _label]) =>
-                            data[kind] !== undefined &&
-                            data[kind][section] !== undefined
-                    )
-                    .filter(
-                        ([kind, section, _label]) =>
-                            data[kind][section].length > 0
-                    )
-                    .map(([kind, section, label, sectionID]) => {
-                        return (
-                            <DashboardSection
-                                id={sectionID}
-                                kind={kind}
-                                key={`${kind}-${section}`}
-                                items={data[kind][section]}
-                                name={label}
-                                section={section}
-                                intl={intl}
-                            />
-                        );
-                    })
-            )}
-
+            {isLoading ? <DashboardSkeleton /> : componentContent}
             <div className={classes.footer} />
         </div>
     );

--- a/src/components/dashboard/index.js
+++ b/src/components/dashboard/index.js
@@ -57,7 +57,10 @@ const useStyles = makeStyles((theme) => ({
         display: "flex",
         flexWrap: "wrap",
         justifyContent: "flex-start",
-        padding: theme.spacing(2),
+        paddingTop: theme.spacing(2),
+        paddingBottom: theme.spacing(2),
+        paddingLeft: 0,
+        paddingRight: 0,
 
         // Try to eek as much space out of the iPhone SE cards as possible.
         [theme.breakpoints.down("sm")]: {
@@ -84,11 +87,12 @@ const useStyles = makeStyles((theme) => ({
         },
     },
     dashboardCard: {
-        width: 450,
+        width: 425,
         height: 225,
         display: "flex",
         flexDirection: "column",
-        margin: theme.spacing(1),
+        marginTop: theme.spacing(2),
+        marginRight: theme.spacing(2),
 
         [theme.breakpoints.down("sm")]: {
             width: 300,

--- a/src/components/dashboard/index.js
+++ b/src/components/dashboard/index.js
@@ -14,6 +14,7 @@ import {
     Card,
     CardActions,
     CardContent,
+    CardHeader,
     Divider,
     Typography,
 } from "@material-ui/core";
@@ -37,6 +38,10 @@ const makeID = (...names) => buildID(ids.BASE, ...names);
 const useStyles = makeStyles((theme) => ({
     root: {
         flexGrow: 1,
+        paddingTop: 0,
+        paddingRight: theme.spacing(2),
+        paddingBottom: theme.spacing(2),
+        paddingLeft: theme.spacing(2),
     },
     dividerRoot: {
         marginBottom: theme.spacing(1),
@@ -158,6 +163,16 @@ const cleanDescription = (description) => {
     return desc;
 };
 
+const cleanTitle = (title) => {
+    let retval;
+    if (title.length > constants.TITLE_MAX_LENGTH) {
+        retval = title.slice(0, constants.TITLE_MAX_LENGTH) + "...";
+    } else {
+        retval = title;
+    }
+    return retval;
+};
+
 /**
  * An item in the dashboard.
  *
@@ -181,24 +196,28 @@ export const DashboardItem = (props) => {
             id={makeID(ids.ITEM, cardID)}
             elevation={4}
         >
+            <CardHeader
+                title={
+                    <Typography noWrap variant="h6">
+                        {cleanTitle(content.name)}
+                    </Typography>
+                }
+                subheader={
+                    <Typography
+                        // classes={{ root: classes.subtitle }}
+                        noWrap
+                        color="textSecondary"
+                        variant="subtitle2"
+                    >
+                        {origination} {`${user} on ${date}`}
+                    </Typography>
+                }
+            />
             <CardContent
                 classes={{
                     root: classes.root,
                 }}
             >
-                <Typography noWrap variant="h6" component="h6">
-                    {content.name}
-                </Typography>
-
-                <Typography
-                    classes={{ root: classes.subtitle }}
-                    gutterBottom
-                    noWrap
-                    color="textSecondary"
-                >
-                    {origination} {`${user} on ${date}`}
-                </Typography>
-
                 <Typography color="textSecondary" variant="body2" component="p">
                     {description}
                 </Typography>

--- a/src/components/dashboard/messages.js
+++ b/src/components/dashboard/messages.js
@@ -14,5 +14,6 @@ export default {
         startedBy: "Started by",
         publishedBy: "Published by",
         by: "By",
+        noDescriptionProvided: "No description was provided.",
     },
 };


### PR DESCRIPTION
This PR does the following:
* Changes the title and subtitle to a CardHeader.
* Assigns an avatar icon based on the content type.
* Changes the primary color of the CardHeader and open button based on the section. Needed in order to provide a bit of color to the dashboard.
* Adds a default description of "No description was provided." for the cards.
* Links to the planned details pages for apps and analyses using `router.push`.
* Adjusts the sizes of the cards slightly to allow more items per row.
* Modifies field limits and card layouts for mobile.

Limitations:
* Links for Apps and Analyses currently 404 since the routing for those hasn't been implemented yet and are outside the scope of this PR.

Notes:
* Colors for the cards come from the existing CyVerse palette in ui-lib.

![image](https://user-images.githubusercontent.com/49783/82610056-8f3df200-9b72-11ea-869c-dd87fe9c1b85.png)

![image](https://user-images.githubusercontent.com/49783/82610089-9cf37780-9b72-11ea-94e7-3b7472712064.png)

![image](https://user-images.githubusercontent.com/49783/82610152-bac0dc80-9b72-11ea-9c37-44cdcb5885f9.png)

![image](https://user-images.githubusercontent.com/49783/82610215-d4622400-9b72-11ea-8434-93c5b9dc3900.png)

![image](https://user-images.githubusercontent.com/49783/82610248-e217a980-9b72-11ea-80fc-89d110094021.png)

![image](https://user-images.githubusercontent.com/49783/82610288-f52a7980-9b72-11ea-958a-2718efd6f76f.png)

