### PR TITLE
Refactor VICE admin UI to use react-table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2184,6 +2184,11 @@
                 }
             }
         },
+        "@scarf/scarf": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.0.6.tgz",
+            "integrity": "sha512-y4+DuXrAd1W5UIY3zTcsosi/1GyYT8k5jGnZ/wG7UUHVrU+MHlH4Mp87KK2/lvMW4+H7HVcdB+aJhqywgXksjA=="
+        },
         "@sindresorhus/is": {
             "version": "0.14.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18921,6 +18921,14 @@
                 "refractor": "^2.4.1"
             }
         },
+        "react-table": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.2.1.tgz",
+            "integrity": "sha512-cICU3w5yFWTDluz9yFePziEQXGt3PK5R1Va3InP7qMGnZOKm8kv0GiDMli+VOqE1uM1dBYPb9BEad15up1ac6g==",
+            "requires": {
+                "@scarf/scarf": "^1.0.4"
+            }
+        },
         "react-test-renderer": {
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.13.1.tgz",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
         "react-query": "^2.4.7",
         "react-query-devtools": "^2.1.1",
         "react-select": "^2.4.4",
+        "react-table": "^7.2.1",
         "request": "^2.88.0",
         "request-promise": "^4.2.5",
         "sanitize-html": "^1.24.0",

--- a/src/components/vice/admin/index.js
+++ b/src/components/vice/admin/index.js
@@ -86,12 +86,12 @@ const defineColumn = (
     align = "left",
     enableSorting = true
 ) => ({
-    name,
+    Header: name,
+    accessor: field,
     align,
     enableSorting,
     key: keyID,
     id: keyID,
-    field,
 });
 
 // The column definitions for the table.
@@ -299,7 +299,7 @@ const VICEAdminTabs = ({ data = {} }) => {
                     key={tabPanelID(tabName)}
                 >
                     <CollapsibleTable
-                        rows={analysisRows}
+                        data={analysisRows}
                         columns={columns[tabName]}
                         title={msg(tabName)}
                         showActions={tabName === "analyses"}

--- a/src/components/vice/admin/index.js
+++ b/src/components/vice/admin/index.js
@@ -20,7 +20,7 @@ import getData, {
 } from "../../../serviceFacades/vice/admin";
 
 import RowFilter from "./filter";
-import CollapsibleTable from "./table";
+import CollapsibleTable, { defineColumn, ExpanderColumn } from "./table";
 import JobLimits from "./joblimits";
 
 import ids from "./ids";
@@ -79,24 +79,9 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-const defineColumn = (
-    name,
-    keyID,
-    field,
-    align = "left",
-    enableSorting = true
-) => ({
-    Header: name,
-    accessor: field,
-    align,
-    enableSorting,
-    key: keyID,
-    id: keyID,
-});
-
 // The column definitions for the table.
 const commonColumns = [
-    defineColumn("", COMMON_COLUMNS.EXPAND, "", "left", false),
+    ExpanderColumn,
     defineColumn("Username", COMMON_COLUMNS.USERNAME, "username"),
     defineColumn(
         "Date Created",

--- a/src/components/vice/admin/index.js
+++ b/src/components/vice/admin/index.js
@@ -7,6 +7,8 @@ import { makeStyles } from "@material-ui/styles";
 import {
     build as buildID,
     getMessage as msg,
+    announce,
+    AnnouncerConstants,
     withI18N,
 } from "@cyverse-de/ui-lib";
 
@@ -349,16 +351,10 @@ const VICEAdminTabs = ({ data = {} }) => {
 const VICEAdmin = () => {
     const classes = useStyles();
 
-    const { status, data, error } = useQuery(VICE_ADMIN_QUERY_KEY, getData, {
-        refetchInterval: constants.REFETCH_INTERVAL,
-    });
+    const { status, data, error } = useQuery(VICE_ADMIN_QUERY_KEY, getData);
 
     const isLoading = status === constants.LOADING;
     const hasErrored = status === constants.ERROR;
-
-    if (hasErrored) {
-        console.log(error.message);
-    }
 
     const [filters, setFilters] = useState({});
 
@@ -387,6 +383,15 @@ const VICEAdmin = () => {
         },
         data
     );
+
+    useEffect(() => {
+        if (hasErrored) {
+            announce({
+                text: error.message,
+                variant: AnnouncerConstants.ERROR,
+            });
+        }
+    }, [hasErrored, error]);
 
     return (
         <div id={id(ids.ROOT)} className={classes.root}>

--- a/src/components/vice/admin/index.js
+++ b/src/components/vice/admin/index.js
@@ -77,6 +77,12 @@ const useStyles = makeStyles((theme) => ({
         backgroundColor: theme.palette.primary.main,
         color: theme.palette.primary.contrastText,
     },
+    tabPanelRoot: {
+        paddingLeft: 0,
+        paddingRight: 0,
+        paddingTop: theme.spacing(2),
+        paddingBottom: theme.spacing(2),
+    },
 }));
 
 // The column definitions for the table.
@@ -282,6 +288,7 @@ const VICEAdminTabs = ({ data = {} }) => {
                     value={`${index}`}
                     id={tabPanelID(tabName)}
                     key={tabPanelID(tabName)}
+                    classes={{ root: classes.tabPanelRoot }}
                 >
                     <CollapsibleTable
                         data={analysisRows}

--- a/src/components/vice/admin/table/actionButtons.js
+++ b/src/components/vice/admin/table/actionButtons.js
@@ -54,10 +54,14 @@ export default ({
     const classes = useStyles();
     const [open, setOpen] = useState(false);
 
+    const externalID = row.original.externalID;
+
     const { status, data, error } = useQuery(
-        ["async-data", row.externalID],
+        ["async-data", externalID],
         asyncData
     );
+
+    console.log(row);
 
     const isLoading = status === "loading";
     const hasErrored = status === "error";
@@ -70,8 +74,10 @@ export default ({
         let tlErr;
         let tlData;
 
+        console.log(data);
+
         try {
-            tlData = dataFn(data.analysisID, row.externalID);
+            tlData = dataFn(data.analysisID, externalID);
         } catch (err) {
             tlErr = err;
         }
@@ -80,6 +86,8 @@ export default ({
             ? AnnouncerConstants.ERROR
             : AnnouncerConstants.SUCCESS;
         const text = tlErr ? tlErr.message : msg(msgKey);
+
+        console.log(`text: ${text}    variant: ${variant}`);
 
         announce({ text, variant });
 
@@ -102,7 +110,7 @@ export default ({
             ) : (
                 <>
                     <ActionButton
-                        baseID={row.externalID}
+                        baseID={externalID}
                         name="extendTimeLimit"
                         handler={handleExtendTimeLimit}
                         popperMsgKey="timeLimitExtended"
@@ -110,7 +118,7 @@ export default ({
                     />
 
                     <ActionButton
-                        baseID={row.externalID}
+                        baseID={externalID}
                         name="downloadInputs"
                         handler={handleDownloadInputs}
                         popperMsgKey="downloadInputsCommandSent"
@@ -118,7 +126,7 @@ export default ({
                     />
 
                     <ActionButton
-                        baseID={row.externalID}
+                        baseID={externalID}
                         name="uploadOutputs"
                         handler={handleUploadOutputs}
                         popperMsgKey="uploadOutputsCommandSent"
@@ -126,7 +134,7 @@ export default ({
                     />
 
                     <ActionButton
-                        baseID={row.externalID}
+                        baseID={externalID}
                         name="exit"
                         handler={handleExit}
                         popperMsgKey="exitCommandSent"
@@ -134,7 +142,7 @@ export default ({
                     />
 
                     <ActionButton
-                        baseID={row.externalID}
+                        baseID={externalID}
                         name="saveAndExit"
                         handler={handleExit}
                         popperMsgKey="saveAndExitCommandSent"

--- a/src/components/vice/admin/table/actionButtons.js
+++ b/src/components/vice/admin/table/actionButtons.js
@@ -92,7 +92,7 @@ const ActionButtons = ({
     return (
         <div className={classes.actions}>
             {isLoading ? (
-                <ActionButtonsSkeleton />
+                <ActionButtonsSkeleton id={id(externalID, "skeleton")} />
             ) : (
                 <>
                     <ActionButton

--- a/src/components/vice/admin/table/actionButtons.js
+++ b/src/components/vice/admin/table/actionButtons.js
@@ -1,10 +1,17 @@
 import React, { useState, useEffect } from "react";
 import { useQuery } from "react-query";
 
-import { Button, Popper } from "@material-ui/core";
+import {
+    Button,
+    //    Popper,
+} from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
 
-import { getMessage as msg } from "@cyverse-de/ui-lib";
+import {
+    getMessage as msg,
+    announce,
+    AnnouncerConstants,
+} from "@cyverse-de/ui-lib";
 
 import { id } from "./functions";
 import useStyles from "./styles";
@@ -45,10 +52,7 @@ export default ({
     handleSaveAndExit = (_) => {},
 }) => {
     const classes = useStyles();
-
-    const [anchorEl, setAnchorEl] = useState(null);
     const [open, setOpen] = useState(false);
-    const [popperMessage, setPopperMessage] = useState("");
 
     const { status, data, error } = useQuery(
         ["async-data", row.externalID],
@@ -62,7 +66,7 @@ export default ({
         console.log(error);
     }
 
-    const onClick = (event, dataFn, msgKey) => {
+    const onClick = (_event, dataFn, msgKey) => {
         let tlErr;
         let tlData;
 
@@ -72,9 +76,12 @@ export default ({
             tlErr = err;
         }
 
-        setAnchorEl(event.currentTarget);
-        setPopperMessage(tlErr ? tlErr.message : msg(msgKey));
-        setOpen(true);
+        const variant = tlErr
+            ? AnnouncerConstants.ERROR
+            : AnnouncerConstants.SUCCESS;
+        const text = tlErr ? tlErr.message : msg(msgKey);
+
+        announce({ text, variant });
 
         return tlData;
     };
@@ -133,17 +140,6 @@ export default ({
                         popperMsgKey="saveAndExitCommandSent"
                         onClick={onClick}
                     />
-
-                    <Popper
-                        id={id(row.externalID, "popper")}
-                        open={open}
-                        anchorEl={anchorEl}
-                        placement="top"
-                    >
-                        <div className={classes.paperPopper}>
-                            {popperMessage}
-                        </div>
-                    </Popper>
                 </>
             )}
         </div>

--- a/src/components/vice/admin/table/actionButtons.js
+++ b/src/components/vice/admin/table/actionButtons.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useQuery } from "react-query";
 import { injectIntl } from "react-intl";
 
@@ -25,11 +25,12 @@ const ActionButtonsSkeleton = () => {
     );
 };
 
-const ActionButton = ({ baseID, name, handler, onClick, popperMsgKey }) => {
+const ActionButton = ({ externalID, name, handler, onClick, popperMsgKey }) => {
     const classes = useStyles();
+
     return (
         <Button
-            id={id(baseID, "button", name)}
+            id={id(externalID, "button", name)}
             variant="contained"
             color="primary"
             onClick={(event) => {
@@ -65,10 +66,6 @@ const ActionButtons = ({
     const isLoading = status === "loading";
     const hasErrored = status === "error";
 
-    if (hasErrored) {
-        console.log(error);
-    }
-
     const onClick = (_event, dataFn, msgKey) => {
         let tlErr;
         let tlData;
@@ -89,14 +86,23 @@ const ActionButtons = ({
         return tlData;
     };
 
+    useEffect(() => {
+        if (hasErrored) {
+            announce({
+                text: `Action buttons not available: ${error.message}`,
+                variant: AnnouncerConstants.ERROR,
+            });
+        }
+    }, [hasErrored, error]);
+
     return (
         <div className={classes.actions}>
             {isLoading ? (
                 <ActionButtonsSkeleton id={id(externalID, "skeleton")} />
-            ) : (
+            ) : !hasErrored ? (
                 <>
                     <ActionButton
-                        baseID={externalID}
+                        external={externalID}
                         name="extendTimeLimit"
                         handler={handleExtendTimeLimit}
                         popperMsgKey="timeLimitExtended"
@@ -104,7 +110,7 @@ const ActionButtons = ({
                     />
 
                     <ActionButton
-                        baseID={externalID}
+                        externalID={externalID}
                         name="downloadInputs"
                         handler={handleDownloadInputs}
                         popperMsgKey="downloadInputsCommandSent"
@@ -112,7 +118,7 @@ const ActionButtons = ({
                     />
 
                     <ActionButton
-                        baseID={externalID}
+                        externalID={externalID}
                         name="uploadOutputs"
                         handler={handleUploadOutputs}
                         popperMsgKey="uploadOutputsCommandSent"
@@ -120,7 +126,7 @@ const ActionButtons = ({
                     />
 
                     <ActionButton
-                        baseID={externalID}
+                        externalID={externalID}
                         name="exit"
                         handler={handleExit}
                         popperMsgKey="exitCommandSent"
@@ -128,14 +134,14 @@ const ActionButtons = ({
                     />
 
                     <ActionButton
-                        baseID={externalID}
+                        externalID={externalID}
                         name="saveAndExit"
                         handler={handleExit}
                         popperMsgKey="saveAndExitCommandSent"
                         onClick={onClick}
                     />
                 </>
-            )}
+            ) : null}
         </div>
     );
 };

--- a/src/components/vice/admin/table/actionButtons.js
+++ b/src/components/vice/admin/table/actionButtons.js
@@ -1,20 +1,21 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { useQuery } from "react-query";
+import { injectIntl } from "react-intl";
 
-import {
-    Button,
-    //    Popper,
-} from "@material-ui/core";
+import { Button } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
 
 import {
     getMessage as msg,
+    formatMessage as fmt,
     announce,
     AnnouncerConstants,
+    withI18N,
 } from "@cyverse-de/ui-lib";
 
 import { id } from "./functions";
 import useStyles from "./styles";
+import messages from "./messages";
 
 import { asyncData } from "../../../../serviceFacades/vice/admin";
 
@@ -43,16 +44,16 @@ const ActionButton = ({ baseID, name, handler, onClick, popperMsgKey }) => {
     );
 };
 
-export default ({
+const ActionButtons = ({
     row,
     handleExtendTimeLimit = (_) => {},
     handleDownloadInputs = (_) => {},
     handleUploadOutputs = (_) => {},
     handleExit = (_) => {},
     handleSaveAndExit = (_) => {},
+    intl,
 }) => {
     const classes = useStyles();
-    const [open, setOpen] = useState(false);
 
     const externalID = row.original.externalID;
 
@@ -60,8 +61,6 @@ export default ({
         ["async-data", externalID],
         asyncData
     );
-
-    console.log(row);
 
     const isLoading = status === "loading";
     const hasErrored = status === "error";
@@ -74,8 +73,6 @@ export default ({
         let tlErr;
         let tlData;
 
-        console.log(data);
-
         try {
             tlData = dataFn(data.analysisID, externalID);
         } catch (err) {
@@ -85,23 +82,12 @@ export default ({
         const variant = tlErr
             ? AnnouncerConstants.ERROR
             : AnnouncerConstants.SUCCESS;
-        const text = tlErr ? tlErr.message : msg(msgKey);
-
-        console.log(`text: ${text}    variant: ${variant}`);
+        const text = tlErr ? tlErr.message : fmt(intl, msgKey);
 
         announce({ text, variant });
 
         return tlData;
     };
-
-    useEffect(() => {
-        const timerID = setInterval(() => {
-            if (open) {
-                setOpen(false);
-            }
-        }, 3000);
-        return () => clearInterval(timerID);
-    });
 
     return (
         <div className={classes.actions}>
@@ -153,3 +139,5 @@ export default ({
         </div>
     );
 };
+
+export default withI18N(injectIntl(ActionButtons), messages);

--- a/src/components/vice/admin/table/actionButtons.js
+++ b/src/components/vice/admin/table/actionButtons.js
@@ -1,0 +1,151 @@
+import React, { useState, useEffect } from "react";
+import { useQuery } from "react-query";
+
+import { Button, Popper } from "@material-ui/core";
+import { Skeleton } from "@material-ui/lab";
+
+import { getMessage as msg } from "@cyverse-de/ui-lib";
+
+import { id } from "./functions";
+import useStyles from "./styles";
+
+import { asyncData } from "../../../../serviceFacades/vice/admin";
+
+const ActionButtonsSkeleton = () => {
+    return (
+        <Skeleton variant="rect" animation="wave" height={75} width="100%" />
+    );
+};
+
+const ActionButton = ({ baseID, name, handler, onClick, popperMsgKey }) => {
+    const classes = useStyles();
+    return (
+        <Button
+            id={id(baseID, "button", name)}
+            variant="contained"
+            color="primary"
+            onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                return onClick(event, handler, popperMsgKey);
+            }}
+            className={classes.actionButton}
+        >
+            {msg(name)}
+        </Button>
+    );
+};
+
+export default ({
+    row,
+    handleExtendTimeLimit = (_) => {},
+    handleDownloadInputs = (_) => {},
+    handleUploadOutputs = (_) => {},
+    handleExit = (_) => {},
+    handleSaveAndExit = (_) => {},
+}) => {
+    const classes = useStyles();
+
+    const [anchorEl, setAnchorEl] = useState(null);
+    const [open, setOpen] = useState(false);
+    const [popperMessage, setPopperMessage] = useState("");
+
+    const { status, data, error } = useQuery(
+        ["async-data", row.externalID],
+        asyncData
+    );
+
+    const isLoading = status === "loading";
+    const hasErrored = status === "error";
+
+    if (hasErrored) {
+        console.log(error);
+    }
+
+    const onClick = (event, dataFn, msgKey) => {
+        let tlErr;
+        let tlData;
+
+        try {
+            tlData = dataFn(data.analysisID, row.externalID);
+        } catch (err) {
+            tlErr = err;
+        }
+
+        setAnchorEl(event.currentTarget);
+        setPopperMessage(tlErr ? tlErr.message : msg(msgKey));
+        setOpen(true);
+
+        return tlData;
+    };
+
+    useEffect(() => {
+        const timerID = setInterval(() => {
+            if (open) {
+                setOpen(false);
+            }
+        }, 3000);
+        return () => clearInterval(timerID);
+    });
+
+    return (
+        <div className={classes.actions}>
+            {isLoading ? (
+                <ActionButtonsSkeleton />
+            ) : (
+                <>
+                    <ActionButton
+                        baseID={row.externalID}
+                        name="extendTimeLimit"
+                        handler={handleExtendTimeLimit}
+                        popperMsgKey="timeLimitExtended"
+                        onClick={onClick}
+                    />
+
+                    <ActionButton
+                        baseID={row.externalID}
+                        name="downloadInputs"
+                        handler={handleDownloadInputs}
+                        popperMsgKey="downloadInputsCommandSent"
+                        onClick={onClick}
+                    />
+
+                    <ActionButton
+                        baseID={row.externalID}
+                        name="uploadOutputs"
+                        handler={handleUploadOutputs}
+                        popperMsgKey="uploadOutputsCommandSent"
+                        onClick={onClick}
+                    />
+
+                    <ActionButton
+                        baseID={row.externalID}
+                        name="exit"
+                        handler={handleExit}
+                        popperMsgKey="exitCommandSent"
+                        onClick={onClick}
+                    />
+
+                    <ActionButton
+                        baseID={row.externalID}
+                        name="saveAndExit"
+                        handler={handleExit}
+                        popperMsgKey="saveAndExitCommandSent"
+                        onClick={onClick}
+                    />
+
+                    <Popper
+                        id={id(row.externalID, "popper")}
+                        open={open}
+                        anchorEl={anchorEl}
+                        placement="top"
+                    >
+                        <div className={classes.paperPopper}>
+                            {popperMessage}
+                        </div>
+                    </Popper>
+                </>
+            )}
+        </div>
+    );
+};

--- a/src/components/vice/admin/table/functions.js
+++ b/src/components/vice/admin/table/functions.js
@@ -1,0 +1,6 @@
+// Constructs an ID for an element.
+import { build as buildID } from "@cyverse-de/ui-lib";
+
+import ids from "./ids";
+
+export const id = (...names) => buildID(ids.BASE, ...names);

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -125,13 +125,15 @@ const CollapsibleTableRow = ({
                     style={{
                         paddingBottom: 0,
                         paddingTop: 0,
+                        width: "10%",
                     }}
-                    colSpan={1}
+                    colSpan={row.isExpanded ? 1 : 0}
                 ></TableCell>
                 <TableCell
                     style={{
                         paddingBottom: 0,
                         paddingTop: 0,
+                        width: "90%",
                     }}
                     colSpan={visibleColumns.length}
                 >

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -257,7 +257,7 @@ const CollapsibleTableRow = ({
     startColumn,
     endColumn,
     showActions,
-    onSelection = (_row) => {},
+    onSelection = (_row, selected) => {},
     handleExit,
     handleSaveAndExit,
     handleExtendTimeLimit,
@@ -274,8 +274,10 @@ const CollapsibleTableRow = ({
     const handleClick = (event) => {
         event.preventDefault();
         event.stopPropagation();
-        setSelected(!selected);
-        return onSelection(row);
+
+        const newValue = !selected;
+        setSelected(newValue);
+        return onSelection(row, newValue);
     };
 
     const expanderID = id(baseID, "row", "expander");
@@ -371,6 +373,10 @@ const CollapsibleTable = ({
     const isLarge = useMediaQuery(theme.breakpoints.up("lg"));
     const isXL = useMediaQuery(theme.breakpoints.up("xl"));
 
+    const [selectedRows, setSelectedRows] = useState([]);
+
+    console.log(selectedRows);
+
     let startColumn;
     let endColumn;
 
@@ -451,6 +457,19 @@ const CollapsibleTable = ({
                                 startColumn={startColumn}
                                 endColumn={endColumn}
                                 showActions={showActions}
+                                onSelection={(row, selected) => {
+                                    selected
+                                        ? setSelectedRows([
+                                              row.externalID,
+                                              ...selectedRows,
+                                          ])
+                                        : setSelectedRows(
+                                              selectedRows.filter(
+                                                  (value) =>
+                                                      value !== row.externalID
+                                              )
+                                          );
+                                }}
                                 handleExit={handleExit}
                                 handleSaveAndExit={handleSaveAndExit}
                                 handleExtendTimeLimit={handleExtendTimeLimit}

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -1,7 +1,6 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 
 import {
-    build as buildID,
     withI18N,
     EnhancedTableHead,
     getMessage as msg,
@@ -20,166 +19,16 @@ import {
     IconButton,
     useTheme,
     useMediaQuery,
-    Button,
-    Popper,
 } from "@material-ui/core";
-
-import { Skeleton } from "@material-ui/lab";
 
 import { KeyboardArrowUp, KeyboardArrowDown } from "@material-ui/icons";
 
-import { useQuery } from "react-query";
-
-import {
-    asyncData,
-    ASYNC_DATA_QUERY_KEY,
-} from "../../../../serviceFacades/vice/admin";
+import ActionButtons from "./actionButtons";
 
 import messages from "./messages";
 import ids from "./ids";
+import { id } from "./functions";
 import useStyles from "./styles";
-
-// Constructs an ID for an element.
-const id = (...names) => buildID(ids.BASE, ...names);
-
-const ActionButtonsSkeleton = () => {
-    return (
-        <Skeleton variant="rect" animation="wave" height={75} width="100%" />
-    );
-};
-
-const ActionButton = ({ baseID, name, handler, onClick, popperMsgKey }) => {
-    const classes = useStyles();
-    return (
-        <Button
-            id={id(baseID, "button", name)}
-            variant="contained"
-            color="primary"
-            onClick={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-                return onClick(event, handler, popperMsgKey);
-            }}
-            className={classes.actionButton}
-        >
-            {msg(name)}
-        </Button>
-    );
-};
-
-const ActionButtons = ({
-    row,
-    handleExtendTimeLimit = (_) => {},
-    handleDownloadInputs = (_) => {},
-    handleUploadOutputs = (_) => {},
-    handleExit = (_) => {},
-    handleSaveAndExit = (_) => {},
-}) => {
-    const classes = useStyles();
-
-    const [anchorEl, setAnchorEl] = useState(null);
-    const [open, setOpen] = useState(false);
-    const [popperMessage, setPopperMessage] = useState("");
-
-    const { status, data, error } = useQuery(
-        [ASYNC_DATA_QUERY_KEY, row.externalID],
-        asyncData
-    );
-
-    const isLoading = status === "loading";
-    const hasErrored = status === "error";
-
-    if (hasErrored) {
-        console.log(error);
-    }
-
-    const onClick = (event, dataFn, msgKey) => {
-        let tlErr;
-        let tlData;
-
-        try {
-            tlData = dataFn(data.analysisID, row.externalID);
-        } catch (err) {
-            tlErr = err;
-        }
-
-        setAnchorEl(event.currentTarget);
-        setPopperMessage(tlErr ? tlErr.message : msg(msgKey));
-        setOpen(true);
-
-        return tlData;
-    };
-
-    useEffect(() => {
-        const timerID = setInterval(() => {
-            if (open) {
-                setOpen(false);
-            }
-        }, 3000);
-        return () => clearInterval(timerID);
-    });
-
-    return (
-        <div className={classes.actions}>
-            {isLoading ? (
-                <ActionButtonsSkeleton />
-            ) : (
-                <>
-                    <ActionButton
-                        baseID={row.externalID}
-                        name="extendTimeLimit"
-                        handler={handleExtendTimeLimit}
-                        popperMsgKey="timeLimitExtended"
-                        onClick={onClick}
-                    />
-
-                    <ActionButton
-                        baseID={row.externalID}
-                        name="downloadInputs"
-                        handler={handleDownloadInputs}
-                        popperMsgKey="downloadInputsCommandSent"
-                        onClick={onClick}
-                    />
-
-                    <ActionButton
-                        baseID={row.externalID}
-                        name="uploadOutputs"
-                        handler={handleUploadOutputs}
-                        popperMsgKey="uploadOutputsCommandSent"
-                        onClick={onClick}
-                    />
-
-                    <ActionButton
-                        baseID={row.externalID}
-                        name="exit"
-                        handler={handleExit}
-                        popperMsgKey="exitCommandSent"
-                        onClick={onClick}
-                    />
-
-                    <ActionButton
-                        baseID={row.externalID}
-                        name="saveAndExit"
-                        handler={handleExit}
-                        popperMsgKey="saveAndExitCommandSent"
-                        onClick={onClick}
-                    />
-
-                    <Popper
-                        id={id(row.externalID, "popper")}
-                        open={open}
-                        anchorEl={anchorEl}
-                        placement="top"
-                    >
-                        <div className={classes.paperPopper}>
-                            {popperMessage}
-                        </div>
-                    </Popper>
-                </>
-            )}
-        </div>
-    );
-};
 
 const ExtendedDataCard = ({
     columns,

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -16,12 +16,13 @@ import {
     useTheme,
     useMediaQuery,
     IconButton,
+    TableSortLabel,
 } from "@material-ui/core";
 
 // import { Skeleton } from "@material-ui/lab";
 import { KeyboardArrowUp, KeyboardArrowDown } from "@material-ui/icons";
 
-import { useTable, useExpanded } from "react-table";
+import { useTable, useExpanded, useSortBy } from "react-table";
 
 import ActionButtons from "./actionButtons";
 
@@ -225,6 +226,7 @@ const CollapsibleTable = ({
             columns,
             data,
         },
+        useSortBy,
         useExpanded
     );
 
@@ -282,8 +284,21 @@ const CollapsibleTable = ({
                         {headerGroups.map((headerGroup) => (
                             <TableRow {...headerGroup.getHeaderGroupProps()}>
                                 {headerGroup.headers.map((column) => (
-                                    <TableCell {...column.getHeaderProps()}>
-                                        {column.render("Header")}
+                                    <TableCell
+                                        {...column.getHeaderProps(
+                                            column.getSortByToggleProps()
+                                        )}
+                                    >
+                                        <TableSortLabel
+                                            active={column.isSorted}
+                                            direction={
+                                                column.isSortedDesc
+                                                    ? "desc"
+                                                    : "asc"
+                                            }
+                                        >
+                                            {column.render("Header")}
+                                        </TableSortLabel>
                                     </TableCell>
                                 ))}
                             </TableRow>

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -55,7 +55,11 @@ const ActionButton = ({ baseID, name, handler, onClick, popperMsgKey }) => {
             id={id(baseID, "button", name)}
             variant="contained"
             color="primary"
-            onClick={(event) => onClick(event, handler, popperMsgKey)}
+            onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                return onClick(event, handler, popperMsgKey);
+            }}
             className={classes.actionButton}
         >
             {msg(name)}
@@ -253,6 +257,7 @@ const CollapsibleTableRow = ({
     startColumn,
     endColumn,
     showActions,
+    onSelection = (_row) => {},
     handleExit,
     handleSaveAndExit,
     handleExtendTimeLimit,
@@ -264,18 +269,37 @@ const CollapsibleTableRow = ({
     const [open, setOpen] = useState(defaultOpen);
     const classes = useStyles();
 
+    const [selected, setSelected] = useState(false);
+
+    const handleClick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        setSelected(!selected);
+        return onSelection(row);
+    };
+
     const expanderID = id(baseID, "row", "expander");
     const rowID = id(baseID, "row");
     const collapseID = id(rowID, "collapse");
 
     return (
         <>
-            <TableRow className={classes.row} key={rowID} id={rowID}>
+            <TableRow
+                className={classes.row}
+                key={rowID}
+                id={rowID}
+                selected={selected}
+                onClick={handleClick}
+            >
                 <TableCell key={expanderID} id={expanderID}>
                     <IconButton
                         aria-label={msg("expandRow")}
                         size="small"
-                        onClick={() => setOpen(!open)}
+                        onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            setOpen(!open);
+                        }}
                     >
                         {open ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
                     </IconButton>
@@ -291,7 +315,12 @@ const CollapsibleTableRow = ({
                 })}
             </TableRow>
 
-            <TableRow key={collapseID} id={collapseID}>
+            <TableRow
+                key={collapseID}
+                id={collapseID}
+                selected={selected}
+                onClick={handleClick}
+            >
                 <TableCell
                     style={{ paddingBottom: 0, paddingTop: 0, width: "90%" }}
                     colSpan={endColumn}

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -4,6 +4,7 @@ import { withI18N, getMessage as msg } from "@cyverse-de/ui-lib";
 
 import {
     Box,
+    Collapse,
     Table,
     TableBody,
     TableCell,
@@ -51,12 +52,19 @@ const ExtendedDataCard = ({
         return columnIDs.includes(row.column.id);
     });
 
+    const newID = (value) => id(ids.BASE, collapseID, "cell", value);
+
     return (
         <Box>
             <div className={classes.extended} {...row.getRowProps()}>
-                {filteredCells.map((cell) => {
+                {filteredCells.map((cell, index) => {
+                    const thisID = newID(index);
                     return (
-                        <div className={classes.dataEntry}>
+                        <div
+                            className={classes.dataEntry}
+                            key={thisID}
+                            id={thisID}
+                        >
                             {cell.render("Header")}
                             {cell.render("Cell")}
                         </div>
@@ -112,22 +120,22 @@ const CollapsibleTableRow = ({
                 })}
             </TableRow>
 
-            {row.isExpanded ? (
-                <TableRow key={collapseID} id={collapseID}>
-                    <TableCell
-                        style={{
-                            paddingBottom: 0,
-                            paddingTop: 0,
-                        }}
-                        colSpan={1}
-                    ></TableCell>
-                    <TableCell
-                        style={{
-                            paddingBottom: 0,
-                            paddingTop: 0,
-                        }}
-                        colSpan={visibleColumns.length}
-                    >
+            <TableRow key={collapseID} id={collapseID}>
+                <TableCell
+                    style={{
+                        paddingBottom: 0,
+                        paddingTop: 0,
+                    }}
+                    colSpan={1}
+                ></TableCell>
+                <TableCell
+                    style={{
+                        paddingBottom: 0,
+                        paddingTop: 0,
+                    }}
+                    colSpan={visibleColumns.length}
+                >
+                    <Collapse in={row.isExpanded} timeout="auto" unmountOnExit>
                         <ExtendedDataCard
                             columns={hiddenColumns}
                             row={row}
@@ -139,9 +147,9 @@ const CollapsibleTableRow = ({
                             handleUploadOutputs={handleUploadOutputs}
                             handleDownloadInputs={handleDownloadInputs}
                         />
-                    </TableCell>
-                </TableRow>
-            ) : null}
+                    </Collapse>
+                </TableCell>
+            </TableRow>
         </>
     );
 };

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -210,6 +210,7 @@ const CollapsibleTable = ({
     const isLarge = useMediaQuery(theme.breakpoints.up("lg"));
     const isMedium = useMediaQuery(theme.breakpoints.up("md"));
     const isSmall = useMediaQuery(theme.breakpoints.up("sm"));
+    const isExtraSmall = useMediaQuery(theme.breakpoints.up("xs"));
 
     const {
         getTableProps,
@@ -239,6 +240,8 @@ const CollapsibleTable = ({
         } else if (isMedium) {
             numCols = 4;
         } else if (isSmall) {
+            numCols = 3;
+        } else if (isExtraSmall) {
             numCols = 2;
         } else {
             numCols = 7;
@@ -247,7 +250,15 @@ const CollapsibleTable = ({
         const hidden = columns.slice(numCols);
         setHiddenColumnObjs(hidden);
         setHiddenColumns(hidden.map((column) => column.id));
-    }, [setHiddenColumns, columns, isXL, isLarge, isMedium, isSmall]);
+    }, [
+        setHiddenColumns,
+        columns,
+        isXL,
+        isLarge,
+        isMedium,
+        isSmall,
+        isExtraSmall,
+    ]);
 
     const tableID = id(ids.ROOT);
 

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 import {
     withI18N,
@@ -17,17 +17,11 @@ import {
     TableRow,
     Typography,
     //    IconButton,
-    //    useTheme,
-    //    useMediaQuery,
+    useTheme,
+    useMediaQuery,
 } from "@material-ui/core";
 
-import {
-    useGlobalFilter,
-    useSortBy,
-    useExpanded,
-    useRowSelect,
-    useTable,
-} from "react-table";
+import { useTable } from "react-table";
 
 //import ActionButtons from "./actionButtons";
 
@@ -48,29 +42,44 @@ const CollapsibleTable = ({
     // handleUploadOutputs,
 }) => {
     const classes = useStyles();
-    //const theme = useTheme();
+    const theme = useTheme();
+
+    const isXL = useMediaQuery(theme.breakpoints.up("xl"));
+    const isSmall = useMediaQuery(theme.breakpoints.up("xs"));
+    const isMedium = useMediaQuery(theme.breakpoints.up("sm"));
+    const isLarge = useMediaQuery(theme.breakpoints.up("lg"));
+
+    let numVisibleColumns;
+
+    if (isXL) {
+        numVisibleColumns = 7;
+    } else if (isLarge) {
+        numVisibleColumns = 6;
+    } else if (isMedium) {
+        numVisibleColumns = 4;
+    } else if (isSmall) {
+        numVisibleColumns = 2;
+    } else {
+        numVisibleColumns = 7;
+    }
 
     const {
         getTableProps,
         getTableBodyProps,
         headerGroups,
         prepareRow,
-        // preGlobalFilteredRows,
-        // setGlobalFilter,
         rows,
-        // state: {
-        //     selectedRowIds, globalFilter, expanded,
-        // },
-    } = useTable(
-        {
-            columns,
-            data,
-        },
-        useGlobalFilter,
-        useSortBy,
-        useRowSelect,
-        useExpanded
-    );
+        setHiddenColumns,
+    } = useTable({
+        columns,
+        data,
+    });
+
+    useEffect(() => {
+        setHiddenColumns(
+            columns.slice(numVisibleColumns).map((column) => column.id)
+        );
+    }, [setHiddenColumns, columns, numVisibleColumns]);
 
     const tableID = id(ids.ROOT);
 

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -167,6 +167,7 @@ export const ExpanderColumn = {
             </IconButton>
         </span>
     ),
+    disableSortBy: true,
 };
 
 export const defineColumn = (
@@ -188,7 +189,7 @@ export const defineColumn = (
     ),
     accessor: field,
     align,
-    enableSorting,
+    disableSortBy: !enableSorting,
     key: keyID,
     id: keyID,
 });
@@ -289,16 +290,20 @@ const CollapsibleTable = ({
                                             column.getSortByToggleProps()
                                         )}
                                     >
-                                        <TableSortLabel
-                                            active={column.isSorted}
-                                            direction={
-                                                column.isSortedDesc
-                                                    ? "desc"
-                                                    : "asc"
-                                            }
-                                        >
-                                            {column.render("Header")}
-                                        </TableSortLabel>
+                                        {column.canSort ? (
+                                            <TableSortLabel
+                                                active={column.isSorted}
+                                                direction={
+                                                    column.isSortedDesc
+                                                        ? "desc"
+                                                        : "asc"
+                                                }
+                                            >
+                                                {column.render("Header")}
+                                            </TableSortLabel>
+                                        ) : (
+                                            column.render("Header")
+                                        )}
                                     </TableCell>
                                 ))}
                             </TableRow>

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -1,279 +1,78 @@
-import React, { useState } from "react";
+import React from "react";
 
 import {
     withI18N,
-    EnhancedTableHead,
-    getMessage as msg,
+    //    getMessage as msg,
 } from "@cyverse-de/ui-lib";
 
 import {
-    Box,
-    Collapse,
+    //    Box,
+    //    Collapse,
     Table,
     TableBody,
     TableCell,
     TableContainer,
+    TableHead,
     Paper,
     TableRow,
     Typography,
-    IconButton,
-    useTheme,
-    useMediaQuery,
+    //    IconButton,
+    //    useTheme,
+    //    useMediaQuery,
 } from "@material-ui/core";
 
-import { KeyboardArrowUp, KeyboardArrowDown } from "@material-ui/icons";
+import {
+    useGlobalFilter,
+    useSortBy,
+    useExpanded,
+    useRowSelect,
+    useTable,
+} from "react-table";
 
-import ActionButtons from "./actionButtons";
+//import ActionButtons from "./actionButtons";
 
 import messages from "./messages";
 import ids from "./ids";
 import { id } from "./functions";
 import useStyles from "./styles";
 
-const ExtendedDataCard = ({
-    columns,
-    row,
-    collapseID,
-    showActions = false,
-    handleExit,
-    handleSaveAndExit,
-    handleExtendTimeLimit,
-    handleUploadOutputs,
-    handleDownloadInputs,
-}) => {
-    const classes = useStyles();
-    const theme = useTheme();
-    const isMedium = useMediaQuery(theme.breakpoints.down("md"));
-
-    let display = "inline";
-    if (isMedium) {
-        display = "block";
-    }
-
-    return (
-        <Box margin={1}>
-            <div className={`${classes.extended} ${classes.actions}`}>
-                {columns.map((column) => {
-                    return (
-                        <div
-                            className={classes.dataEntry}
-                            id={id(collapseID, column.field)}
-                            key={id(collapseID, column.field)}
-                        >
-                            <Typography
-                                variant="body2"
-                                align="left"
-                                display={display}
-                                id={id(collapseID, column.field, "label")}
-                                classes={{ root: classes.dataEntryLabel }}
-                            >
-                                {column.name && `${column.name}:`}
-                            </Typography>
-
-                            <Typography
-                                variant="body2"
-                                align="left"
-                                display={display}
-                                id={id(collapseID, column.field, "value")}
-                            >
-                                {row &&
-                                    row.hasOwnProperty(column.field) &&
-                                    row[column.field]}
-                            </Typography>
-                        </div>
-                    );
-                })}
-            </div>
-
-            {showActions && (
-                <ActionButtons
-                    row={row}
-                    handleDownloadInputs={handleDownloadInputs}
-                    handleUploadOutputs={handleUploadOutputs}
-                    handleExtendTimeLimit={handleExtendTimeLimit}
-                    handleExit={handleExit}
-                    handleSaveAndExit={handleSaveAndExit}
-                />
-            )}
-        </Box>
-    );
-};
-
-const CollapsibleTableRow = ({
-    row,
-    columns,
-    baseID,
-    startColumn,
-    endColumn,
-    showActions,
-    onSelection = (_row, selected) => {},
-    handleExit,
-    handleSaveAndExit,
-    handleExtendTimeLimit,
-    handleUploadOutputs,
-    handleDownloadInputs,
-}) => {
-    const defaultOpen = false;
-
-    const [open, setOpen] = useState(defaultOpen);
-    const classes = useStyles();
-
-    const [selected, setSelected] = useState(false);
-
-    const handleClick = (event) => {
-        event.preventDefault();
-        event.stopPropagation();
-
-        const newValue = !selected;
-        setSelected(newValue);
-        return onSelection(row, newValue);
-    };
-
-    const expanderID = id(baseID, "row", "expander");
-    const rowID = id(baseID, "row");
-    const collapseID = id(rowID, "collapse");
-
-    return (
-        <>
-            <TableRow
-                className={classes.row}
-                key={rowID}
-                id={rowID}
-                selected={selected}
-                onClick={handleClick}
-            >
-                <TableCell key={expanderID} id={expanderID}>
-                    <IconButton
-                        aria-label={msg("expandRow")}
-                        size="small"
-                        onClick={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            setOpen(!open);
-                        }}
-                    >
-                        {open ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
-                    </IconButton>
-                </TableCell>
-
-                {columns.slice(startColumn, endColumn).map((column) => {
-                    const fieldID = id(rowID, column.field);
-                    return (
-                        <TableCell key={fieldID} id={fieldID}>
-                            {row[column.field]}
-                        </TableCell>
-                    );
-                })}
-            </TableRow>
-
-            <TableRow
-                key={collapseID}
-                id={collapseID}
-                selected={selected}
-                onClick={handleClick}
-            >
-                <TableCell
-                    style={{ paddingBottom: 0, paddingTop: 0, width: "90%" }}
-                    colSpan={endColumn}
-                >
-                    <Collapse in={open} timeout="auto" unmountOnExit>
-                        <ExtendedDataCard
-                            columns={columns.slice(endColumn)}
-                            row={row}
-                            collapseID={collapseID}
-                            showActions={showActions}
-                            handleExit={(analysisID, externalID) => {
-                                setOpen(defaultOpen);
-                                return handleExit(analysisID, externalID);
-                            }}
-                            handleSaveAndExit={(analysisID, externalID) => {
-                                setOpen(defaultOpen);
-                                return handleSaveAndExit(
-                                    analysisID,
-                                    externalID
-                                );
-                            }}
-                            handleExtendTimeLimit={handleExtendTimeLimit}
-                            handleUploadOutputs={handleUploadOutputs}
-                            handleDownloadInputs={handleDownloadInputs}
-                        />
-                    </Collapse>
-                </TableCell>
-            </TableRow>
-        </>
-    );
-};
-
 const CollapsibleTable = ({
     columns,
-    rows,
+    data,
     title,
-    showActions = false,
-    handleExit,
-    handleSaveAndExit,
-    handleExtendTimeLimit,
-    handleDownloadInputs,
-    handleUploadOutputs,
+    // showActions = false,
+    // handleExit,
+    // handleSaveAndExit,
+    // handleExtendTimeLimit,
+    // handleDownloadInputs,
+    // handleUploadOutputs,
 }) => {
     const classes = useStyles();
-    const theme = useTheme();
-    const isSmall = useMediaQuery(theme.breakpoints.up("xs"));
-    const isMedium = useMediaQuery(theme.breakpoints.up("sm"));
-    const isLarge = useMediaQuery(theme.breakpoints.up("lg"));
-    const isXL = useMediaQuery(theme.breakpoints.up("xl"));
+    //const theme = useTheme();
 
-    const [selectedRows, setSelectedRows] = useState([]);
-
-    console.log(selectedRows);
-
-    let startColumn;
-    let endColumn;
-
-    if (isXL) {
-        startColumn = 1;
-        endColumn = 7;
-    } else if (isLarge) {
-        startColumn = 1;
-        endColumn = 6;
-    } else if (isMedium) {
-        startColumn = 1;
-        endColumn = 4;
-    } else if (isSmall) {
-        startColumn = 1;
-        endColumn = 2;
-    } else {
-        startColumn = 1;
-        endColumn = 7;
-    }
-
-    // The first entry in columns should be the expander columns,
-    // so default to the second entry for sorting. The field is the
-    // actual name of the column.
-    const defaultOrderColumn = columns[1].field;
-    const [orderColumn, setOrderColumn] = useState(defaultOrderColumn);
-
-    const defaultOrder = "asc";
-    const [order, setOrder] = useState(defaultOrder);
+    const {
+        getTableProps,
+        getTableBodyProps,
+        headerGroups,
+        prepareRow,
+        // preGlobalFilteredRows,
+        // setGlobalFilter,
+        rows,
+        // state: {
+        //     selectedRowIds, globalFilter, expanded,
+        // },
+    } = useTable(
+        {
+            columns,
+            data,
+        },
+        useGlobalFilter,
+        useSortBy,
+        useRowSelect,
+        useExpanded
+    );
 
     const tableID = id(ids.ROOT);
-
-    const sortAscending = (one, two) =>
-        one[orderColumn].localeCompare(two[orderColumn]) * -1;
-
-    const sortDescending = (one, two) =>
-        one[orderColumn].localeCompare(two[orderColumn]);
-
-    const handleRequestSort = (_event, columnName) => {
-        const isAscending = orderColumn === columnName && order === "asc";
-        setOrder(isAscending ? "desc" : "asc");
-        setOrderColumn(columnName);
-
-        if (isAscending) {
-            rows.sort(sortAscending);
-        } else {
-            rows.sort(sortDescending);
-        }
-    };
 
     return (
         <Paper className={classes.paper}>
@@ -286,46 +85,42 @@ const CollapsibleTable = ({
             </Typography>
 
             <TableContainer classes={{ root: classes.root }}>
-                <Table id={tableID} classes={{ root: classes.table }}>
-                    <EnhancedTableHead
-                        selectable={false}
-                        baseId={tableID}
-                        order={order}
-                        orderBy={orderColumn}
-                        columnData={columns.slice(0, endColumn)}
-                        onRequestSort={handleRequestSort}
-                    ></EnhancedTableHead>
-
-                    <TableBody>
-                        {rows?.map((row, index) => (
-                            <CollapsibleTableRow
-                                row={row}
-                                key={row.externalID}
-                                baseID={row.externalID}
-                                columns={columns}
-                                startColumn={startColumn}
-                                endColumn={endColumn}
-                                showActions={showActions}
-                                onSelection={(row, selected) => {
-                                    selected
-                                        ? setSelectedRows([
-                                              row.externalID,
-                                              ...selectedRows,
-                                          ])
-                                        : setSelectedRows(
-                                              selectedRows.filter(
-                                                  (value) =>
-                                                      value !== row.externalID
-                                              )
-                                          );
-                                }}
-                                handleExit={handleExit}
-                                handleSaveAndExit={handleSaveAndExit}
-                                handleExtendTimeLimit={handleExtendTimeLimit}
-                                handleDownloadInputs={handleDownloadInputs}
-                                handleUploadOutputs={handleUploadOutputs}
-                            />
+                <Table
+                    id={tableID}
+                    classes={{ root: classes.table }}
+                    {...getTableProps()}
+                >
+                    <TableHead>
+                        {headerGroups.map((headerGroup) => (
+                            <tr {...headerGroup.getHeaderGroupProps()}>
+                                {headerGroup.headers.map((column) => (
+                                    <th {...column.getHeaderProps()}>
+                                        {column.render("Header")}
+                                    </th>
+                                ))}
+                            </tr>
                         ))}
+                    </TableHead>
+
+                    <TableBody {...getTableBodyProps()}>
+                        {rows?.map((row, index) => {
+                            prepareRow(row);
+
+                            return (
+                                <TableRow
+                                    className={classes.row}
+                                    {...row.getRowProps()}
+                                >
+                                    {row.cells.map((cell) => {
+                                        return (
+                                            <TableCell {...cell.getCellProps()}>
+                                                {cell.render("Cell")}
+                                            </TableCell>
+                                        );
+                                    })}
+                                </TableRow>
+                            );
+                        })}
                     </TableBody>
                 </Table>
             </TableContainer>

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -19,7 +19,6 @@ import {
     TableSortLabel,
 } from "@material-ui/core";
 
-// import { Skeleton } from "@material-ui/lab";
 import { KeyboardArrowUp, KeyboardArrowDown } from "@material-ui/icons";
 
 import { useTable, useExpanded, useSortBy } from "react-table";

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -98,6 +98,7 @@ const CollapsibleTableRow = ({
     handleExtendTimeLimit,
     handleUploadOutputs,
     handleDownloadInputs,
+    isMobile = false,
 }) => {
     const classes = useStyles();
 
@@ -122,19 +123,22 @@ const CollapsibleTableRow = ({
             </TableRow>
 
             <TableRow key={collapseID} id={collapseID}>
+                {!isMobile ? (
+                    <TableCell
+                        style={{
+                            paddingBottom: 0,
+                            paddingTop: 0,
+                            width: "5%",
+                        }}
+                        colSpan={row.isExpanded ? 1 : 0}
+                    ></TableCell>
+                ) : null}
+
                 <TableCell
                     style={{
                         paddingBottom: 0,
                         paddingTop: 0,
-                        width: "10%",
-                    }}
-                    colSpan={row.isExpanded ? 1 : 0}
-                ></TableCell>
-                <TableCell
-                    style={{
-                        paddingBottom: 0,
-                        paddingTop: 0,
-                        width: "90%",
+                        width: "95%",
                     }}
                     colSpan={visibleColumns.length}
                 >
@@ -214,6 +218,10 @@ const CollapsibleTable = ({
     const isSmall = useMediaQuery(theme.breakpoints.up("sm"));
     const isExtraSmall = useMediaQuery(theme.breakpoints.up("xs"));
 
+    // Needs to be set in the useLayoutEffect, otherwise it acts weird
+    // because the media queries generate incorrect results on the server.
+    const [isMobile, setIsMobile] = useState(false);
+
     const {
         getTableProps,
         getTableBodyProps,
@@ -249,6 +257,7 @@ const CollapsibleTable = ({
         } else {
             numCols = 7;
         }
+        setIsMobile((isXL || isLarge || isMedium) === false);
 
         const hidden = columns.slice(numCols);
         setHiddenColumnObjs(hidden);
@@ -329,6 +338,7 @@ const CollapsibleTable = ({
                                     handleDownloadInputs={handleDownloadInputs}
                                     handleUploadOutputs={handleUploadOutputs}
                                     showActions={showActions}
+                                    isMobile={isMobile}
                                 />
                             );
                         })}

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useLayoutEffect } from "react";
 
 import {
     withI18N,
@@ -16,10 +16,12 @@ import {
     Paper,
     TableRow,
     Typography,
-    //    IconButton,
     useTheme,
     useMediaQuery,
+    //    IconButton,
 } from "@material-ui/core";
+
+// import { Skeleton } from "@material-ui/lab";
 
 import { useTable } from "react-table";
 
@@ -45,41 +47,39 @@ const CollapsibleTable = ({
     const theme = useTheme();
 
     const isXL = useMediaQuery(theme.breakpoints.up("xl"));
-    const isSmall = useMediaQuery(theme.breakpoints.up("xs"));
-    const isMedium = useMediaQuery(theme.breakpoints.up("sm"));
     const isLarge = useMediaQuery(theme.breakpoints.up("lg"));
-
-    let numVisibleColumns;
-
-    if (isXL) {
-        numVisibleColumns = 7;
-    } else if (isLarge) {
-        numVisibleColumns = 6;
-    } else if (isMedium) {
-        numVisibleColumns = 4;
-    } else if (isSmall) {
-        numVisibleColumns = 2;
-    } else {
-        numVisibleColumns = 7;
-    }
+    const isMedium = useMediaQuery(theme.breakpoints.up("md"));
+    const isSmall = useMediaQuery(theme.breakpoints.up("sm"));
 
     const {
         getTableProps,
         getTableBodyProps,
         headerGroups,
         prepareRow,
-        rows,
         setHiddenColumns,
+        rows,
     } = useTable({
         columns,
         data,
     });
 
-    useEffect(() => {
-        setHiddenColumns(
-            columns.slice(numVisibleColumns).map((column) => column.id)
-        );
-    }, [setHiddenColumns, columns, numVisibleColumns]);
+    useLayoutEffect(() => {
+        let numCols;
+
+        if (isXL) {
+            numCols = 7;
+        } else if (isLarge) {
+            numCols = 6;
+        } else if (isMedium) {
+            numCols = 4;
+        } else if (isSmall) {
+            numCols = 2;
+        } else {
+            numCols = 7;
+        }
+
+        setHiddenColumns(columns.slice(numCols).map((column) => column.id));
+    }, [setHiddenColumns, columns, isXL, isLarge, isMedium, isSmall]);
 
     const tableID = id(ids.ROOT);
 

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -1,13 +1,9 @@
-import React, { useLayoutEffect } from "react";
+import React, { useLayoutEffect, useState } from "react";
+
+import { withI18N, getMessage as msg } from "@cyverse-de/ui-lib";
 
 import {
-    withI18N,
-    //    getMessage as msg,
-} from "@cyverse-de/ui-lib";
-
-import {
-    //    Box,
-    //    Collapse,
+    Box,
     Table,
     TableBody,
     TableCell,
@@ -18,30 +14,180 @@ import {
     Typography,
     useTheme,
     useMediaQuery,
-    //    IconButton,
+    IconButton,
 } from "@material-ui/core";
 
 // import { Skeleton } from "@material-ui/lab";
+import { KeyboardArrowUp, KeyboardArrowDown } from "@material-ui/icons";
 
-import { useTable } from "react-table";
+import { useTable, useExpanded } from "react-table";
 
-//import ActionButtons from "./actionButtons";
+import ActionButtons from "./actionButtons";
 
 import messages from "./messages";
 import ids from "./ids";
 import { id } from "./functions";
 import useStyles from "./styles";
 
+const ExtendedDataCard = ({
+    columns,
+    row,
+    collapseID,
+    showActions = false,
+    handleExit,
+    handleSaveAndExit,
+    handleExtendTimeLimit,
+    handleUploadOutputs,
+    handleDownloadInputs,
+}) => {
+    const classes = useStyles();
+    const theme = useTheme();
+    const isMedium = useMediaQuery(theme.breakpoints.down("md"));
+
+    let display = "inline";
+    if (isMedium) {
+        display = "block";
+    }
+
+    // These should be the column IDs of the columns displayed in the
+    // ExtendedDataCard, which currently corresponds to the hidden columns.
+    const columnIDs = columns.map((c) => c.id);
+
+    // Find only the cells for the hidden columns.
+    const filteredCells = row.allCells.filter((row) => {
+        return columnIDs.includes(row.column.id);
+    });
+
+    return (
+        <Box margin={1}>
+            <div
+                className={`${classes.extended} ${classes.actions}`}
+                {...row.getRowProps()}
+            >
+                {filteredCells.map((cell) => {
+                    return (
+                        <div className={classes.dataEntry}>
+                            <Typography
+                                variant="body2"
+                                align="left"
+                                display={display}
+                                // id={id(collapseID, column.field, "label")}
+                                classes={{ root: classes.dataEntryLabel }}
+                            >
+                                {cell.render("Header")}
+                            </Typography>
+
+                            <Typography
+                                variant="body2"
+                                align="left"
+                                display={display}
+                                // id={id(collapseID, column.field, "value")}
+                            >
+                                {cell.render("Cell")}
+                            </Typography>
+                        </div>
+                    );
+                })}
+            </div>
+
+            {showActions && (
+                <ActionButtons
+                    row={row}
+                    handleDownloadInputs={handleDownloadInputs}
+                    handleUploadOutputs={handleUploadOutputs}
+                    handleExtendTimeLimit={handleExtendTimeLimit}
+                    handleExit={handleExit}
+                    handleSaveAndExit={handleSaveAndExit}
+                />
+            )}
+        </Box>
+    );
+};
+
+const CollapsibleTableRow = ({
+    row,
+    visibleColumns,
+    hiddenColumns,
+    baseID,
+    showActions,
+    handleExit,
+    handleSaveAndExit,
+    handleExtendTimeLimit,
+    handleUploadOutputs,
+    handleDownloadInputs,
+}) => {
+    const classes = useStyles();
+
+    const rowID = id(baseID, "row");
+    const collapseID = id(rowID, "collapse");
+
+    return (
+        <>
+            <TableRow
+                className={classes.row}
+                key={rowID}
+                id={rowID}
+                {...row.getRowProps()}
+            >
+                {row.cells.map((cell) => {
+                    return (
+                        <TableCell {...cell.getCellProps()}>
+                            {cell.render("Cell")}
+                        </TableCell>
+                    );
+                })}
+            </TableRow>
+
+            {row.isExpanded ? (
+                <TableRow key={collapseID} id={collapseID}>
+                    <TableCell
+                        style={{
+                            paddingBottom: 0,
+                            paddingTop: 0,
+                            width: "90%",
+                        }}
+                        colSpan={visibleColumns.length}
+                    >
+                        <ExtendedDataCard
+                            columns={hiddenColumns}
+                            row={row}
+                            collapseID={collapseID}
+                            showActions={showActions}
+                            handleExit={handleExit}
+                            handleSaveAndExit={handleSaveAndExit}
+                            handleExtendTimeLimit={handleExtendTimeLimit}
+                            handleUploadOutputs={handleUploadOutputs}
+                            handleDownloadInputs={handleDownloadInputs}
+                        />
+                    </TableCell>
+                </TableRow>
+            ) : null}
+        </>
+    );
+};
+
+export const ExpanderColumn = {
+    id: "expander",
+    Header: () => null,
+    Cell: ({ row }) => (
+        <span {...row.getToggleRowExpandedProps()}>
+            <IconButton aria-label={msg("expandRow")} size="small">
+                {row.isExpanded ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
+            </IconButton>
+        </span>
+    ),
+};
+
 const CollapsibleTable = ({
     columns,
     data,
     title,
-    // showActions = false,
-    // handleExit,
-    // handleSaveAndExit,
-    // handleExtendTimeLimit,
-    // handleDownloadInputs,
-    // handleUploadOutputs,
+    showActions = false,
+    handleExit,
+    handleSaveAndExit,
+    handleExtendTimeLimit,
+    handleDownloadInputs,
+    handleUploadOutputs,
 }) => {
     const classes = useStyles();
     const theme = useTheme();
@@ -58,10 +204,17 @@ const CollapsibleTable = ({
         prepareRow,
         setHiddenColumns,
         rows,
-    } = useTable({
-        columns,
-        data,
-    });
+        visibleColumns,
+        //state: { expanded },
+    } = useTable(
+        {
+            columns,
+            data,
+        },
+        useExpanded
+    );
+
+    const [hiddenColumnObjs, setHiddenColumnObjs] = useState([]);
 
     useLayoutEffect(() => {
         let numCols;
@@ -78,7 +231,9 @@ const CollapsibleTable = ({
             numCols = 7;
         }
 
-        setHiddenColumns(columns.slice(numCols).map((column) => column.id));
+        const hidden = columns.slice(numCols);
+        setHiddenColumnObjs(hidden);
+        setHiddenColumns(hidden.map((column) => column.id));
     }, [setHiddenColumns, columns, isXL, isLarge, isMedium, isSmall]);
 
     const tableID = id(ids.ROOT);
@@ -116,18 +271,21 @@ const CollapsibleTable = ({
                             prepareRow(row);
 
                             return (
-                                <TableRow
-                                    className={classes.row}
-                                    {...row.getRowProps()}
-                                >
-                                    {row.cells.map((cell) => {
-                                        return (
-                                            <TableCell {...cell.getCellProps()}>
-                                                {cell.render("Cell")}
-                                            </TableCell>
-                                        );
-                                    })}
-                                </TableRow>
+                                <CollapsibleTableRow
+                                    row={row}
+                                    key={row.original.externalID}
+                                    baseID={row.original.externalID}
+                                    visibleColumns={visibleColumns}
+                                    hiddenColumns={hiddenColumnObjs}
+                                    handleExit={handleExit}
+                                    handleSaveAndExit={handleSaveAndExit}
+                                    handleExtendTimeLimit={
+                                        handleExtendTimeLimit
+                                    }
+                                    handleDownloadInputs={handleDownloadInputs}
+                                    handleUploadOutputs={handleUploadOutputs}
+                                    showActions={showActions}
+                                />
                             );
                         })}
                     </TableBody>

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -41,13 +41,6 @@ const ExtendedDataCard = ({
     handleDownloadInputs,
 }) => {
     const classes = useStyles();
-    const theme = useTheme();
-    const isMedium = useMediaQuery(theme.breakpoints.down("md"));
-
-    let display = "inline";
-    if (isMedium) {
-        display = "block";
-    }
 
     // These should be the column IDs of the columns displayed in the
     // ExtendedDataCard, which currently corresponds to the hidden columns.
@@ -59,32 +52,13 @@ const ExtendedDataCard = ({
     });
 
     return (
-        <Box margin={1}>
-            <div
-                className={`${classes.extended} ${classes.actions}`}
-                {...row.getRowProps()}
-            >
+        <Box>
+            <div className={classes.extended} {...row.getRowProps()}>
                 {filteredCells.map((cell) => {
                     return (
                         <div className={classes.dataEntry}>
-                            <Typography
-                                variant="body2"
-                                align="left"
-                                display={display}
-                                // id={id(collapseID, column.field, "label")}
-                                classes={{ root: classes.dataEntryLabel }}
-                            >
-                                {cell.render("Header")}
-                            </Typography>
-
-                            <Typography
-                                variant="body2"
-                                align="left"
-                                display={display}
-                                // id={id(collapseID, column.field, "value")}
-                            >
-                                {cell.render("Cell")}
-                            </Typography>
+                            {cell.render("Header")}
+                            {cell.render("Cell")}
                         </div>
                     );
                 })}
@@ -144,7 +118,13 @@ const CollapsibleTableRow = ({
                         style={{
                             paddingBottom: 0,
                             paddingTop: 0,
-                            width: "90%",
+                        }}
+                        colSpan={1}
+                    ></TableCell>
+                    <TableCell
+                        style={{
+                            paddingBottom: 0,
+                            paddingTop: 0,
                         }}
                         colSpan={visibleColumns.length}
                     >
@@ -178,6 +158,30 @@ export const ExpanderColumn = {
     ),
 };
 
+export const defineColumn = (
+    name,
+    keyID,
+    field,
+    align = "left",
+    enableSorting = true
+) => ({
+    Header: (_table, _columnModel) => (
+        <Typography variant="subtitle1" align={align}>
+            {name}
+        </Typography>
+    ),
+    Cell: ({ value }) => (
+        <Typography variant="body2" align={align}>
+            {value}
+        </Typography>
+    ),
+    accessor: field,
+    align,
+    enableSorting,
+    key: keyID,
+    id: keyID,
+});
+
 const CollapsibleTable = ({
     columns,
     data,
@@ -205,7 +209,6 @@ const CollapsibleTable = ({
         setHiddenColumns,
         rows,
         visibleColumns,
-        //state: { expanded },
     } = useTable(
         {
             columns,
@@ -256,13 +259,13 @@ const CollapsibleTable = ({
                 >
                     <TableHead>
                         {headerGroups.map((headerGroup) => (
-                            <tr {...headerGroup.getHeaderGroupProps()}>
+                            <TableRow {...headerGroup.getHeaderGroupProps()}>
                                 {headerGroup.headers.map((column) => (
-                                    <th {...column.getHeaderProps()}>
+                                    <TableCell {...column.getHeaderProps()}>
                                         {column.render("Header")}
-                                    </th>
+                                    </TableCell>
                                 ))}
-                            </tr>
+                            </TableRow>
                         ))}
                     </TableHead>
 

--- a/src/components/vice/admin/table/messages.js
+++ b/src/components/vice/admin/table/messages.js
@@ -12,6 +12,8 @@ export default {
         expandRow: "Expand Row",
         saveAndExit: "Save and Exit",
         exit: "Exit",
+        exitCommandSent: "Exit command sent",
+        saveAndExitCommandSent: "Save and Exit command sent",
         extendTimeLimit: "Extend Time Limit",
         downloadInputs: "Download Inputs",
         uploadOutputs: "Upload Outputs",

--- a/src/components/vice/admin/table/styles.js
+++ b/src/components/vice/admin/table/styles.js
@@ -58,15 +58,6 @@ export default makeStyles((theme) => ({
         marginBottom: theme.spacing(1),
         marginTop: theme.spacing(1),
     },
-    // actions: {
-    //     marginLeft: theme.spacing(11),
-    //     marginRight: theme.spacing(11),
-
-    //     [theme.breakpoints.down("sm")]: {
-    //         marginLeft: theme.spacing(1),
-    //         marginRight: theme.spacing(1),
-    //     },
-    // },
     paperPopper: {
         border: "1px solid",
         padding: theme.spacing(1),

--- a/src/components/vice/admin/table/styles.js
+++ b/src/components/vice/admin/table/styles.js
@@ -56,15 +56,15 @@ export default makeStyles((theme) => ({
         marginBottom: theme.spacing(1),
         marginTop: theme.spacing(1),
     },
-    actions: {
-        marginLeft: theme.spacing(11),
-        marginRight: theme.spacing(11),
+    // actions: {
+    //     marginLeft: theme.spacing(11),
+    //     marginRight: theme.spacing(11),
 
-        [theme.breakpoints.down("sm")]: {
-            marginLeft: theme.spacing(1),
-            marginRight: theme.spacing(1),
-        },
-    },
+    //     [theme.breakpoints.down("sm")]: {
+    //         marginLeft: theme.spacing(1),
+    //         marginRight: theme.spacing(1),
+    //     },
+    // },
     paperPopper: {
         border: "1px solid",
         padding: theme.spacing(1),

--- a/src/components/vice/admin/table/styles.js
+++ b/src/components/vice/admin/table/styles.js
@@ -26,6 +26,8 @@ export default makeStyles((theme) => ({
         },
     },
     dataEntry: {
+        textOverFlow: "ellipsis",
+
         [theme.breakpoints.up("xs")]: {
             width: "100%",
             marginLeft: 0,

--- a/stories/vice/admin/CollapsibleTable.stories.js
+++ b/stories/vice/admin/CollapsibleTable.stories.js
@@ -2,6 +2,7 @@ import React from "react";
 
 import CollapsibleTable, {
     ExpanderColumn,
+    defineColumn,
 } from "../../../src/components/vice/admin/table";
 import {
     COMMON_COLUMNS,
@@ -64,21 +65,6 @@ const testData = {
         },
     ],
 };
-
-const defineColumn = (
-    name,
-    keyID,
-    field,
-    align = "left",
-    enableSorting = true
-) => ({
-    Header: name,
-    accessor: field,
-    align,
-    enableSorting,
-    key: keyID,
-    id: keyID,
-});
 
 // The column definitions for the table.
 const commonColumns = [

--- a/stories/vice/admin/CollapsibleTable.stories.js
+++ b/stories/vice/admin/CollapsibleTable.stories.js
@@ -70,12 +70,12 @@ const defineColumn = (
     align = "left",
     enableSorting = true
 ) => ({
-    name,
+    Header: name,
+    accessor: field,
     align,
     enableSorting,
     key: keyID,
     id: keyID,
-    field,
 });
 
 // The column definitions for the table.
@@ -95,19 +95,21 @@ const commonColumns = [
     defineColumn("User ID", COMMON_COLUMNS.USER_ID, "userID"),
 ];
 
-const deploymentColumns = [
-    ...commonColumns,
-    defineColumn("Image", DEPLOYMENT_COLUMNS.IMAGE, "image"),
-    defineColumn("Port", DEPLOYMENT_COLUMNS.PORT, "port"),
-    defineColumn("UID", DEPLOYMENT_COLUMNS.UID, "uid"),
-    defineColumn("GID", DEPLOYMENT_COLUMNS.GID, "gid"),
-];
+const testColumns = {
+    deployments: [
+        ...commonColumns,
+        defineColumn("Image", DEPLOYMENT_COLUMNS.IMAGE, "image"),
+        defineColumn("Port", DEPLOYMENT_COLUMNS.PORT, "port"),
+        defineColumn("UID", DEPLOYMENT_COLUMNS.UID, "uid"),
+        defineColumn("GID", DEPLOYMENT_COLUMNS.GID, "gid"),
+    ],
+};
 
 export const CollapsibleTableTest = () => {
     return (
         <CollapsibleTable
-            columns={deploymentColumns}
-            rows={testData.deployments}
+            columns={testColumns.deployments}
+            data={testData.deployments}
             title="Deployments"
         />
     );

--- a/stories/vice/admin/CollapsibleTable.stories.js
+++ b/stories/vice/admin/CollapsibleTable.stories.js
@@ -80,7 +80,7 @@ const defineColumn = (
 
 // The column definitions for the table.
 const commonColumns = [
-    defineColumn("", COMMON_COLUMNS.EXPAND, "", "left", false),
+    defineColumn("+", COMMON_COLUMNS.EXPAND, "", "left", false),
     defineColumn("Username", COMMON_COLUMNS.USERNAME, "username"),
     defineColumn(
         "Date Created",

--- a/stories/vice/admin/CollapsibleTable.stories.js
+++ b/stories/vice/admin/CollapsibleTable.stories.js
@@ -1,6 +1,8 @@
 import React from "react";
 
-import CollapsibleTable from "../../../src/components/vice/admin/table";
+import CollapsibleTable, {
+    ExpanderColumn,
+} from "../../../src/components/vice/admin/table";
 import {
     COMMON_COLUMNS,
     DEPLOYMENT_COLUMNS,
@@ -80,7 +82,7 @@ const defineColumn = (
 
 // The column definitions for the table.
 const commonColumns = [
-    defineColumn("+", COMMON_COLUMNS.EXPAND, "", "left", false),
+    ExpanderColumn,
     defineColumn("Username", COMMON_COLUMNS.USERNAME, "username"),
     defineColumn(
         "Date Created",


### PR DESCRIPTION
Refactors the VICE admin UI to use react-table. The major improvement here is the standardized state management API, which will enable future support for features such as:
- per-column filters
- global filters
- reordering rows
- resizing rows

Right now I'm only really taking advantage of the hidden columns and row expansion features, which are used to push columns into the collapsed part of each row when the screen becomes too small to display them.

Previously, this PR was being used to add bulk actions to the VICE admin UI, but it was growing too large to be easily reviewed. I refocused the PR on adding react-table and supporting the existing feature set to keep it from getting overwhelming. The bulk actions feature is still planned.

## Desktop
### Unexpanded
![image](https://user-images.githubusercontent.com/49783/87452446-16797600-c5b6-11ea-9e87-6f2e44bfb05c.png)
### Expanded
![image](https://user-images.githubusercontent.com/49783/87452525-28f3af80-c5b6-11ea-8f8b-27e914118921.png)
### Sorted by username
![image](https://user-images.githubusercontent.com/49783/87452667-56d8f400-c5b6-11ea-96a4-8a7cd653c10d.png)

## Tablet
### Unexpanded
![image](https://user-images.githubusercontent.com/49783/87452956-b3d4aa00-c5b6-11ea-9e97-29b6e3da23d2.png)
### Expanded
![image](https://user-images.githubusercontent.com/49783/87453105-e383b200-c5b6-11ea-8de0-d9cd6258e604.png)
### Sorted by username
![image](https://user-images.githubusercontent.com/49783/87453175-feeebd00-c5b6-11ea-8ac3-1a14fb863f3a.png)

## Phone
### Unexpanded
![image](https://user-images.githubusercontent.com/49783/87453357-39585a00-c5b7-11ea-827f-0834c39792b7.png)
### Expanded
Without action buttons showing
![image](https://user-images.githubusercontent.com/49783/87453477-6278ea80-c5b7-11ea-970d-7d739d1c211f.png)
With action buttons showing
![image](https://user-images.githubusercontent.com/49783/87453512-6f95d980-c5b7-11ea-856f-fe514b6e8e9a.png)
### Sorted by username
![image](https://user-images.githubusercontent.com/49783/87453581-876d5d80-c5b7-11ea-8e54-7ec9da058959.png)



