### PR TITLE
VICE Admin Reorg and Analysis Mgmt

### DIFF
--- a/src/components/vice/admin/constants.js
+++ b/src/components/vice/admin/constants.js
@@ -59,3 +59,7 @@ export const CONFIG_MAP_COLUMNS = {
 export const INGRESS_COLUMNS = {
     ...COMMON_COLUMNS,
 };
+
+export const LOADING = "loading";
+export const ERROR = "error";
+export const REFETCH_INTERVAL = 10000;

--- a/src/components/vice/admin/constants.js
+++ b/src/components/vice/admin/constants.js
@@ -11,6 +11,10 @@ export const COMMON_COLUMNS = {
     EXPAND: "expand",
 };
 
+export const ANALYSIS_COLUMNS = {
+    ACTIONS: "actions",
+};
+
 export const DEPLOYMENT_COLUMNS = {
     ...COMMON_COLUMNS,
     IMAGE: "image",

--- a/src/components/vice/admin/index.js
+++ b/src/components/vice/admin/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 import { useQuery, useMutation, queryCache } from "react-query";
 
@@ -217,10 +217,6 @@ const VICEAdminTabs = ({ data }) => {
     const tabPanelID = (name) => id(ids.ROOT, "admin", "tab-panels", name);
     const ariaControls = (name) => `vice-admin-tabs-${name}`;
 
-    const [analysisRows, setAnalysisRows] = useState(
-        data ? getAnalyses(data) : []
-    );
-
     const [mutantExit] = useMutation(exit, {
         onSuccess: () => queryCache.refetchQueries(getDataQueryName),
     });
@@ -236,6 +232,12 @@ const VICEAdminTabs = ({ data }) => {
     const [mutantDownloadInputs] = useMutation(downloadInputFiles, {
         onSuccess: () => queryCache.refetchQueries(getDataQueryName),
     });
+
+    const [analysisRows, setAnalysisRows] = useState([]);
+
+    useEffect(() => {
+        setAnalysisRows(getAnalyses(data));
+    }, [data]);
 
     const orderOfTabs = [
         "analyses",
@@ -327,7 +329,10 @@ const VICEAdminTabs = ({ data }) => {
 const VICEAdmin = () => {
     const classes = useStyles();
 
-    const { status, data, error } = useQuery(getDataQueryName, getData);
+    const { status, data, error } = useQuery(getDataQueryName, getData, {
+        refetchInterval: 10000,
+    });
+
     const isLoading = status === "loading";
     const hasErrored = status === "error";
 

--- a/src/components/vice/admin/index.js
+++ b/src/components/vice/admin/index.js
@@ -213,7 +213,9 @@ const VICEAdminTabs = ({ data }) => {
     const tabPanelID = (name) => id(ids.ROOT, "admin", "tab-panels", name);
     const ariaControls = (name) => `vice-admin-tabs-${name}`;
 
-    const analysisRows = data ? getAnalyses(data) : [];
+    const [analysisRows, setAnalysisRows] = useState(
+        data ? getAnalyses(data) : []
+    );
 
     const [mutantExit] = useMutation(exit, {
         onSuccess: () => queryCache.refetchQueries(getDataQueryName),
@@ -267,29 +269,45 @@ const VICEAdminTabs = ({ data }) => {
                         columns={columns[tabName]}
                         title={msg(tabName)}
                         showActions={tabName === "analyses"}
-                        handleExit={async (analysisID) => {
+                        handleExit={async (analysisID, externalID) => {
                             const data = await mutantExit({ analysisID });
+                            setAnalysisRows(
+                                analysisRows.filter(
+                                    (obj) => obj.externalID !== externalID
+                                )
+                            );
                             return data;
                         }}
-                        handleSaveAndExit={async (analysisID) => {
+                        handleSaveAndExit={async (analysisID, externalID) => {
                             const data = await mutantSaveAndExit({
                                 analysisID,
                             });
+                            setAnalysisRows(
+                                analysisRows.filter(
+                                    (obj) => obj.externalID !== externalID
+                                )
+                            );
                             return data;
                         }}
-                        handleExtendTimeLimit={async (analysisID) => {
+                        handleExtendTimeLimit={async (
+                            analysisID,
+                            externalID
+                        ) => {
                             const data = await mutantExtendTimeLimit({
                                 analysisID,
                             });
                             return data;
                         }}
-                        handleUploadOutputs={async (analysisID) => {
+                        handleUploadOutputs={async (analysisID, externalID) => {
                             const data = await mutantUploadOutputs({
                                 analysisID,
                             });
                             return data;
                         }}
-                        handleDownloadInputs={async (analysisID) => {
+                        handleDownloadInputs={async (
+                            analysisID,
+                            externalID
+                        ) => {
                             const data = await mutantDownloadInputs({
                                 analysisID,
                             });

--- a/src/components/vice/admin/index.js
+++ b/src/components/vice/admin/index.js
@@ -34,6 +34,7 @@ import { Skeleton, TabList, TabContext, TabPanel } from "@material-ui/lab";
 import { JSONPath } from "jsonpath-plus";
 import efcs from "./filter/efcs";
 import { AppBar, Tab } from "@material-ui/core";
+import constants from "../../../constants";
 
 const id = (...values) => buildID(ids.ROOT, ...values);
 
@@ -334,11 +335,11 @@ const VICEAdmin = () => {
     const classes = useStyles();
 
     const { status, data, error } = useQuery(getDataQueryName, getData, {
-        refetchInterval: 10000,
+        refetchInterval: constants.REFETCH_INTERVAL,
     });
 
-    const isLoading = status === "loading";
-    const hasErrored = status === "error";
+    const isLoading = status === constants.LOADING;
+    const hasErrored = status === constants.ERROR;
 
     if (hasErrored) {
         console.log(error.message);

--- a/src/components/vice/admin/index.js
+++ b/src/components/vice/admin/index.js
@@ -166,7 +166,7 @@ const columns = {
     ingresses: commonColumns,
 };
 
-const getAnalyses = ({ deployments }) => {
+const getAnalyses = ({ deployments = [] }) => {
     let analyses = {};
 
     // Should only need to interate through the deployments to find the
@@ -210,7 +210,7 @@ const VICEAdminSkeleton = () => {
     );
 };
 
-const VICEAdminTabs = ({ data }) => {
+const VICEAdminTabs = ({ data = {} }) => {
     const [value, setValue] = useState("0");
 
     const tabID = (name) => id(ids.ROOT, "admin", "tabs", name);

--- a/src/components/vice/admin/index.js
+++ b/src/components/vice/admin/index.js
@@ -251,7 +251,11 @@ const VICEAdminTabs = ({ data = {} }) => {
     return (
         <TabContext value={value}>
             <AppBar position="static" color="primary">
-                <TabList onChange={(_, newValue) => setValue(newValue)}>
+                <TabList
+                    onChange={(_, newValue) => setValue(newValue)}
+                    variant="scrollable"
+                    scrollButtons="auto"
+                >
                     {orderOfTabs.map((tabName, index) => (
                         <Tab
                             label={msg(tabName)}

--- a/src/components/vice/admin/index.js
+++ b/src/components/vice/admin/index.js
@@ -231,7 +231,6 @@ const VICEAdminTabs = ({ data = {} }) => {
 
     const tabID = (name) => id(ids.ROOT, "admin", "tabs", name);
     const tabPanelID = (name) => id(ids.ROOT, "admin", "tab-panels", name);
-    const ariaControls = (name) => `vice-admin-tabs-${name}`;
 
     const [mutantExit] = useMutation(exit, {
         onSuccess: () => queryCache.refetchQueries(getDataQueryName),
@@ -283,7 +282,7 @@ const VICEAdminTabs = ({ data = {} }) => {
                             id={tabID(tabName)}
                             key={tabID(tabName)}
                             value={`${index}`}
-                            aria-controls={ariaControls(tabName)}
+                            aria-controls={tabPanelID(tabName)}
                             classes={{
                                 root: classes.tabRoot,
                                 selected: classes.tabSelected,

--- a/src/components/vice/admin/index.js
+++ b/src/components/vice/admin/index.js
@@ -33,7 +33,7 @@ import { Skeleton, TabList, TabContext, TabPanel } from "@material-ui/lab";
 
 import { JSONPath } from "jsonpath-plus";
 import efcs from "./filter/efcs";
-import { AppBar, Tab } from "@material-ui/core";
+import { AppBar, Tab, Button } from "@material-ui/core";
 
 const id = (...values) => buildID(ids.ROOT, ...values);
 
@@ -56,6 +56,10 @@ const useStyles = makeStyles((theme) => ({
         [theme.breakpoints.down("sm")]: {
             height: 32,
         },
+    },
+    refresh: {
+        marginBottom: theme.spacing(1),
+        marginTop: theme.spacing(1),
     },
 }));
 
@@ -323,9 +327,7 @@ const VICEAdminTabs = ({ data }) => {
 const VICEAdmin = () => {
     const classes = useStyles();
 
-    const { status, data, error } = useQuery(getDataQueryName, getData, {
-        refetchInterval: 10000,
-    });
+    const { status, data, error } = useQuery(getDataQueryName, getData);
     const isLoading = status === "loading";
     const hasErrored = status === "error";
 
@@ -372,6 +374,19 @@ const VICEAdmin = () => {
                         addToFilters={addToFilters}
                         deleteFromFilters={deleteFromFilters}
                     />
+
+                    <Button
+                        variant="contained"
+                        color="primary"
+                        className={classes.refresh}
+                        onClick={() =>
+                            queryCache.refetchQueries(getDataQueryName, {
+                                force: true,
+                            })
+                        }
+                    >
+                        {msg("refresh")}
+                    </Button>
 
                     <VICEAdminTabs data={filteredData} />
                 </>

--- a/src/components/vice/admin/index.js
+++ b/src/components/vice/admin/index.js
@@ -33,7 +33,7 @@ import { Skeleton, TabList, TabContext, TabPanel } from "@material-ui/lab";
 
 import { JSONPath } from "jsonpath-plus";
 import efcs from "./filter/efcs";
-import { AppBar, Tab, Button } from "@material-ui/core";
+import { AppBar, Tab } from "@material-ui/core";
 
 const id = (...values) => buildID(ids.ROOT, ...values);
 
@@ -379,19 +379,6 @@ const VICEAdmin = () => {
                         addToFilters={addToFilters}
                         deleteFromFilters={deleteFromFilters}
                     />
-
-                    <Button
-                        variant="contained"
-                        color="primary"
-                        className={classes.refresh}
-                        onClick={() =>
-                            queryCache.refetchQueries(getDataQueryName, {
-                                force: true,
-                            })
-                        }
-                    >
-                        {msg("refresh")}
-                    </Button>
 
                     <VICEAdminTabs data={filteredData} />
                 </>

--- a/src/components/vice/admin/index.js
+++ b/src/components/vice/admin/index.js
@@ -268,27 +268,32 @@ const VICEAdminTabs = ({ data }) => {
                         title={msg(tabName)}
                         showActions={tabName === "analyses"}
                         handleExit={async (analysisID) => {
-                            await mutantExit({ analysisID });
+                            const data = await mutantExit({ analysisID });
+                            return data;
                         }}
                         handleSaveAndExit={async (analysisID) => {
-                            await mutantSaveAndExit({
+                            const data = await mutantSaveAndExit({
                                 analysisID,
                             });
+                            return data;
                         }}
                         handleExtendTimeLimit={async (analysisID) => {
-                            await mutantExtendTimeLimit({
+                            const data = await mutantExtendTimeLimit({
                                 analysisID,
                             });
+                            return data;
                         }}
                         handleUploadOutputs={async (analysisID) => {
-                            await mutantUploadOutputs({
+                            const data = await mutantUploadOutputs({
                                 analysisID,
                             });
+                            return data;
                         }}
                         handleDownloadInputs={async (analysisID) => {
-                            await mutantDownloadInputs({
+                            const data = await mutantDownloadInputs({
                                 analysisID,
                             });
+                            return data;
                         }}
                     />
                 </TabPanel>
@@ -300,7 +305,9 @@ const VICEAdminTabs = ({ data }) => {
 const VICEAdmin = () => {
     const classes = useStyles();
 
-    const { status, data, error } = useQuery(getDataQueryName, getData);
+    const { status, data, error } = useQuery(getDataQueryName, getData, {
+        refetchInterval: 10000,
+    });
     const isLoading = status === "loading";
     const hasErrored = status === "error";
 

--- a/src/components/vice/admin/index.js
+++ b/src/components/vice/admin/index.js
@@ -23,10 +23,11 @@ import {
     SERVICE_COLUMNS,
     POD_COLUMNS,
 } from "./constants";
-import { Skeleton } from "@material-ui/lab";
+import { Skeleton, TabList, TabContext, TabPanel } from "@material-ui/lab";
 
 import { JSONPath } from "jsonpath-plus";
 import efcs from "./filter/efcs";
+import { AppBar, Tab } from "@material-ui/core";
 
 const id = (...values) => buildID(ids.ROOT, ...values);
 
@@ -191,6 +192,117 @@ const VICEAdminSkeleton = () => {
     );
 };
 
+const VICEAdminTabs = ({ data }) => {
+    const [value, setValue] = useState("0");
+
+    const tabID = (name) => id(ids.ROOT, "admin", "tabs", name);
+    const tabPanelID = (name) => id(ids.ROOT, "admin", "tab-panels", name);
+    const ariaControls = (name) => `vice-admin-tabs-${name}`;
+
+    const analysisRows = data ? getAnalyses(data) : [];
+
+    return (
+        <TabContext value={value}>
+            <AppBar position="static" color="primary">
+                <TabList
+                    onChange={(_, newValue) => setValue(newValue)}
+                    aria-label={msg("adminTabs")}
+                >
+                    <Tab
+                        label={msg("analyses")}
+                        id={tabID("analyses")}
+                        value="0"
+                        aria-controls={ariaControls("analyses")}
+                    />
+
+                    <Tab
+                        label={msg("deployments")}
+                        id={tabID("deployments")}
+                        value="1"
+                        aria-controls={ariaControls("deployments")}
+                    />
+
+                    <Tab
+                        label={msg("services")}
+                        id={tabID("services")}
+                        value="2"
+                        aria-controls={ariaControls("services")}
+                    />
+
+                    <Tab
+                        label={msg("pods")}
+                        id={tabID("pods")}
+                        value="3"
+                        aria-controls={ariaControls("pods")}
+                    />
+
+                    <Tab
+                        label={msg("configMaps")}
+                        id={tabID("configMaps")}
+                        value="4"
+                        aria-controls={ariaControls("configMaps")}
+                    />
+
+                    <Tab
+                        label={msg("ingresses")}
+                        id={tabID("ingresses")}
+                        value="5"
+                        aria-controls={ariaControls("ingresses")}
+                    />
+                </TabList>
+            </AppBar>
+
+            <TabPanel value="0" id={tabPanelID("analyses")}>
+                <CollapsibleTable
+                    rows={analysisRows}
+                    columns={commonColumns}
+                    title={msg("analyses")}
+                />
+            </TabPanel>
+
+            <TabPanel value="1" id={tabPanelID("deployments")}>
+                <CollapsibleTable
+                    rows={data?.deployments}
+                    columns={deploymentColumns}
+                    title={msg("deployments")}
+                />
+            </TabPanel>
+
+            <TabPanel value="2" id={tabPanelID("services")}>
+                <CollapsibleTable
+                    rows={data?.services}
+                    columns={serviceColumns}
+                    title={msg("services")}
+                />
+            </TabPanel>
+
+            <TabPanel value="3" id={tabPanelID("pods")}>
+                <CollapsibleTable
+                    rows={data?.pods}
+                    columns={podColumns}
+                    title={msg("pods")}
+                />
+            </TabPanel>
+
+            <TabPanel value="4" id={tabPanelID("configMaps")}>
+                <CollapsibleTable
+                    rows={data?.configMaps}
+                    columns={commonColumns}
+                    title={msg("configMaps")}
+                />
+            </TabPanel>
+
+            <TabPanel value="5" id={tabPanelID("ingresses")}>
+                <CollapsibleTable
+                    rows={data?.ingresses}
+                    columns={commonColumns}
+                    title={msg("ingresses")}
+                />
+            </TabPanel>
+        </TabContext>
+    );
+};
+
 const VICEAdmin = () => {
     const classes = useStyles();
 
@@ -230,8 +342,6 @@ const VICEAdmin = () => {
         data
     );
 
-    const analysisRows = filteredData ? getAnalyses(filteredData) : [];
-
     return (
         <div id={id(ids.ROOT)} className={classes.root}>
             {isLoading ? (
@@ -244,41 +354,7 @@ const VICEAdmin = () => {
                         deleteFromFilters={deleteFromFilters}
                     />
 
-                    <CollapsibleTable
-                        rows={analysisRows}
-                        columns={commonColumns}
-                        title={msg("analyses")}
-                    />
-
-                    <CollapsibleTable
-                        rows={filteredData?.deployments}
-                        columns={deploymentColumns}
-                        title={msg("deployments")}
-                    />
-
-                    <CollapsibleTable
-                        rows={filteredData?.services}
-                        columns={serviceColumns}
-                        title={msg("services")}
-                    />
-
-                    <CollapsibleTable
-                        rows={filteredData?.pods}
-                        columns={podColumns}
-                        title={msg("pods")}
-                    />
-
-                    <CollapsibleTable
-                        rows={filteredData?.configMaps}
-                        columns={commonColumns}
-                        title={msg("configMaps")}
-                    />
-
-                    <CollapsibleTable
-                        rows={filteredData?.ingresses}
-                        columns={commonColumns}
-                        title={msg("ingresses")}
-                    />
+                    <VICEAdminTabs data={filteredData} />
                 </>
             )}
             <div className={classes.footer} />

--- a/src/components/vice/admin/index.js
+++ b/src/components/vice/admin/index.js
@@ -22,7 +22,6 @@ import CollapsibleTable from "./table";
 import ids from "./ids";
 import messages from "./messages";
 import {
-    ANALYSIS_COLUMNS,
     DEPLOYMENT_COLUMNS,
     COMMON_COLUMNS,
     SERVICE_COLUMNS,
@@ -91,10 +90,7 @@ const commonColumns = [
 ];
 
 const columns = {
-    analyses: [
-        ...commonColumns,
-        defineColumn("", ANALYSIS_COLUMNS.ACTIONS, "", "left", false),
-    ],
+    analyses: commonColumns,
 
     deployments: [
         ...commonColumns,

--- a/src/components/vice/admin/index.js
+++ b/src/components/vice/admin/index.js
@@ -11,6 +11,8 @@ import {
 } from "@cyverse-de/ui-lib";
 
 import getData, {
+    saveOutputFiles,
+    downloadInputFiles,
     extendTimeLimit,
     saveAndExit,
     exit,
@@ -214,6 +216,8 @@ const VICEAdminTabs = ({ data }) => {
     const [mutantExit] = useMutation(exit);
     const [mutantSaveAndExit] = useMutation(saveAndExit);
     const [mutantExtendTimeLimit] = useMutation(extendTimeLimit);
+    const [mutantUploadOutputs] = useMutation(saveOutputFiles);
+    const [mutantDownloadInputs] = useMutation(downloadInputFiles);
 
     const orderOfTabs = [
         "analyses",
@@ -272,6 +276,26 @@ const VICEAdminTabs = ({ data }) => {
                         handleExtendTimeLimit={async (analysisID) => {
                             try {
                                 const data = await mutantExtendTimeLimit({
+                                    analysisID,
+                                });
+                                console.log(data);
+                            } catch (err) {
+                                console.log(err);
+                            }
+                        }}
+                        handleUploadOutputs={async (analysisID) => {
+                            try {
+                                const data = await mutantUploadOutputs({
+                                    analysisID,
+                                });
+                                console.log(data);
+                            } catch (err) {
+                                console.log(err);
+                            }
+                        }}
+                        handleDownloadInputs={async (analysisID) => {
+                            try {
+                                const data = await mutantDownloadInputs({
                                     analysisID,
                                 });
                                 console.log(data);

--- a/src/components/vice/admin/index.js
+++ b/src/components/vice/admin/index.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-import { useQuery, useMutation } from "react-query";
+import { useQuery, useMutation, queryCache } from "react-query";
 
 import { makeStyles } from "@material-ui/styles";
 
@@ -73,6 +73,8 @@ const defineColumn = (
     id: keyID,
     field,
 });
+
+const getDataQueryName = "vice-admin";
 
 // The column definitions for the table.
 const commonColumns = [
@@ -213,11 +215,21 @@ const VICEAdminTabs = ({ data }) => {
 
     const analysisRows = data ? getAnalyses(data) : [];
 
-    const [mutantExit] = useMutation(exit);
-    const [mutantSaveAndExit] = useMutation(saveAndExit);
-    const [mutantExtendTimeLimit] = useMutation(extendTimeLimit);
-    const [mutantUploadOutputs] = useMutation(saveOutputFiles);
-    const [mutantDownloadInputs] = useMutation(downloadInputFiles);
+    const [mutantExit] = useMutation(exit, {
+        onSuccess: () => queryCache.refetchQueries(getDataQueryName),
+    });
+    const [mutantSaveAndExit] = useMutation(saveAndExit, {
+        onSuccess: () => queryCache.refetchQueries(getDataQueryName),
+    });
+    const [mutantExtendTimeLimit] = useMutation(extendTimeLimit, {
+        onSuccess: () => queryCache.refetchQueries(getDataQueryName),
+    });
+    const [mutantUploadOutputs] = useMutation(saveOutputFiles, {
+        onSuccess: () => queryCache.refetchQueries(getDataQueryName),
+    });
+    const [mutantDownloadInputs] = useMutation(downloadInputFiles, {
+        onSuccess: () => queryCache.refetchQueries(getDataQueryName),
+    });
 
     const orderOfTabs = [
         "analyses",
@@ -256,52 +268,27 @@ const VICEAdminTabs = ({ data }) => {
                         title={msg(tabName)}
                         showActions={tabName === "analyses"}
                         handleExit={async (analysisID) => {
-                            try {
-                                const data = await mutantExit({ analysisID });
-                                console.log(data); // TODO: do something better here.
-                            } catch (err) {
-                                console.log(err); // TODO: do something better here.
-                            }
+                            await mutantExit({ analysisID });
                         }}
                         handleSaveAndExit={async (analysisID) => {
-                            try {
-                                const data = await mutantSaveAndExit({
-                                    analysisID,
-                                });
-                                console.log(data);
-                            } catch (err) {
-                                console.log(err);
-                            }
+                            await mutantSaveAndExit({
+                                analysisID,
+                            });
                         }}
                         handleExtendTimeLimit={async (analysisID) => {
-                            try {
-                                const data = await mutantExtendTimeLimit({
-                                    analysisID,
-                                });
-                                console.log(data);
-                            } catch (err) {
-                                console.log(err);
-                            }
+                            await mutantExtendTimeLimit({
+                                analysisID,
+                            });
                         }}
                         handleUploadOutputs={async (analysisID) => {
-                            try {
-                                const data = await mutantUploadOutputs({
-                                    analysisID,
-                                });
-                                console.log(data);
-                            } catch (err) {
-                                console.log(err);
-                            }
+                            await mutantUploadOutputs({
+                                analysisID,
+                            });
                         }}
                         handleDownloadInputs={async (analysisID) => {
-                            try {
-                                const data = await mutantDownloadInputs({
-                                    analysisID,
-                                });
-                                console.log(data);
-                            } catch (err) {
-                                console.log(err);
-                            }
+                            await mutantDownloadInputs({
+                                analysisID,
+                            });
                         }}
                     />
                 </TabPanel>
@@ -313,7 +300,7 @@ const VICEAdminTabs = ({ data }) => {
 const VICEAdmin = () => {
     const classes = useStyles();
 
-    const { status, data, error } = useQuery("vice-admin", getData);
+    const { status, data, error } = useQuery(getDataQueryName, getData);
     const isLoading = status === "loading";
     const hasErrored = status === "error";
 

--- a/src/components/vice/admin/index.js
+++ b/src/components/vice/admin/index.js
@@ -62,6 +62,19 @@ const useStyles = makeStyles((theme) => ({
         marginBottom: theme.spacing(1),
         marginTop: theme.spacing(1),
     },
+    tabAppBarColorPrimary: {
+        backgroundColor: theme.palette.white,
+    },
+    tabRoot: {
+        color: theme.palette.darkGray,
+        "&:hover": {
+            color: theme.palette.black,
+        },
+    },
+    tabSelected: {
+        backgroundColor: theme.palette.primary.main,
+        color: theme.palette.primary.contrastText,
+    },
 }));
 
 const defineColumn = (
@@ -212,6 +225,8 @@ const VICEAdminSkeleton = () => {
 };
 
 const VICEAdminTabs = ({ data = {} }) => {
+    const classes = useStyles();
+
     const [value, setValue] = useState("0");
 
     const tabID = (name) => id(ids.ROOT, "admin", "tabs", name);
@@ -251,11 +266,16 @@ const VICEAdminTabs = ({ data = {} }) => {
 
     return (
         <TabContext value={value}>
-            <AppBar position="static" color="primary">
+            <AppBar
+                position="static"
+                color="primary"
+                classes={{ colorPrimary: classes.tabAppBarColorPrimary }}
+            >
                 <TabList
                     onChange={(_, newValue) => setValue(newValue)}
                     variant="scrollable"
                     scrollButtons="auto"
+                    indicatorColor="secondary"
                 >
                     {orderOfTabs.map((tabName, index) => (
                         <Tab
@@ -264,6 +284,10 @@ const VICEAdminTabs = ({ data = {} }) => {
                             key={tabID(tabName)}
                             value={`${index}`}
                             aria-controls={ariaControls(tabName)}
+                            classes={{
+                                root: classes.tabRoot,
+                                selected: classes.tabSelected,
+                            }}
                         />
                     ))}
                 </TabList>

--- a/src/components/vice/admin/messages.js
+++ b/src/components/vice/admin/messages.js
@@ -17,5 +17,6 @@ export default {
         configMaps: "ConfigMaps",
         ingresses: "Ingresses",
         adminTabs: "Admin Tabs",
+        refresh: "Refresh",
     },
 };

--- a/src/components/vice/admin/messages.js
+++ b/src/components/vice/admin/messages.js
@@ -16,5 +16,6 @@ export default {
         pods: "Pods",
         configMaps: "ConfigMaps",
         ingresses: "Ingresses",
+        adminTabs: "Admin Tabs",
     },
 };

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -47,14 +47,6 @@ const useStyles = makeStyles((theme) => ({
     },
     extended: {
         display: "flex",
-        marginLeft: theme.spacing(7),
-        marginRight: theme.spacing(7),
-
-        [theme.breakpoints.down("sm")]: {
-            marginLeft: theme.spacing(1),
-            marginRight: theme.spacing(1),
-        },
-
         flexWrap: "wrap",
         flexShrink: 0,
         flexGrow: 0,
@@ -81,12 +73,28 @@ const useStyles = makeStyles((theme) => ({
         },
         [theme.breakpoints.up("lg")]: {
             width: 350,
-            margin: theme.spacing(2),
+            marginTop: theme.spacing(2),
+            marginBottom: theme.spacing(2),
+            marginRight: theme.spacing(2),
         },
     },
     dataEntryLabel: {
         marginRight: theme.spacing(1),
         fontWeight: 500,
+    },
+    actionButton: {
+        marginRight: theme.spacing(1),
+        marginBottom: theme.spacing(1),
+        marginTop: theme.spacing(1),
+    },
+    actions: {
+        marginLeft: theme.spacing(11),
+        marginRight: theme.spacing(11),
+
+        [theme.breakpoints.down("sm")]: {
+            marginLeft: theme.spacing(1),
+            marginRight: theme.spacing(1),
+        },
     },
 }));
 
@@ -110,7 +118,7 @@ const ExtendedDataCard = ({
 
     return (
         <Box margin={1}>
-            <div className={classes.extended}>
+            <div className={`${classes.extended} ${classes.actions}`}>
                 {columns.map((column) => {
                     return (
                         <div
@@ -125,7 +133,7 @@ const ExtendedDataCard = ({
                                 id={id(collapseID, column.field, "label")}
                                 classes={{ root: classes.dataEntryLabel }}
                             >
-                                {`${column.name}:`}
+                                {column.name && `${column.name}:`}
                             </Typography>
                             <Typography
                                 variant="body2"
@@ -133,34 +141,42 @@ const ExtendedDataCard = ({
                                 display={display}
                                 id={id(collapseID, column.field, "value")}
                             >
-                                {row[column.field] || "N/A"}
+                                {row &&
+                                    row.hasOwnProperty(column.field) &&
+                                    row[column.field]}
                             </Typography>
                         </div>
                     );
                 })}
-                {showActions && (
-                    <>
-                        <Button
-                            variant="contained"
-                            onClick={() => handleExtendTimeLimit(row)}
-                        >
-                            {msg("extendTimeLimit")}
-                        </Button>
-                        <Button
-                            variant="contained"
-                            onClick={() => handleExit(row)}
-                        >
-                            {msg("exit")}
-                        </Button>
-                        <Button
-                            variant="contained"
-                            onClick={() => handleSaveAndExit(row)}
-                        >
-                            {msg("saveAndExit")}
-                        </Button>
-                    </>
-                )}
             </div>
+            {showActions && (
+                <div className={classes.actions}>
+                    <Button
+                        variant="contained"
+                        color="primary"
+                        onClick={() => handleExtendTimeLimit(row)}
+                        className={classes.actionButton}
+                    >
+                        {msg("extendTimeLimit")}
+                    </Button>
+                    <Button
+                        variant="contained"
+                        color="primary"
+                        onClick={() => handleExit(row)}
+                        className={classes.actionButton}
+                    >
+                        {msg("exit")}
+                    </Button>
+                    <Button
+                        variant="contained"
+                        color="primary"
+                        onClick={() => handleSaveAndExit(row)}
+                        className={classes.actionButton}
+                    >
+                        {msg("saveAndExit")}
+                    </Button>
+                </div>
+            )}
         </Box>
     );
 };

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -321,18 +321,9 @@ const CollapsibleTableRow = ({
                                 setOpen(defaultOpen);
                                 return handleSaveAndExit(analysisID);
                             }}
-                            handleExtendTimeLimit={(analysisID) => {
-                                setOpen(defaultOpen);
-                                return handleExtendTimeLimit(analysisID);
-                            }}
-                            handleUploadOutputs={(analysisID) => {
-                                setOpen(defaultOpen);
-                                return handleUploadOutputs(analysisID);
-                            }}
-                            handleDownloadInputs={(analysisID) => {
-                                setOpen(defaultOpen);
-                                return handleDownloadInputs(analysisID);
-                            }}
+                            handleExtendTimeLimit={handleExtendTimeLimit}
+                            handleUploadOutputs={handleUploadOutputs}
+                            handleDownloadInputs={handleDownloadInputs}
                         />
                     </Collapse>
                 </TableCell>
@@ -431,36 +422,17 @@ const CollapsibleTable = ({
                         {rows?.map((row, index) => (
                             <CollapsibleTableRow
                                 row={row}
-                                key={index}
+                                key={row.externalID}
+                                baseID={row.externalID}
                                 columns={columns}
                                 startColumn={startColumn}
                                 endColumn={endColumn}
                                 showActions={showActions}
-                                handleExit={(analysisID) => {
-                                    setOrder(defaultOrder);
-                                    setOrderColumn(defaultOrderColumn);
-                                    return handleExit(analysisID);
-                                }}
-                                handleSaveAndExit={(analysisID) => {
-                                    setOrder(defaultOrder);
-                                    setOrderColumn(defaultOrderColumn);
-                                    return handleSaveAndExit(analysisID);
-                                }}
-                                handleExtendTimeLimit={(analysisID) => {
-                                    setOrder(defaultOrder);
-                                    setOrderColumn(defaultOrderColumn);
-                                    return handleExtendTimeLimit(analysisID);
-                                }}
-                                handleDownloadInputs={(analysisID) => {
-                                    setOrder(defaultOrder);
-                                    setOrderColumn(defaultOrderColumn);
-                                    return handleDownloadInputs(analysisID);
-                                }}
-                                handleUploadOutputs={(analysisID) => {
-                                    setOrder(defaultOrder);
-                                    setOrderColumn(defaultOrderColumn);
-                                    return handleUploadOutputs(analysisID);
-                                }}
+                                handleExit={handleExit}
+                                handleSaveAndExit={handleSaveAndExit}
+                                handleExtendTimeLimit={handleExtendTimeLimit}
+                                handleDownloadInputs={handleDownloadInputs}
+                                handleUploadOutputs={handleUploadOutputs}
                             />
                         ))}
                     </TableBody>

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -41,14 +41,7 @@ const id = (...names) => buildID(ids.BASE, ...names);
 
 const ActionButtonsSkeleton = () => {
     return (
-        <>
-            <Skeleton
-                variant="rect"
-                animation="wave"
-                height={75}
-                width="100%"
-            />
-        </>
+        <Skeleton variant="rect" animation="wave" height={75} width="100%" />
     );
 };
 

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -21,6 +21,7 @@ import {
     IconButton,
     useTheme,
     useMediaQuery,
+    Button,
 } from "@material-ui/core";
 
 import messages from "./messages";
@@ -89,7 +90,15 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-const ExtendedDataCard = ({ columns, row, collapseID }) => {
+const ExtendedDataCard = ({
+    columns,
+    row,
+    collapseID,
+    showActions = false,
+    handleExit,
+    handleSaveAndExit,
+    handleExtendTimeLimit,
+}) => {
     const classes = useStyles();
     const theme = useTheme();
     const isMedium = useMediaQuery(theme.breakpoints.down("md"));
@@ -107,6 +116,7 @@ const ExtendedDataCard = ({ columns, row, collapseID }) => {
                         <div
                             className={classes.dataEntry}
                             id={id(collapseID, column.field)}
+                            key={id(collapseID, column.field)}
                         >
                             <Typography
                                 variant="body2"
@@ -128,6 +138,28 @@ const ExtendedDataCard = ({ columns, row, collapseID }) => {
                         </div>
                     );
                 })}
+                {showActions && (
+                    <>
+                        <Button
+                            variant="contained"
+                            onClick={() => handleExtendTimeLimit(row)}
+                        >
+                            {msg("extendTimeLimit")}
+                        </Button>
+                        <Button
+                            variant="contained"
+                            onClick={() => handleExit(row)}
+                        >
+                            {msg("exit")}
+                        </Button>
+                        <Button
+                            variant="contained"
+                            onClick={() => handleSaveAndExit(row)}
+                        >
+                            {msg("saveAndExit")}
+                        </Button>
+                    </>
+                )}
             </div>
         </Box>
     );
@@ -139,6 +171,10 @@ const CollapsibleTableRow = ({
     baseID,
     startColumn,
     endColumn,
+    showActions,
+    handleExit,
+    handleSaveAndExit,
+    handleExtendTimeLimit,
 }) => {
     const [open, setOpen] = useState(false);
     const classes = useStyles();
@@ -180,6 +216,10 @@ const CollapsibleTableRow = ({
                             columns={columns.slice(endColumn)}
                             row={row}
                             collapseID={collapseID}
+                            showActions={showActions}
+                            handleExit={handleExit}
+                            handleSaveAndExit={handleSaveAndExit}
+                            handleExtendTimeLimit={handleExtendTimeLimit}
                         />
                     </Collapse>
                 </TableCell>
@@ -188,7 +228,15 @@ const CollapsibleTableRow = ({
     );
 };
 
-const CollapsibleTable = ({ columns, rows, title }) => {
+const CollapsibleTable = ({
+    columns,
+    rows,
+    title,
+    showActions = false,
+    handleExit = (_analysisID) => {},
+    handleSaveAndExit = (_analysisID) => {},
+    handleExtendTimeLimit = (_analysisID) => {},
+}) => {
     const classes = useStyles();
     const theme = useTheme();
     const isSmall = useMediaQuery(theme.breakpoints.up("xs"));
@@ -270,6 +318,10 @@ const CollapsibleTable = ({ columns, rows, title }) => {
                                 columns={columns}
                                 startColumn={startColumn}
                                 endColumn={endColumn}
+                                showActions={showActions}
+                                handleExit={handleExit}
+                                handleSaveAndExit={handleSaveAndExit}
+                                handleExtendTimeLimit={handleExtendTimeLimit}
                             />
                         ))}
                     </TableBody>

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -147,7 +147,12 @@ const ActionButtons = ({
                     <Button
                         variant="contained"
                         color="primary"
-                        onClick={() => handleExtendTimeLimit(data.analysisID)}
+                        onClick={() =>
+                            handleExtendTimeLimit(
+                                data.analysisID,
+                                row.externalID
+                            )
+                        }
                         className={classes.actionButton}
                     >
                         {msg("extendTimeLimit")}
@@ -155,7 +160,12 @@ const ActionButtons = ({
                     <Button
                         variant="contained"
                         color="primary"
-                        onClick={() => handleDownloadInputs(data.analysisID)}
+                        onClick={() =>
+                            handleDownloadInputs(
+                                data.analysisID,
+                                row.externalID
+                            )
+                        }
                         className={classes.actionButton}
                     >
                         {msg("downloadInputs")}
@@ -163,7 +173,9 @@ const ActionButtons = ({
                     <Button
                         variant="contained"
                         color="primary"
-                        onClick={() => handleUploadOutputs(data.analysisID)}
+                        onClick={() =>
+                            handleUploadOutputs(data.analysisID, row.externalID)
+                        }
                         className={classes.actionButton}
                     >
                         {msg("uploadOutputs")}
@@ -171,7 +183,9 @@ const ActionButtons = ({
                     <Button
                         variant="contained"
                         color="primary"
-                        onClick={() => handleExit(data.analysisID)}
+                        onClick={() =>
+                            handleExit(data.analysisID, row.externalID)
+                        }
                         className={classes.actionButton}
                     >
                         {msg("exit")}
@@ -179,7 +193,9 @@ const ActionButtons = ({
                     <Button
                         variant="contained"
                         color="primary"
-                        onClick={() => handleSaveAndExit(data.analysisID)}
+                        onClick={() =>
+                            handleSaveAndExit(data.analysisID, row.externalID)
+                        }
                         className={classes.actionButton}
                     >
                         {msg("saveAndExit")}
@@ -313,13 +329,16 @@ const CollapsibleTableRow = ({
                             row={row}
                             collapseID={collapseID}
                             showActions={showActions}
-                            handleExit={(analysisID) => {
+                            handleExit={(analysisID, externalID) => {
                                 setOpen(defaultOpen);
-                                return handleExit(analysisID);
+                                return handleExit(analysisID, externalID);
                             }}
-                            handleSaveAndExit={(analysisID) => {
+                            handleSaveAndExit={(analysisID, externalID) => {
                                 setOpen(defaultOpen);
-                                return handleSaveAndExit(analysisID);
+                                return handleSaveAndExit(
+                                    analysisID,
+                                    externalID
+                                );
                             }}
                             handleExtendTimeLimit={handleExtendTimeLimit}
                             handleUploadOutputs={handleUploadOutputs}

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -178,6 +178,7 @@ const ActionButtons = ({
             ) : (
                 <>
                     <Button
+                        id={id(row.externalID, "button", "extendTimeLimit")}
                         variant="contained"
                         color="primary"
                         onClick={(event) =>
@@ -191,7 +192,9 @@ const ActionButtons = ({
                     >
                         {msg("extendTimeLimit")}
                     </Button>
+
                     <Button
+                        id={id(row.externalID, "button", "downloadInputs")}
                         variant="contained"
                         color="primary"
                         onClick={(event) =>
@@ -205,7 +208,9 @@ const ActionButtons = ({
                     >
                         {msg("downloadInputs")}
                     </Button>
+
                     <Button
+                        id={id(row.externalID, "button", "uploadOutputs")}
                         variant="contained"
                         color="primary"
                         onClick={(event) =>
@@ -219,7 +224,9 @@ const ActionButtons = ({
                     >
                         {msg("uploadOutputs")}
                     </Button>
+
                     <Button
+                        id={id(row.externalID, "button", "exit")}
                         variant="contained"
                         color="primary"
                         onClick={() =>
@@ -229,7 +236,9 @@ const ActionButtons = ({
                     >
                         {msg("exit")}
                     </Button>
+
                     <Button
+                        id={id(row.externalID, "button", "saveAndExit")}
                         variant="contained"
                         color="primary"
                         onClick={() =>

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -24,6 +24,12 @@ import {
     Button,
 } from "@material-ui/core";
 
+import { Skeleton } from "@material-ui/lab";
+
+import { useQuery } from "react-query";
+
+import { asyncData } from "../../../../serviceFacades/vice/admin";
+
 import messages from "./messages";
 import ids from "./ids";
 import { KeyboardArrowUp, KeyboardArrowDown } from "@material-ui/icons";
@@ -98,6 +104,92 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
+const ActionButtonsSkeleton = () => {
+    return (
+        <>
+            <Skeleton
+                variant="rect"
+                animation="wave"
+                height={75}
+                width="100%"
+            />
+        </>
+    );
+};
+
+const ActionButtons = ({
+    row,
+    handleExtendTimeLimit = (_) => {},
+    handleDownloadInputs = (_) => {},
+    handleUploadOutputs = (_) => {},
+    handleExit = (_) => {},
+    handleSaveAndExit = (_) => {},
+}) => {
+    const classes = useStyles();
+
+    const { status, data, error } = useQuery(
+        ["async-data", row.externalID],
+        asyncData
+    );
+    const isLoading = status === "loading";
+    const hasErrored = status === "error";
+
+    if (hasErrored) {
+        console.log(error);
+    }
+
+    return (
+        <div className={classes.actions}>
+            {isLoading ? (
+                <ActionButtonsSkeleton />
+            ) : (
+                <>
+                    <Button
+                        variant="contained"
+                        color="primary"
+                        onClick={() => handleExtendTimeLimit(data.analysisID)}
+                        className={classes.actionButton}
+                    >
+                        {msg("extendTimeLimit")}
+                    </Button>
+                    <Button
+                        variant="contained"
+                        color="primary"
+                        onClick={() => handleDownloadInputs(data.analysisID)}
+                        className={classes.actionButton}
+                    >
+                        {msg("downloadInputs")}
+                    </Button>
+                    <Button
+                        variant="contained"
+                        color="primary"
+                        onClick={() => handleUploadOutputs(data.analysisID)}
+                        className={classes.actionButton}
+                    >
+                        {msg("uploadOutputs")}
+                    </Button>
+                    <Button
+                        variant="contained"
+                        color="primary"
+                        onClick={() => handleExit(data.analysisID)}
+                        className={classes.actionButton}
+                    >
+                        {msg("exit")}
+                    </Button>
+                    <Button
+                        variant="contained"
+                        color="primary"
+                        onClick={() => handleSaveAndExit(data.analysisID)}
+                        className={classes.actionButton}
+                    >
+                        {msg("saveAndExit")}
+                    </Button>
+                </>
+            )}
+        </div>
+    );
+};
+
 const ExtendedDataCard = ({
     columns,
     row,
@@ -106,6 +198,8 @@ const ExtendedDataCard = ({
     handleExit,
     handleSaveAndExit,
     handleExtendTimeLimit,
+    handleUploadOutputs,
+    handleDownloadInputs,
 }) => {
     const classes = useStyles();
     const theme = useTheme();
@@ -150,32 +244,14 @@ const ExtendedDataCard = ({
                 })}
             </div>
             {showActions && (
-                <div className={classes.actions}>
-                    <Button
-                        variant="contained"
-                        color="primary"
-                        onClick={() => handleExtendTimeLimit(row)}
-                        className={classes.actionButton}
-                    >
-                        {msg("extendTimeLimit")}
-                    </Button>
-                    <Button
-                        variant="contained"
-                        color="primary"
-                        onClick={() => handleExit(row)}
-                        className={classes.actionButton}
-                    >
-                        {msg("exit")}
-                    </Button>
-                    <Button
-                        variant="contained"
-                        color="primary"
-                        onClick={() => handleSaveAndExit(row)}
-                        className={classes.actionButton}
-                    >
-                        {msg("saveAndExit")}
-                    </Button>
-                </div>
+                <ActionButtons
+                    row={row}
+                    handleDownloadInputs={handleDownloadInputs}
+                    handleUploadOutputs={handleUploadOutputs}
+                    handleExtendTimeLimit={handleExtendTimeLimit}
+                    handleExit={handleExit}
+                    handleSaveAndExit={handleSaveAndExit}
+                />
             )}
         </Box>
     );
@@ -191,6 +267,8 @@ const CollapsibleTableRow = ({
     handleExit,
     handleSaveAndExit,
     handleExtendTimeLimit,
+    handleUploadOutputs,
+    handleDownloadInputs,
 }) => {
     const [open, setOpen] = useState(false);
     const classes = useStyles();
@@ -236,6 +314,8 @@ const CollapsibleTableRow = ({
                             handleExit={handleExit}
                             handleSaveAndExit={handleSaveAndExit}
                             handleExtendTimeLimit={handleExtendTimeLimit}
+                            handleUploadOutputs={handleUploadOutputs}
+                            handleDownloadInputs={handleDownloadInputs}
                         />
                     </Collapse>
                 </TableCell>
@@ -249,9 +329,11 @@ const CollapsibleTable = ({
     rows,
     title,
     showActions = false,
-    handleExit = (_analysisID) => {},
-    handleSaveAndExit = (_analysisID) => {},
-    handleExtendTimeLimit = (_analysisID) => {},
+    handleExit,
+    handleSaveAndExit,
+    handleExtendTimeLimit,
+    handleDownloadInputs,
+    handleUploadOutputs,
 }) => {
     const classes = useStyles();
     const theme = useTheme();
@@ -338,6 +420,8 @@ const CollapsibleTable = ({
                                 handleExit={handleExit}
                                 handleSaveAndExit={handleSaveAndExit}
                                 handleExtendTimeLimit={handleExtendTimeLimit}
+                                handleDownloadInputs={handleDownloadInputs}
+                                handleUploadOutputs={handleUploadOutputs}
                             />
                         ))}
                     </TableBody>

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -17,7 +17,6 @@ import {
     Paper,
     TableRow,
     Typography,
-    makeStyles,
     IconButton,
     useTheme,
     useMediaQuery,
@@ -27,88 +26,18 @@ import {
 
 import { Skeleton } from "@material-ui/lab";
 
+import { KeyboardArrowUp, KeyboardArrowDown } from "@material-ui/icons";
+
 import { useQuery } from "react-query";
 
 import { asyncData } from "../../../../serviceFacades/vice/admin";
 
 import messages from "./messages";
 import ids from "./ids";
-import { KeyboardArrowUp, KeyboardArrowDown } from "@material-ui/icons";
+import useStyles from "./styles";
 
 // Constructs an ID for an element.
 const id = (...names) => buildID(ids.BASE, ...names);
-
-const useStyles = makeStyles((theme) => ({
-    root: {
-        width: "100%",
-    },
-    paper: {
-        width: "100%",
-        marginBottom: theme.spacing(5),
-    },
-    title: {
-        padding: theme.spacing(2),
-    },
-    table: {
-        height: "100%",
-    },
-    extended: {
-        display: "flex",
-        flexWrap: "wrap",
-        flexShrink: 0,
-        flexGrow: 0,
-    },
-    row: {
-        "& > *": {
-            borderBottom: "unset",
-        },
-    },
-    dataEntry: {
-        [theme.breakpoints.up("xs")]: {
-            width: "100%",
-            marginLeft: 0,
-            marginRight: 0,
-            marginTop: theme.spacing(1),
-            marginBottom: theme.spacing(1),
-        },
-        [theme.breakpoints.up("sm")]: {
-            width: 300,
-            marginLeft: 0,
-            marginRight: 0,
-            marginTop: theme.spacing(1),
-            marginBottom: theme.spacing(1),
-        },
-        [theme.breakpoints.up("lg")]: {
-            width: 350,
-            marginTop: theme.spacing(2),
-            marginBottom: theme.spacing(2),
-            marginRight: theme.spacing(2),
-        },
-    },
-    dataEntryLabel: {
-        marginRight: theme.spacing(1),
-        fontWeight: 500,
-    },
-    actionButton: {
-        marginRight: theme.spacing(1),
-        marginBottom: theme.spacing(1),
-        marginTop: theme.spacing(1),
-    },
-    actions: {
-        marginLeft: theme.spacing(11),
-        marginRight: theme.spacing(11),
-
-        [theme.breakpoints.down("sm")]: {
-            marginLeft: theme.spacing(1),
-            marginRight: theme.spacing(1),
-        },
-    },
-    paperPopper: {
-        border: "1px solid",
-        padding: theme.spacing(1),
-        backgroundColor: theme.palette.background.paper,
-    },
-}));
 
 const ActionButtonsSkeleton = () => {
     return (
@@ -120,6 +49,21 @@ const ActionButtonsSkeleton = () => {
                 width="100%"
             />
         </>
+    );
+};
+
+const ActionButton = ({ baseID, name, handler, onClick }) => {
+    const classes = useStyles();
+    return (
+        <Button
+            id={id(baseID, "button", name)}
+            variant="contained"
+            color="primary"
+            onClick={(event) => onClick(event, handler, name)}
+            className={classes.actionButton}
+        >
+            {msg(name)}
+        </Button>
     );
 };
 
@@ -181,77 +125,40 @@ const ActionButtons = ({
                 <ActionButtonsSkeleton />
             ) : (
                 <>
-                    <Button
-                        id={id(row.externalID, "button", "extendTimeLimit")}
-                        variant="contained"
-                        color="primary"
-                        onClick={(event) =>
-                            onClick(
-                                event,
-                                handleExtendTimeLimit,
-                                "timeLimitExtended"
-                            )
-                        }
-                        className={classes.actionButton}
-                    >
-                        {msg("extendTimeLimit")}
-                    </Button>
+                    <ActionButton
+                        baseID={row.externalID}
+                        name="extendTimeLimit"
+                        handler={handleExtendTimeLimit}
+                        onClick={onClick}
+                    />
 
-                    <Button
-                        id={id(row.externalID, "button", "downloadInputs")}
-                        variant="contained"
-                        color="primary"
-                        onClick={(event) =>
-                            onClick(
-                                event,
-                                handleDownloadInputs,
-                                "downloadInputsCommandSent"
-                            )
-                        }
-                        className={classes.actionButton}
-                    >
-                        {msg("downloadInputs")}
-                    </Button>
+                    <ActionButton
+                        baseID={row.externalID}
+                        name="downloadInputs"
+                        handler={handleDownloadInputs}
+                        onClick={onClick}
+                    />
 
-                    <Button
-                        id={id(row.externalID, "button", "uploadOutputs")}
-                        variant="contained"
-                        color="primary"
-                        onClick={(event) =>
-                            onClick(
-                                event,
-                                handleUploadOutputs,
-                                "uploadOutputsCommandSent"
-                            )
-                        }
-                        className={classes.actionButton}
-                    >
-                        {msg("uploadOutputs")}
-                    </Button>
+                    <ActionButton
+                        baseID={row.externalID}
+                        name="uploadOutputs"
+                        handler={handleUploadOutputs}
+                        onClick={onClick}
+                    />
 
-                    <Button
-                        id={id(row.externalID, "button", "exit")}
-                        variant="contained"
-                        color="primary"
-                        onClick={() =>
-                            handleExit(data.analysisID, row.externalID)
-                        }
-                        className={classes.actionButton}
-                    >
-                        {msg("exit")}
-                    </Button>
+                    <ActionButton
+                        baseID={row.externalID}
+                        name="exit"
+                        handler={handleExit}
+                        onClick={onClick}
+                    />
 
-                    <Button
-                        id={id(row.externalID, "button", "saveAndExit")}
-                        variant="contained"
-                        color="primary"
-                        onClick={() =>
-                            handleSaveAndExit(data.analysisID, row.externalID)
-                        }
-                        className={classes.actionButton}
-                    >
-                        {msg("saveAndExit")}
-                    </Button>
+                    <ActionButton
+                        baseID={row.externalID}
+                        name="saveAndExit"
+                        handler={handleExit}
+                        onClick={onClick}
+                    />
 
                     <Popper
                         id={id(row.externalID, "popper")}

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -270,7 +270,9 @@ const CollapsibleTableRow = ({
     handleUploadOutputs,
     handleDownloadInputs,
 }) => {
-    const [open, setOpen] = useState(false);
+    const defaultOpen = false;
+
+    const [open, setOpen] = useState(defaultOpen);
     const classes = useStyles();
 
     const expanderID = id(baseID, "row", "expander");
@@ -311,11 +313,26 @@ const CollapsibleTableRow = ({
                             row={row}
                             collapseID={collapseID}
                             showActions={showActions}
-                            handleExit={handleExit}
-                            handleSaveAndExit={handleSaveAndExit}
-                            handleExtendTimeLimit={handleExtendTimeLimit}
-                            handleUploadOutputs={handleUploadOutputs}
-                            handleDownloadInputs={handleDownloadInputs}
+                            handleExit={(analysisID) => {
+                                setOpen(defaultOpen);
+                                return handleExit(analysisID);
+                            }}
+                            handleSaveAndExit={(analysisID) => {
+                                setOpen(defaultOpen);
+                                return handleSaveAndExit(analysisID);
+                            }}
+                            handleExtendTimeLimit={(analysisID) => {
+                                setOpen(defaultOpen);
+                                return handleExtendTimeLimit(analysisID);
+                            }}
+                            handleUploadOutputs={(analysisID) => {
+                                setOpen(defaultOpen);
+                                return handleUploadOutputs(analysisID);
+                            }}
+                            handleDownloadInputs={(analysisID) => {
+                                setOpen(defaultOpen);
+                                return handleDownloadInputs(analysisID);
+                            }}
                         />
                     </Collapse>
                 </TableCell>
@@ -365,9 +382,11 @@ const CollapsibleTable = ({
     // The first entry in columns should be the expander columns,
     // so default to the second entry for sorting. The field is the
     // actual name of the column.
-    const [orderColumn, setOrderColumn] = useState(columns[1].field);
+    const defaultOrderColumn = columns[1].field;
+    const [orderColumn, setOrderColumn] = useState(defaultOrderColumn);
 
-    const [order, setOrder] = useState("asc");
+    const defaultOrder = "asc";
+    const [order, setOrder] = useState(defaultOrder);
 
     const tableID = id(ids.ROOT);
 
@@ -417,11 +436,31 @@ const CollapsibleTable = ({
                                 startColumn={startColumn}
                                 endColumn={endColumn}
                                 showActions={showActions}
-                                handleExit={handleExit}
-                                handleSaveAndExit={handleSaveAndExit}
-                                handleExtendTimeLimit={handleExtendTimeLimit}
-                                handleDownloadInputs={handleDownloadInputs}
-                                handleUploadOutputs={handleUploadOutputs}
+                                handleExit={(analysisID) => {
+                                    setOrder(defaultOrder);
+                                    setOrderColumn(defaultOrderColumn);
+                                    return handleExit(analysisID);
+                                }}
+                                handleSaveAndExit={(analysisID) => {
+                                    setOrder(defaultOrder);
+                                    setOrderColumn(defaultOrderColumn);
+                                    return handleSaveAndExit(analysisID);
+                                }}
+                                handleExtendTimeLimit={(analysisID) => {
+                                    setOrder(defaultOrder);
+                                    setOrderColumn(defaultOrderColumn);
+                                    return handleExtendTimeLimit(analysisID);
+                                }}
+                                handleDownloadInputs={(analysisID) => {
+                                    setOrder(defaultOrder);
+                                    setOrderColumn(defaultOrderColumn);
+                                    return handleDownloadInputs(analysisID);
+                                }}
+                                handleUploadOutputs={(analysisID) => {
+                                    setOrder(defaultOrder);
+                                    setOrderColumn(defaultOrderColumn);
+                                    return handleUploadOutputs(analysisID);
+                                }}
                             />
                         ))}
                     </TableBody>

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -103,6 +103,11 @@ const useStyles = makeStyles((theme) => ({
             marginRight: theme.spacing(1),
         },
     },
+    paperPopper: {
+        border: "1px solid",
+        padding: theme.spacing(1),
+        backgroundColor: theme.palette.background.paper,
+    },
 }));
 
 const ActionButtonsSkeleton = () => {
@@ -236,12 +241,14 @@ const ActionButtons = ({
                     </Button>
 
                     <Popper
-                        id={id(data.analysisID, "popper")}
+                        id={id(row.externalID, "popper")}
                         open={open}
                         anchorEl={anchorEl}
                         placement="top"
                     >
-                        {popperMessage}
+                        <div className={classes.paperPopper}>
+                            {popperMessage}
+                        </div>
                     </Popper>
                 </>
             )}

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -52,14 +52,14 @@ const ActionButtonsSkeleton = () => {
     );
 };
 
-const ActionButton = ({ baseID, name, handler, onClick }) => {
+const ActionButton = ({ baseID, name, handler, onClick, popperMsgKey }) => {
     const classes = useStyles();
     return (
         <Button
             id={id(baseID, "button", name)}
             variant="contained"
             color="primary"
-            onClick={(event) => onClick(event, handler, name)}
+            onClick={(event) => onClick(event, handler, popperMsgKey)}
             className={classes.actionButton}
         >
             {msg(name)}
@@ -129,6 +129,7 @@ const ActionButtons = ({
                         baseID={row.externalID}
                         name="extendTimeLimit"
                         handler={handleExtendTimeLimit}
+                        popperMsgKey="timeLimitExtended"
                         onClick={onClick}
                     />
 
@@ -136,6 +137,7 @@ const ActionButtons = ({
                         baseID={row.externalID}
                         name="downloadInputs"
                         handler={handleDownloadInputs}
+                        popperMsgKey="downloadInputsCommandSent"
                         onClick={onClick}
                     />
 
@@ -143,6 +145,7 @@ const ActionButtons = ({
                         baseID={row.externalID}
                         name="uploadOutputs"
                         handler={handleUploadOutputs}
+                        popperMsgKey="uploadOutputsCommandSent"
                         onClick={onClick}
                     />
 
@@ -150,6 +153,7 @@ const ActionButtons = ({
                         baseID={row.externalID}
                         name="exit"
                         handler={handleExit}
+                        popperMsgKey="exitCommandSent"
                         onClick={onClick}
                     />
 
@@ -157,6 +161,7 @@ const ActionButtons = ({
                         baseID={row.externalID}
                         name="saveAndExit"
                         handler={handleExit}
+                        popperMsgKey="saveAndExitCommandSent"
                         onClick={onClick}
                     />
 

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -141,6 +141,7 @@ const ActionButtons = ({
         ["async-data", row.externalID],
         asyncData
     );
+
     const isLoading = status === "loading";
     const hasErrored = status === "error";
 
@@ -151,14 +152,17 @@ const ActionButtons = ({
     const onClick = (event, dataFn, msgKey) => {
         let tlErr;
         let tlData;
+
         try {
             tlData = dataFn(data.analysisID, row.externalID);
         } catch (err) {
             tlErr = err;
         }
+
         setAnchorEl(event.currentTarget);
         setPopperMessage(tlErr ? tlErr.message : msg(msgKey));
         setOpen(true);
+
         return tlData;
     };
 
@@ -304,6 +308,7 @@ const ExtendedDataCard = ({
                             >
                                 {column.name && `${column.name}:`}
                             </Typography>
+
                             <Typography
                                 variant="body2"
                                 align="left"
@@ -318,6 +323,7 @@ const ExtendedDataCard = ({
                     );
                 })}
             </div>
+
             {showActions && (
                 <ActionButtons
                     row={row}
@@ -486,6 +492,7 @@ const CollapsibleTable = ({
             >
                 {title}
             </Typography>
+
             <TableContainer classes={{ root: classes.root }}>
                 <Table id={tableID} classes={{ root: classes.table }}>
                     <EnhancedTableHead
@@ -496,6 +503,7 @@ const CollapsibleTable = ({
                         columnData={columns.slice(0, endColumn)}
                         onRequestSort={handleRequestSort}
                     ></EnhancedTableHead>
+
                     <TableBody>
                         {rows?.map((row, index) => (
                             <CollapsibleTableRow

--- a/src/components/vice/admin/table/messages.js
+++ b/src/components/vice/admin/table/messages.js
@@ -10,5 +10,8 @@ export default {
         gidColumn: "GID",
         commandColumn: "Command",
         expandRow: "Expand Row",
+        saveAndExit: "Save and Exit",
+        exit: "Exit",
+        extendTimeLimit: "Extend Time Limit",
     },
 };

--- a/src/components/vice/admin/table/messages.js
+++ b/src/components/vice/admin/table/messages.js
@@ -15,5 +15,8 @@ export default {
         extendTimeLimit: "Extend Time Limit",
         downloadInputs: "Download Inputs",
         uploadOutputs: "Upload Outputs",
+        timeLimitExtended: "Time limit extended by 3 days",
+        downloadInputsCommandSent: "Download inputs command sent",
+        uploadOutputsCommandSent: "Upload outputs command sent",
     },
 };

--- a/src/components/vice/admin/table/messages.js
+++ b/src/components/vice/admin/table/messages.js
@@ -13,5 +13,7 @@ export default {
         saveAndExit: "Save and Exit",
         exit: "Exit",
         extendTimeLimit: "Extend Time Limit",
+        downloadInputs: "Download Inputs",
+        uploadOutputs: "Upload Outputs",
     },
 };

--- a/src/components/vice/admin/table/styles.js
+++ b/src/components/vice/admin/table/styles.js
@@ -1,0 +1,73 @@
+import { makeStyles } from "@material-ui/core";
+
+export default makeStyles((theme) => ({
+    root: {
+        width: "100%",
+    },
+    paper: {
+        width: "100%",
+        marginBottom: theme.spacing(5),
+    },
+    title: {
+        padding: theme.spacing(2),
+    },
+    table: {
+        height: "100%",
+    },
+    extended: {
+        display: "flex",
+        flexWrap: "wrap",
+        flexShrink: 0,
+        flexGrow: 0,
+    },
+    row: {
+        "& > *": {
+            borderBottom: "unset",
+        },
+    },
+    dataEntry: {
+        [theme.breakpoints.up("xs")]: {
+            width: "100%",
+            marginLeft: 0,
+            marginRight: 0,
+            marginTop: theme.spacing(1),
+            marginBottom: theme.spacing(1),
+        },
+        [theme.breakpoints.up("sm")]: {
+            width: 300,
+            marginLeft: 0,
+            marginRight: 0,
+            marginTop: theme.spacing(1),
+            marginBottom: theme.spacing(1),
+        },
+        [theme.breakpoints.up("lg")]: {
+            width: 350,
+            marginTop: theme.spacing(2),
+            marginBottom: theme.spacing(2),
+            marginRight: theme.spacing(2),
+        },
+    },
+    dataEntryLabel: {
+        marginRight: theme.spacing(1),
+        fontWeight: 500,
+    },
+    actionButton: {
+        marginRight: theme.spacing(1),
+        marginBottom: theme.spacing(1),
+        marginTop: theme.spacing(1),
+    },
+    actions: {
+        marginLeft: theme.spacing(11),
+        marginRight: theme.spacing(11),
+
+        [theme.breakpoints.down("sm")]: {
+            marginLeft: theme.spacing(1),
+            marginRight: theme.spacing(1),
+        },
+    },
+    paperPopper: {
+        border: "1px solid",
+        padding: theme.spacing(1),
+        backgroundColor: theme.palette.background.paper,
+    },
+}));

--- a/src/serviceFacades/vice/admin.js
+++ b/src/serviceFacades/vice/admin.js
@@ -1,8 +1,8 @@
 import callApi from "../../common/callApi";
 
-export const asyncData = () =>
+export const asyncData = (_key, externalID) =>
     callApi({
-        endpoint: "/api/admin/vice/async-data",
+        endpoint: `/api/admin/vice/async-data?external-id=${externalID}`,
         method: "GET",
     });
 

--- a/src/serviceFacades/vice/admin.js
+++ b/src/serviceFacades/vice/admin.js
@@ -6,43 +6,43 @@ export const asyncData = () =>
         method: "GET",
     });
 
-export const getTimeLimit = (analysisID) =>
+export const getTimeLimit = ({ analysisID }) =>
     callApi({
         endpoint: `/api/admin/vice/analyses/${analysisID}/time-limit`,
         method: "GET",
     });
 
-export const extendTimeLimit = (analysisID) =>
+export const extendTimeLimit = ({ analysisID }) =>
     callApi({
         endpoint: `/api/admin/vice/analyses/${analysisID}/time-limit`,
         method: "POST",
     });
 
-export const externalID = (analysisID) =>
+export const externalID = ({ analysisID }) =>
     callApi({
         endpoint: `/api/admin/vice/analyses/${analysisID}/external-id`,
         method: "GET",
     });
 
-export const exit = (analysisID) =>
+export const exit = ({ analysisID }) =>
     callApi({
         endpoint: `/api/admin/vice/analyses/${analysisID}/exit`,
         method: "POST",
     });
 
-export const saveAndExit = (analysisID) =>
+export const saveAndExit = ({ analysisID }) =>
     callApi({
         endpoint: `/api/admin/vice/analyses/${analysisID}/save-and-exit`,
         method: "POST",
     });
 
-export const saveOutputFiles = (analysisID) =>
+export const saveOutputFiles = ({ analysisID }) =>
     callApi({
         endpoint: `/api/admin/vice/analyses/${analysisID}/save-output-files`,
         method: "POST",
     });
 
-export const downloadInputFiles = (analysisID) =>
+export const downloadInputFiles = ({ analysisID }) =>
     callApi({
         endpoint: `/api/admin/vice/analyses/${analysisID}/download-input-files`,
         method: "POST",

--- a/src/serviceFacades/vice/admin.js
+++ b/src/serviceFacades/vice/admin.js
@@ -1,5 +1,53 @@
 import callApi from "../../common/callApi";
 
+export const asyncData = () =>
+    callApi({
+        endpoint: "/api/admin/vice/async-data",
+        method: "GET",
+    });
+
+export const getTimeLimit = (analysisID) =>
+    callApi({
+        endpoint: `/api/admin/vice/analyses/${analysisID}/time-limit`,
+        method: "GET",
+    });
+
+export const extendTimeLimit = (analysisID) =>
+    callApi({
+        endpoint: `/api/admin/vice/analyses/${analysisID}/time-limit`,
+        method: "POST",
+    });
+
+export const externalID = (analysisID) =>
+    callApi({
+        endpoint: `/api/admin/vice/analyses/${analysisID}/external-id`,
+        method: "GET",
+    });
+
+export const exit = (analysisID) =>
+    callApi({
+        endpoint: `/api/admin/vice/analyses/${analysisID}/exit`,
+        method: "POST",
+    });
+
+export const saveAndExit = (analysisID) =>
+    callApi({
+        endpoint: `/api/admin/vice/analyses/${analysisID}/save-and-exit`,
+        method: "POST",
+    });
+
+export const saveOutputFiles = (analysisID) =>
+    callApi({
+        endpoint: `/api/admin/vice/analyses/${analysisID}/save-output-files`,
+        method: "POST",
+    });
+
+export const downloadInputFiles = (analysisID) =>
+    callApi({
+        endpoint: `/api/admin/vice/analyses/${analysisID}/download-input-files`,
+        method: "POST",
+    });
+
 export default () =>
     callApi({
         endpoint: "/api/admin/vice/resources",


### PR DESCRIPTION
This PR moves the tables into separate tabs and adds action buttons to each analysis row that allows admins to extend the time limit, trigger file outputs, trigger file inputs, cancel/exit the analysis, and save outputs and exit the analysis.

Each action button should have a popper that provides feedback to the actions. The exit and save and exit actions will collapse the row, delete it, and then cause the set of rows to get refetched.

Additionally, the rows are now retrieved every 10 seconds, so newly launched analyses should show up in the table automatically without a full page refresh.

<img width="1920" alt="Screen Shot 2020-06-18 at 12 57 33 PM" src="https://user-images.githubusercontent.com/49783/85066311-951ff680-b163-11ea-88e6-38f4194279d4.png">

<img width="1918" alt="Screen Shot 2020-06-18 at 12 57 59 PM" src="https://user-images.githubusercontent.com/49783/85066328-9e10c800-b163-11ea-9b01-18941436fdac.png">

<img width="541" alt="Screen Shot 2020-06-18 at 12 58 05 PM" src="https://user-images.githubusercontent.com/49783/85066336-a23ce580-b163-11ea-8261-93fde61072b6.png">

<img width="329" alt="Screen Shot 2020-06-18 at 12 58 31 PM" src="https://user-images.githubusercontent.com/49783/85066349-a79a3000-b163-11ea-8976-677830ca3848.png">

<img width="252" alt="Screen Shot 2020-06-18 at 12 58 53 PM" src="https://user-images.githubusercontent.com/49783/85066362-ae28a780-b163-11ea-9536-2c34461f2364.png">

