### PR TITLE
Add "chromatic-ignore" classname

### DIFF
--- a/src/components/utils/error/ErrorHandler.js
+++ b/src/components/utils/error/ErrorHandler.js
@@ -75,12 +75,18 @@ function ClientInfo(props) {
                 </Typography>
             </GridLabelValue>
             <GridLabelValue label={getMessage("host")}>
-                <Typography id={build(baseId, ids.host)}>
+                <Typography
+                    id={build(baseId, ids.host)}
+                    className={constants.CHROMATIC_IGNORE}
+                >
                     {window.location.origin}
                 </Typography>
             </GridLabelValue>
             <GridLabelValue label={getMessage("timestamp")}>
-                <Typography id={build(baseId, ids.host)}>
+                <Typography
+                    id={build(baseId, ids.host)}
+                    className={constants.CHROMATIC_IGNORE}
+                >
                     {new Date().toString()}
                 </Typography>
             </GridLabelValue>

--- a/src/constants.js
+++ b/src/constants.js
@@ -29,4 +29,5 @@ export default {
             COLUMNS: "sonora.data.columns",
         },
     },
+    CHROMATIC_IGNORE: "chromatic-ignore",
 };


### PR DESCRIPTION
This should keep the ErrorHandler from showing as having a change in Chromatic.  See https://www.chromatic.com/docs/ignoring-elements

[Chromatic build](https://www.chromatic.com/build?appId=5ebad5c6b991d60022b1e72e&number=64) with 0 diffs reported