### PR TITLE
CORE-769 Analysis relaunch page

### DIFF
--- a/src/components/analyses/ids.js
+++ b/src/components/analyses/ids.js
@@ -74,6 +74,13 @@ export default {
     INTERACTIVE: "interactive",
     OSG: "osg",
 
+    DIALOG: {
+        CANCEL: "cancel",
+        CONFIRM: "confirm",
+        RELAUNCH: "relaunch",
+        TITLE: "title",
+    },
+
     ICONS: {
         INTERACTIVE: "interactive",
         BATCH: "batch",

--- a/src/components/analyses/listing/Listing.js
+++ b/src/components/analyses/listing/Listing.js
@@ -94,7 +94,7 @@ function Listing(props) {
 
     const [
         relaunchAnalysesMutation,
-        { isLoading: relaunchLoading, error: relauchError },
+        { isLoading: relaunchLoading, error: relaunchError },
     ] = useMutation(relaunchAnalyses, {
         onSuccess: () => queryCache.invalidateQueries(analysesKey),
     });
@@ -387,7 +387,7 @@ function Listing(props) {
             />
             <TableView
                 loading={isFetching || relaunchLoading}
-                error={error || relauchError}
+                error={error || relaunchError}
                 listing={data}
                 baseId={baseId}
                 order={order}

--- a/src/components/analyses/listing/Listing.js
+++ b/src/components/analyses/listing/Listing.js
@@ -7,7 +7,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { useQuery } from "react-query";
 import { injectIntl } from "react-intl";
-import { useRouter } from "next/router";
 
 import { formatMessage, withI18N } from "@cyverse-de/ui-lib";
 import {
@@ -24,7 +23,6 @@ import AnalysesToolbar, { getOwnershipFilters } from "../toolbar/Toolbar";
 import { getAppTypeFilters } from "../../apps/toolbar/AppNavigation";
 import appType from "../../models/AppType";
 
-import NavigationConstants from "../../../common/NavigationConstants";
 import { useUserProfile } from "../../../contexts/userProfile";
 import { useNotifications } from "../../../contexts/pushNotifications";
 
@@ -48,8 +46,8 @@ const filter = {
 };
 
 function Listing(props) {
-    const router = useRouter();
-    const { baseId, intl } = props;
+    const { baseId, handleGoToOutputFolder, handleRelaunch, intl } = props;
+
     const [isGridView, setGridView] = useState(false);
     const [order, setOrder] = useState("desc");
     const [orderBy, setOrderBy] = useState("startdate");
@@ -299,14 +297,6 @@ function Listing(props) {
         window.open(url, "_blank");
     };
 
-    const handleGoToOutputFolder = (analysis) => {
-        if (analysis.resultfolderid) {
-            router.push(
-                `${constants.PATH_SEPARATOR}${NavigationConstants.DATA}${constants.PATH_SEPARATOR}ds${analysis.resultfolderid}`
-            );
-        }
-    };
-
     const handleAppTypeFilterChange = (appTypeFilter) => {
         setAppTypeFilter(appTypeFilter);
         setSelected([]);
@@ -358,6 +348,7 @@ function Listing(props) {
                 onDetailsSelected={onDetailsSelected}
                 handleInteractiveUrlClick={handleInteractiveUrlClick}
                 handleGoToOutputFolder={handleGoToOutputFolder}
+                handleRelaunch={handleRelaunch}
                 handleBatchIconClick={handleBatchIconClick}
             />
             <TableView
@@ -374,6 +365,7 @@ function Listing(props) {
                 handleRequestSort={handleRequestSort}
                 handleInteractiveUrlClick={handleInteractiveUrlClick}
                 handleGoToOutputFolder={handleGoToOutputFolder}
+                handleRelaunch={handleRelaunch}
                 handleBatchIconClick={handleBatchIconClick}
             />
             {detailsOpen && (

--- a/src/components/analyses/listing/MultiRelaunchWarningDialog.js
+++ b/src/components/analyses/listing/MultiRelaunchWarningDialog.js
@@ -1,0 +1,70 @@
+/**
+ * A confirmation dialog for relaunching multiple analyses.
+ *
+ * @author psarando
+ */
+import React from "react";
+
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    DialogTitle,
+    useMediaQuery,
+    useTheme,
+} from "@material-ui/core";
+
+import { build, getMessage, withI18N } from "@cyverse-de/ui-lib";
+import messages from "../messages";
+import ids from "../ids";
+
+function MultiRelaunchWarningDialog({
+    baseId,
+    open,
+    onClose,
+    confirmMultiRelaunch,
+}) {
+    const theme = useTheme();
+    const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
+
+    const dialogTitleId = build(baseId, ids.DIALOG.RELAUNCH, ids.DIALOG.TITLE);
+
+    return (
+        <Dialog
+            open={open}
+            onClose={onClose}
+            id={build(baseId, ids.DIALOG.RELAUNCH)}
+            fullScreen={fullScreen}
+            aria-labelledby={dialogTitleId}
+        >
+            <DialogTitle id={dialogTitleId}>
+                {getMessage("relaunch")}
+            </DialogTitle>
+            <DialogContent>
+                <DialogContentText>
+                    {getMessage("analysesMultiRelaunchWarning")}
+                </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+                <Button
+                    id={build(baseId, ids.DIALOG.RELAUNCH, ids.DIALOG.CANCEL)}
+                    onClick={onClose}
+                >
+                    {getMessage("cancelBtnText")}
+                </Button>
+                <Button
+                    id={build(baseId, ids.DIALOG.RELAUNCH, ids.DIALOG.CONFIRM)}
+                    onClick={confirmMultiRelaunch}
+                    color="primary"
+                    variant="contained"
+                >
+                    {getMessage("okBtnText")}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+}
+
+export default withI18N(MultiRelaunchWarningDialog, messages);

--- a/src/components/analyses/listing/TableView.js
+++ b/src/components/analyses/listing/TableView.js
@@ -109,7 +109,7 @@ function Status(props) {
 
 function Actions(props) {
     const classes = useStyles();
-    const { analysis } = props;
+    const { analysis, handleRelaunch } = props;
 
     const interactiveUrls = analysis.interactive_urls;
     const handleInteractiveUrlClick = props.handleInteractiveUrlClick;
@@ -168,6 +168,7 @@ function Actions(props) {
                 >
                     <IconButton
                         size="small"
+                        onClick={() => handleRelaunch(analysis)}
                         id={build(baseId, ids.ICONS.RELAUNCH, ids.BUTTON)}
                         className={className}
                     >
@@ -280,6 +281,7 @@ function TableView(props) {
         handleClick,
         handleInteractiveUrlClick,
         handleGoToOutputFolder,
+        handleRelaunch,
         handleBatchIconClick,
         intl,
     } = props;
@@ -438,6 +440,9 @@ function TableView(props) {
                                                     }
                                                     handleGoToOutputFolder={
                                                         handleGoToOutputFolder
+                                                    }
+                                                    handleRelaunch={
+                                                        handleRelaunch
                                                     }
                                                     handleBatchIconClick={
                                                         handleBatchIconClick

--- a/src/components/analyses/listing/TableView.js
+++ b/src/components/analyses/listing/TableView.js
@@ -168,7 +168,7 @@ function Actions(props) {
                 >
                     <IconButton
                         size="small"
-                        onClick={() => handleRelaunch(analysis)}
+                        onClick={() => handleRelaunch([analysis])}
                         id={build(baseId, ids.ICONS.RELAUNCH, ids.BUTTON)}
                         className={className}
                     >

--- a/src/components/analyses/toolbar/AnalysesDotMenu.js
+++ b/src/components/analyses/toolbar/AnalysesDotMenu.js
@@ -35,6 +35,7 @@ function DotMenuItems(props) {
         detailsEnabled,
         handleInteractiveUrlClick,
         handleGoToOutputFolder,
+        handleRelaunch,
         handleBatchIconClick,
         isBatch,
         isVICE,
@@ -81,6 +82,7 @@ function DotMenuItems(props) {
                 id={build(baseId, ids.MENUITEM_RELAUNCH)}
                 onClick={() => {
                     onClose();
+                    handleRelaunch(selectedAnalyses[0]);
                 }}
             >
                 <ListItemIcon>

--- a/src/components/analyses/toolbar/AnalysesDotMenu.js
+++ b/src/components/analyses/toolbar/AnalysesDotMenu.js
@@ -82,7 +82,7 @@ function DotMenuItems(props) {
                 id={build(baseId, ids.MENUITEM_RELAUNCH)}
                 onClick={() => {
                     onClose();
-                    handleRelaunch(selectedAnalyses[0]);
+                    handleRelaunch(selectedAnalyses);
                 }}
             >
                 <ListItemIcon>

--- a/src/components/analyses/toolbar/Toolbar.js
+++ b/src/components/analyses/toolbar/Toolbar.js
@@ -138,6 +138,7 @@ function AnalysesToolbar(props) {
         onDetailsSelected,
         handleInteractiveUrlClick,
         handleGoToOutputFolder,
+        handleRelaunch,
         handleBatchIconClick,
     } = props;
     const analysesNavId = build(baseId, ids.ANALYSES_NAVIGATION);
@@ -229,6 +230,7 @@ function AnalysesToolbar(props) {
                     getSelectedAnalyses={getSelectedAnalyses}
                     handleInteractiveUrlClick={handleInteractiveUrlClick}
                     handleGoToOutputFolder={handleGoToOutputFolder}
+                    handleRelaunch={handleRelaunch}
                     handleBatchIconClick={handleBatchIconClick}
                 />
             )}

--- a/src/components/analyses/utils.js
+++ b/src/components/analyses/utils.js
@@ -1,5 +1,6 @@
 import analysisStatus from "../models/analysisStatus";
 import constants from "../../constants";
+import NavigationConstants from "../../common/NavigationConstants";
 
 /**
  * Get the user who ran this analysis
@@ -76,10 +77,19 @@ const allowAnalyesRelaunch = (selectedAnalyses) => {
     return filteredAnalyses.length === 0;
 };
 
+/**
+ * Builds a path to the Analysis Relaunch page for the given analysis ID.
+ *
+ * @param {string} analysisId The analysis ID.
+ */
+const getAnalysisRelaunchPage = (analysisId) =>
+    `/${NavigationConstants.ANALYSES}/${analysisId}/relaunch`;
+
 export {
     getAnalysisUser,
     isInteractive,
     allowAnalysisTimeExtn,
     isBatchAnalysis,
     allowAnalyesRelaunch,
+    getAnalysisRelaunchPage,
 };

--- a/src/components/apps/launch.js
+++ b/src/components/apps/launch.js
@@ -1,0 +1,95 @@
+/**
+ * @author psarando
+ *
+ * A component for displaying the App Launch Wizard for a given app.
+ * Also handles calling analysis submission and quick-launch-save endpoints.
+ */
+import React from "react";
+
+import { useRouter } from "next/router";
+import { useMutation } from "react-query";
+
+import NavigationConstants from "../../common/NavigationConstants";
+
+import { useConfig } from "../../contexts/config";
+import { useUserProfile } from "../../contexts/userProfile";
+
+import { submitAnalysis } from "../../serviceFacades/analyses";
+import { addQuickLaunch } from "../../serviceFacades/quickLaunches";
+
+import AppLaunchWizard from "./launch/AppLaunchWizard";
+
+export default ({ app, appError, loading }) => {
+    const [submissionError, setSubmissionError] = React.useState(null);
+
+    const [config] = useConfig();
+    const [userProfile] = useUserProfile();
+
+    const router = useRouter();
+
+    const [submitAnalysisMutation] = useMutation(
+        ({ submission }) => submitAnalysis(submission),
+        {
+            onSuccess: (resp, { onSuccess }) => {
+                router.push(`/${NavigationConstants.ANALYSES}`);
+                onSuccess(resp);
+            },
+            onError: (error, { onError }) => {
+                onError(error);
+                setSubmissionError(error);
+            },
+        }
+    );
+
+    const [addQuickLaunchMutation] = useMutation(
+        ({ quickLaunch }) => addQuickLaunch(quickLaunch),
+        {
+            onSuccess: (resp, { onSuccess }) => {
+                // TODO route to app details or QL listing page?
+                onSuccess(resp);
+            },
+            onError: (error, { onError }) => {
+                onError(error);
+                setSubmissionError(error);
+            },
+        }
+    );
+
+    // FIXME: notify, defaultOutputDir, and startingPath
+    // need to come from user prefs.
+    const notify = false;
+    const irodsHomePath = config?.irods?.home_path;
+    const username = userProfile?.id;
+
+    const homePath =
+        irodsHomePath && username ? `${irodsHomePath}/${username}` : "";
+    const startingPath = homePath || "";
+    const defaultOutputDir = homePath ? `${homePath}/analyses` : "";
+
+    const defaultMaxCPUCores = config?.tools?.private.max_cpu_limit;
+    const defaultMaxMemory = config?.tools?.private.max_memory_limit;
+    const defaultMaxDiskSpace = config?.tools?.private.max_disk_limit;
+
+    return (
+        <AppLaunchWizard
+            baseId="apps"
+            notify={notify}
+            defaultOutputDir={defaultOutputDir}
+            startingPath={startingPath}
+            defaultMaxCPUCores={defaultMaxCPUCores}
+            defaultMaxMemory={defaultMaxMemory}
+            defaultMaxDiskSpace={defaultMaxDiskSpace}
+            app={app}
+            appError={appError || submissionError}
+            loading={loading}
+            submitAnalysis={(submission, onSuccess, onError) => {
+                setSubmissionError(null);
+                submitAnalysisMutation({ submission, onSuccess, onError });
+            }}
+            saveQuickLaunch={(quickLaunch, onSuccess, onError) => {
+                setSubmissionError(null);
+                addQuickLaunchMutation({ quickLaunch, onSuccess, onError });
+            }}
+        />
+    );
+};

--- a/src/components/apps/launch/AppLaunchForm.js
+++ b/src/components/apps/launch/AppLaunchForm.js
@@ -194,12 +194,22 @@ const initValues = ({
 
             let value = defaultValue || "";
 
-            if (paramType === constants.PARAM_TYPE.MULTIFILE_SELECTOR) {
-                value = defaultValue || [];
+            if (
+                paramType === constants.PARAM_TYPE.FILE_FOLDER_INPUT ||
+                paramType === constants.PARAM_TYPE.FILE_INPUT ||
+                paramType === constants.PARAM_TYPE.FOLDER_INPUT
+            ) {
+                value = defaultValue?.path || "";
             }
+
+            if (paramType === constants.PARAM_TYPE.MULTIFILE_SELECTOR) {
+                value = defaultValue?.path || [];
+            }
+
             if (paramType === constants.PARAM_TYPE.FLAG) {
                 value = defaultValue && defaultValue !== "false";
             }
+
             if (paramArgs?.length > 0) {
                 const defaultArg = paramArgs.find(
                     (arg) => arg.isDefault || defaultValue?.id === arg.id

--- a/src/components/apps/launch/AppLaunchForm.js
+++ b/src/components/apps/launch/AppLaunchForm.js
@@ -211,9 +211,10 @@ const initValues = ({
             }
 
             if (paramArgs?.length > 0) {
-                const defaultArg = paramArgs.find(
-                    (arg) => arg.isDefault || defaultValue?.id === arg.id
-                );
+                const defaultArg =
+                    paramArgs.find((arg) => defaultValue?.id === arg.id) ||
+                    paramArgs.find((arg) => arg.isDefault);
+
                 value = defaultArg || "";
             }
 

--- a/src/components/apps/launch/ReferenceGenomeSelect.js
+++ b/src/components/apps/launch/ReferenceGenomeSelect.js
@@ -27,6 +27,14 @@ const ReferenceGenomeSelect = withI18N(
         } else if (!referenceGenomes?.length) {
             selectProps.error = true;
             selectProps.helperText = getMessage("errorLoadingReferenceGenomes");
+        } else {
+            // In the case of relaunch or app integrator default values,
+            // the field value object will not be the same instance
+            // as the one parsed from the service response.
+            selectProps.value =
+                referenceGenomes.find(
+                    (refGenome) => refGenome.id === props.field.value?.id
+                ) || "";
         }
 
         return (

--- a/src/components/apps/launch/index.js
+++ b/src/components/apps/launch/index.js
@@ -19,7 +19,7 @@ import { addQuickLaunch } from "../../../serviceFacades/quickLaunches";
 
 import AppLaunchWizard from "./AppLaunchWizard";
 
-export default ({ app, appError, loading }) => {
+export default ({ app, launchError, loading }) => {
     const [submissionError, setSubmissionError] = React.useState(null);
 
     const [config] = useConfig();
@@ -80,7 +80,7 @@ export default ({ app, appError, loading }) => {
             defaultMaxMemory={defaultMaxMemory}
             defaultMaxDiskSpace={defaultMaxDiskSpace}
             app={app}
-            appError={appError || submissionError}
+            appError={launchError || submissionError}
             loading={loading}
             submitAnalysis={(submission, onSuccess, onError) => {
                 setSubmissionError(null);

--- a/src/components/apps/launch/index.js
+++ b/src/components/apps/launch/index.js
@@ -9,15 +9,15 @@ import React from "react";
 import { useRouter } from "next/router";
 import { useMutation } from "react-query";
 
-import NavigationConstants from "../../common/NavigationConstants";
+import NavigationConstants from "../../../common/NavigationConstants";
 
-import { useConfig } from "../../contexts/config";
-import { useUserProfile } from "../../contexts/userProfile";
+import { useConfig } from "../../../contexts/config";
+import { useUserProfile } from "../../../contexts/userProfile";
 
-import { submitAnalysis } from "../../serviceFacades/analyses";
-import { addQuickLaunch } from "../../serviceFacades/quickLaunches";
+import { submitAnalysis } from "../../../serviceFacades/analyses";
+import { addQuickLaunch } from "../../../serviceFacades/quickLaunches";
 
-import AppLaunchWizard from "./launch/AppLaunchWizard";
+import AppLaunchWizard from "./AppLaunchWizard";
 
 export default ({ app, appError, loading }) => {
     const [submissionError, setSubmissionError] = React.useState(null);

--- a/src/components/data/utils.js
+++ b/src/components/data/utils.js
@@ -5,6 +5,8 @@
 import { getMessage } from "@cyverse-de/ui-lib";
 
 import constants from "../../constants";
+import NavigationConstants from "../../common/NavigationConstants";
+
 import DataConstants from "./constants";
 import Permissions, { permissionHierarchy } from "../models/Permissions";
 
@@ -21,6 +23,14 @@ function getEncodedPath(path) {
         .join(constants.PATH_SEPARATOR);
     return encodedPath;
 }
+
+/**
+ * Builds a path to the page of the given folder's data store path.
+ *
+ * @param {string} folderPath The data store path to the folder.
+ */
+const getFolderPage = (folderPath) =>
+    `${constants.PATH_SEPARATOR}${NavigationConstants.DATA}${constants.PATH_SEPARATOR}ds${folderPath}`;
 
 const validateDiskResourceName = (name) => {
     if (name === "") {
@@ -82,6 +92,7 @@ const parseNameFromPath = (path) => {
 
 export {
     getEncodedPath,
+    getFolderPage,
     validateDiskResourceName,
     hasOwn,
     isOwner,

--- a/src/components/layout/Notifications.js
+++ b/src/components/layout/Notifications.js
@@ -71,23 +71,28 @@ function Notifications(props) {
 
     const displayAnalysisNotification = useCallback(
         (notification, status) => {
-            let variant = AnnouncerConstants.INFO;
-            if (status === analysisStatus.COMPLETED) {
-                variant = AnnouncerConstants.SUCCESS;
-            } else if (status === analysisStatus.FAILED) {
-                variant = AnnouncerConstants.ERROR;
-            }
+            const text = notification?.message?.text;
+            const outputFolderPath =
+                notification?.payload?.analysisresultsfolder;
+
+            const completed = status === analysisStatus.COMPLETED;
+            const failed = status === analysisStatus.FAILED;
+
+            const variant = completed
+                ? AnnouncerConstants.SUCCESS
+                : failed
+                ? AnnouncerConstants.ERROR
+                : AnnouncerConstants.INFO;
+
+            const CustomAction =
+                (completed || failed) && outputFolderPath
+                    ? () => analysisCustomAction(outputFolderPath)
+                    : null;
+
             announce({
-                text: notification.message.text,
+                text,
                 variant,
-                CustomAction:
-                    status === analysisStatus.COMPLETED ||
-                    status === analysisStatus.FAILED
-                        ? () =>
-                              analysisCustomAction(
-                                  notification.payload.analysisresultsfolder
-                              )
-                        : null,
+                CustomAction,
             });
         },
         [analysisCustomAction]

--- a/src/pages/analyses.js
+++ b/src/pages/analyses.js
@@ -17,7 +17,7 @@ export default function Analyses() {
                     router.push(getFolderPage(analysis.resultfolderid));
                 }
             }}
-            handleRelaunch={(analysis) => {
+            handleSingleRelaunch={(analysis) => {
                 if (analysis?.id) {
                     router.push(getAnalysisRelaunchPage(analysis.id));
                 }

--- a/src/pages/analyses.js
+++ b/src/pages/analyses.js
@@ -1,6 +1,27 @@
 import React from "react";
+
+import { useRouter } from "next/router";
+
+import { getAnalysisRelaunchPage } from "../components/analyses/utils";
+import { getFolderPage } from "../components/data/utils";
 import Listing from "../components/analyses/listing/Listing";
 
 export default function Analyses() {
-    return <Listing baseId="analyses" />;
+    const router = useRouter();
+
+    return (
+        <Listing
+            baseId="analyses"
+            handleGoToOutputFolder={(analysis) => {
+                if (analysis?.resultfolderid) {
+                    router.push(getFolderPage(analysis.resultfolderid));
+                }
+            }}
+            handleRelaunch={(analysis) => {
+                if (analysis?.id) {
+                    router.push(getAnalysisRelaunchPage(analysis.id));
+                }
+            }}
+        />
+    );
 }

--- a/src/pages/analyses/[analysisId]/relaunch.js
+++ b/src/pages/analyses/[analysisId]/relaunch.js
@@ -56,5 +56,7 @@ export default () => {
 
     const loading = relaunchStatus === constants.LOADING;
 
-    return <AppLaunch app={app} appError={relaunchError} loading={loading} />;
+    return (
+        <AppLaunch app={app} launchError={relaunchError} loading={loading} />
+    );
 };

--- a/src/pages/analyses/[analysisId]/relaunch.js
+++ b/src/pages/analyses/[analysisId]/relaunch.js
@@ -1,0 +1,60 @@
+/**
+ * @author psarando
+ *
+ * A page for displaying the App Launch Wizard for a relaunch of the analysis
+ * with the given ID.
+ */
+import React from "react";
+
+import { useRouter } from "next/router";
+import { useQuery } from "react-query";
+
+import constants from "../../../constants";
+import {
+    getAnalysisRelaunchInfo,
+    ANALYSIS_RELAUNCH_QUERY_KEY,
+} from "../../../serviceFacades/analyses";
+
+import AppLaunch from "../../../components/apps/launch";
+
+export default () => {
+    const [relaunchKey, setRelaunchKey] = React.useState(
+        ANALYSIS_RELAUNCH_QUERY_KEY
+    );
+    const [relaunchQueryEnabled, setRelaunchQueryEnabled] = React.useState(
+        false
+    );
+
+    const [app, setApp] = React.useState(null);
+    const [relaunchError, setRelaunchError] = React.useState(null);
+
+    const router = useRouter();
+    const { analysisId } = router.query;
+
+    React.useEffect(() => {
+        setRelaunchQueryEnabled(!!analysisId);
+
+        if (analysisId) {
+            setRelaunchKey([
+                ANALYSIS_RELAUNCH_QUERY_KEY,
+                {
+                    id: analysisId,
+                },
+            ]);
+        }
+    }, [analysisId, setRelaunchQueryEnabled]);
+
+    const { status: relaunchStatus } = useQuery({
+        queryKey: relaunchKey,
+        queryFn: getAnalysisRelaunchInfo,
+        config: {
+            enabled: relaunchQueryEnabled,
+            onSuccess: setApp,
+            onError: setRelaunchError,
+        },
+    });
+
+    const loading = relaunchStatus === constants.LOADING;
+
+    return <AppLaunch app={app} appError={relaunchError} loading={loading} />;
+};

--- a/src/pages/apps/[systemId]/[appId]/launch.js
+++ b/src/pages/apps/[systemId]/[appId]/launch.js
@@ -2,28 +2,19 @@
  * @author psarando
  *
  * A page for displaying the App Launch Wizard for an app with the given IDs.
- * Also handles calling analysis submission and quick-launch-save endpoints.
  */
 import React from "react";
 
 import { useRouter } from "next/router";
-import { useMutation, useQuery } from "react-query";
+import { useQuery } from "react-query";
 
 import constants from "../../../../constants";
-
-import NavigationConstants from "../../../../common/NavigationConstants";
-
-import { useConfig } from "../../../../contexts/config";
-import { useUserProfile } from "../../../../contexts/userProfile";
-
-import { submitAnalysis } from "../../../../serviceFacades/analyses";
-import { addQuickLaunch } from "../../../../serviceFacades/quickLaunches";
 import {
     getAppDescription,
     APP_DESCRIPTION_QUERY_KEY,
 } from "../../../../serviceFacades/apps";
 
-import AppLaunchWizard from "../../../../components/apps/launch/AppLaunchWizard";
+import AppLaunch from "../../../../components/apps/launch";
 
 export default () => {
     const [appKey, setAppKey] = React.useState(APP_DESCRIPTION_QUERY_KEY);
@@ -34,14 +25,15 @@ export default () => {
     const [app, setApp] = React.useState(null);
     const [appError, setAppError] = React.useState(null);
 
-    const [config] = useConfig();
-    const [userProfile] = useUserProfile();
-
     const router = useRouter();
     const { systemId, appId } = router.query;
 
     React.useEffect(() => {
-        if (systemId && appId) {
+        const hasIds = !!(systemId && appId);
+
+        setAppDescriptionQueryEnabled(hasIds);
+
+        if (hasIds) {
             setAppKey([
                 APP_DESCRIPTION_QUERY_KEY,
                 {
@@ -49,9 +41,6 @@ export default () => {
                     appId,
                 },
             ]);
-            setAppDescriptionQueryEnabled(true);
-        } else {
-            setAppDescriptionQueryEnabled(false);
         }
     }, [systemId, appId, setAppDescriptionQueryEnabled]);
 
@@ -65,71 +54,7 @@ export default () => {
         },
     });
 
-    const [submitAnalysisMutation] = useMutation(
-        ({ submission }) => submitAnalysis(submission),
-        {
-            onSuccess: (resp, { onSuccess }) => {
-                router.push(`/${NavigationConstants.ANALYSES}`);
-                onSuccess(resp);
-            },
-            onError: (error, { onError }) => {
-                onError(error);
-                setAppError(error);
-            },
-        }
-    );
-
-    const [addQuickLaunchMutation] = useMutation(
-        ({ quickLaunch }) => addQuickLaunch(quickLaunch),
-        {
-            onSuccess: (resp, { onSuccess }) => {
-                // TODO route to app details or QL listing page?
-                onSuccess(resp);
-            },
-            onError: (error, { onError }) => {
-                onError(error);
-                setAppError(error);
-            },
-        }
-    );
-
     const loading = appStatus === constants.LOADING;
 
-    // FIXME: notify, defaultOutputDir, and startingPath
-    // need to come from user prefs.
-    const notify = false;
-    const irodsHomePath = config?.irods?.home_path;
-    const username = userProfile?.id;
-
-    const homePath =
-        irodsHomePath && username ? `${irodsHomePath}/${username}` : "";
-    const startingPath = homePath || "";
-    const defaultOutputDir = homePath ? `${homePath}/analyses` : "";
-
-    const defaultMaxCPUCores = config?.tools?.private.max_cpu_limit;
-    const defaultMaxMemory = config?.tools?.private.max_memory_limit;
-    const defaultMaxDiskSpace = config?.tools?.private.max_disk_limit;
-
-    return (
-        <AppLaunchWizard
-            baseId="apps"
-            notify={notify}
-            defaultOutputDir={defaultOutputDir}
-            startingPath={startingPath}
-            defaultMaxCPUCores={defaultMaxCPUCores}
-            defaultMaxMemory={defaultMaxMemory}
-            defaultMaxDiskSpace={defaultMaxDiskSpace}
-            app={app}
-            appError={appError}
-            loading={loading}
-            submitAnalysis={(submission, onSuccess, onError) => {
-                setAppError(null);
-                submitAnalysisMutation({ submission, onSuccess, onError });
-            }}
-            saveQuickLaunch={(quickLaunch, onSuccess, onError) => {
-                setAppError(null);
-                addQuickLaunchMutation({ quickLaunch, onSuccess, onError });
-            }}
-        />
-    );
+    return <AppLaunch app={app} appError={appError} loading={loading} />;
 };

--- a/src/pages/apps/[systemId]/[appId]/launch.js
+++ b/src/pages/apps/[systemId]/[appId]/launch.js
@@ -23,7 +23,7 @@ export default () => {
         setAppDescriptionQueryEnabled,
     ] = React.useState(false);
     const [app, setApp] = React.useState(null);
-    const [appError, setAppError] = React.useState(null);
+    const [launchError, setLaunchError] = React.useState(null);
 
     const router = useRouter();
     const { systemId, appId } = router.query;
@@ -50,11 +50,11 @@ export default () => {
         config: {
             enabled: appDescriptionQueryEnabled,
             onSuccess: setApp,
-            onError: setAppError,
+            onError: setLaunchError,
         },
     });
 
     const loading = appStatus === constants.LOADING;
 
-    return <AppLaunch app={app} appError={appError} loading={loading} />;
+    return <AppLaunch app={app} launchError={launchError} loading={loading} />;
 };

--- a/src/server/api/analyses.js
+++ b/src/server/api/analyses.js
@@ -60,5 +60,15 @@ export default function analysesRouter() {
         })
     );
 
+    logger.info("adding the GET /analyses/:id/relaunch-info handler");
+    api.get(
+        "/analyses/:id/relaunch-info",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "GET",
+            pathname: "/analyses/:id/relaunch-info",
+        })
+    );
+
     return api;
 }

--- a/src/server/api/analyses.js
+++ b/src/server/api/analyses.js
@@ -40,6 +40,19 @@ export default function analysesRouter() {
         })
     );
 
+    logger.info("adding the POST /analyses/relauncher handler");
+    api.post(
+        "/analyses/relauncher",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "POST",
+            pathname: "/analyses/relauncher",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        })
+    );
+
     logger.info("adding the GET /analyses/:id/history");
     api.get(
         "/analyses/:id/history",

--- a/src/serviceFacades/analyses.js
+++ b/src/serviceFacades/analyses.js
@@ -22,6 +22,14 @@ function submitAnalysis(submission) {
     });
 }
 
+function relaunchAnalyses(analysisIds) {
+    return callApi({
+        endpoint: "/api/analyses/relauncher",
+        method: "POST",
+        body: { analyses: analysisIds },
+    });
+}
+
 function getAnalysisHistory(key, { id }) {
     return callApi({
         endpoint: `/api/analyses/${id}/history`,
@@ -48,6 +56,7 @@ export {
     getAnalysisHistory,
     getAnalysisParameters,
     getAnalysisRelaunchInfo,
+    relaunchAnalyses,
     submitAnalysis,
     ANALYSES_LISTING_QUERY_KEY,
     ANALYSIS_HISTORY_QUERY_KEY,

--- a/src/serviceFacades/analyses.js
+++ b/src/serviceFacades/analyses.js
@@ -1,8 +1,9 @@
 import callApi from "../common/callApi";
 
 const ANALYSES_LISTING_QUERY_KEY = "fetchAnalysesListingKey";
-const ANALYSIS_PARAMS_QUERY_KEY = "fetchAnalysisParamsKey";
 const ANALYSIS_HISTORY_QUERY_KEY = "fetchAnalysisHistoryKey";
+const ANALYSIS_PARAMS_QUERY_KEY = "fetchAnalysisParamsKey";
+const ANALYSIS_RELAUNCH_QUERY_KEY = "fetchAnalysisRelaunchKey";
 
 function getAnalyses(key, { rowsPerPage, orderBy, order, page, filter }) {
     return callApi({
@@ -35,12 +36,21 @@ function getAnalysisParameters(key, { id }) {
     });
 }
 
+function getAnalysisRelaunchInfo(key, { id }) {
+    return callApi({
+        endpoint: `/api/analyses/${id}/relaunch-info`,
+        method: "GET",
+    });
+}
+
 export {
     getAnalyses,
     getAnalysisHistory,
     getAnalysisParameters,
+    getAnalysisRelaunchInfo,
     submitAnalysis,
     ANALYSES_LISTING_QUERY_KEY,
     ANALYSIS_HISTORY_QUERY_KEY,
     ANALYSIS_PARAMS_QUERY_KEY,
+    ANALYSIS_RELAUNCH_QUERY_KEY,
 };

--- a/stories/analyses/Listing.stories.js
+++ b/stories/analyses/Listing.stories.js
@@ -11,7 +11,15 @@ export default {
 function ListingTest(props) {
     return (
         <NotificationsProvider>
-            <Listing baseId="tableView" />;
+            <Listing
+                baseId="tableView"
+                handleGoToOutputFolder={(analysis) =>
+                    console.log("Go to output folder", analysis?.resultfolderid)
+                }
+                handleRelaunch={(analysis) =>
+                    console.log("Relaunch Analysis", analysis?.id)
+                }
+            />
         </NotificationsProvider>
     );
 }

--- a/stories/analyses/Listing.stories.js
+++ b/stories/analyses/Listing.stories.js
@@ -16,7 +16,7 @@ function ListingTest(props) {
                 handleGoToOutputFolder={(analysis) =>
                     console.log("Go to output folder", analysis?.resultfolderid)
                 }
-                handleRelaunch={(analysis) =>
+                handleSingleRelaunch={(analysis) =>
                     console.log("Relaunch Analysis", analysis?.id)
                 }
             />
@@ -26,5 +26,7 @@ function ListingTest(props) {
 
 export const AnalysesListingTest = () => {
     mockAxios.onGet(/\/api\/analyses*/).reply(200, listing);
+    mockAxios.onPost("/api/analyses/relauncher").reply(200);
+
     return <ListingTest />;
 };

--- a/stories/analyses/TableView.stories.js
+++ b/stories/analyses/TableView.stories.js
@@ -23,8 +23,8 @@ export const AnalysesTableViewTest = () => {
             handleGoToOutputFolder={(analysis) =>
                 console.log("Go to output folder", analysis?.resultfolderid)
             }
-            handleRelaunch={(analysis) =>
-                console.log("Relaunch Analysis", analysis?.id)
+            handleRelaunch={(analyses) =>
+                console.log("Relaunch Analysis", analyses[0]?.id)
             }
             handleBatchIconClick={() => logger("Expand batch analyses")}
         />

--- a/stories/analyses/TableView.stories.js
+++ b/stories/analyses/TableView.stories.js
@@ -20,7 +20,12 @@ export const AnalysesTableViewTest = () => {
             handleSelectAllClick={() => logger("Select all clicked")}
             handleClick={() => logger("Row clicked")}
             handleInteractiveUrlClick={() => logger("Open VICE Analyses")}
-            handleGoToOutputFolder={() => logger("Go to output folder")}
+            handleGoToOutputFolder={(analysis) =>
+                console.log("Go to output folder", analysis?.resultfolderid)
+            }
+            handleRelaunch={(analysis) =>
+                console.log("Relaunch Analysis", analysis?.id)
+            }
             handleBatchIconClick={() => logger("Expand batch analyses")}
         />
     );

--- a/stories/apps/launch/data/SelectParamsApp.js
+++ b/stories/apps/launch/data/SelectParamsApp.js
@@ -127,7 +127,7 @@ export default {
                         },
                         {
                             name: "--int-list",
-                            isDefault: false,
+                            isDefault: true,
                             id: "e9de035e-5ce2-11ea-aa6d-008cfa5ae621",
                             display: "2",
                             value: "Value 2",

--- a/stories/apps/launch/relaunch/DEWordCount.stories.js
+++ b/stories/apps/launch/relaunch/DEWordCount.stories.js
@@ -1,0 +1,57 @@
+import React from "react";
+
+import constants from "../../../../src/constants";
+
+import AppLaunchStoryBase from "../AppLaunchStoryBase";
+import WordCountApp from "../data/WordCountApp";
+
+export const DEWordCountRelaunch = () => {
+    const [
+        {
+            parameters: [fileInput],
+            ...inputGroup
+        },
+    ] = WordCountApp.groups;
+
+    const fileValue = {
+        path: "/iplant/home/aramsey/CORE-9077_test_file.txt",
+    };
+
+    const app = {
+        ...WordCountApp,
+        description:
+            "This relaunch story should have preset values for the input file" +
+            " and for all resource requirements.",
+        requirements: [
+            {
+                step_number: 0,
+                default_memory: 2147483648,
+                default_disk_space: 1073741824,
+                default_cpu_cores: 1,
+            },
+        ],
+        groups: [
+            {
+                ...inputGroup,
+                parameters: [
+                    {
+                        ...fileInput,
+                        value: fileValue,
+                        defaultValue: fileValue,
+                    },
+                ],
+            },
+        ],
+    };
+
+    return (
+        <AppLaunchStoryBase
+            app={app}
+            defaultMaxCPUCores={8}
+            defaultMaxMemory={4 * constants.ONE_GiB}
+            defaultMaxDiskSpace={64 * constants.ONE_GiB}
+        />
+    );
+};
+
+export default { title: "Apps / Launch / Relaunch" };

--- a/stories/apps/launch/relaunch/InputParams.stories.js
+++ b/stories/apps/launch/relaunch/InputParams.stories.js
@@ -1,0 +1,65 @@
+import React from "react";
+
+import AppLaunchStoryBase from "../AppLaunchStoryBase";
+import InputParamsApp from "../data/InputParamsApp";
+
+export const InputParamsRelaunch = () => {
+    const [
+        {
+            parameters: [fileInput, folderInput, multiInput, ...parameters],
+            ...inputGroup
+        },
+        ...groups
+    ] = InputParamsApp.groups;
+
+    const fileValue = {
+        path: "/iplant/home/aramsey/CORE-9077_test_file.txt",
+    };
+
+    const folderValue = {
+        path: "/iplant/home/aramsey/bad'name",
+    };
+
+    const multiFileValue = {
+        path: [
+            "/iplant/home/aramsey/CORE-9077-path.list",
+            "/iplant/home/aramsey/CORE-9077_test_file.txt",
+            "/iplant/home/aramsey/Discovery Environment-CyVerse-blue.svg",
+        ],
+    };
+
+    const app = {
+        ...InputParamsApp,
+        description:
+            "This relaunch story should have preset values for all" +
+            " file and folder input fields.",
+        groups: [
+            {
+                ...inputGroup,
+                parameters: [
+                    {
+                        ...fileInput,
+                        value: fileValue,
+                        defaultValue: fileValue,
+                    },
+                    {
+                        ...folderInput,
+                        value: folderValue,
+                        defaultValue: folderValue,
+                    },
+                    {
+                        ...multiInput,
+                        value: multiFileValue,
+                        defaultValue: multiFileValue,
+                    },
+                    ...parameters,
+                ],
+            },
+            ...groups,
+        ],
+    };
+
+    return <AppLaunchStoryBase app={app} />;
+};
+
+export default { title: "Apps / Launch / Relaunch" };

--- a/stories/apps/launch/relaunch/ReferenceGenomeParams.stories.js
+++ b/stories/apps/launch/relaunch/ReferenceGenomeParams.stories.js
@@ -1,0 +1,93 @@
+import React from "react";
+
+import { mockAxios } from "../../../axiosMock";
+
+import AppLaunchStoryBase from "../AppLaunchStoryBase";
+import ReferenceGenomeApp from "../data/ReferenceGenomeApp";
+import ReferenceGenomeListing from "../data/ReferenceGenomeListing";
+
+export const ReferenceGenomeParamsRelaunch = () => {
+    mockAxios
+        .onGet(/\/api\/reference-genomes/)
+        .reply(200, ReferenceGenomeListing);
+
+    const [{ parameters, ...listGroup }] = ReferenceGenomeApp.groups;
+
+    const cacaoValue = {
+        created_by: "vaughn@iplantcollaborative.org",
+        id: "b7d3e1b7-e1f8-42cb-86b2-4f85e329e42a",
+        last_modified_by: "vaughn@iplantcollaborative.org",
+        name: "Theobroma cacao [Cocoa bean] (Phytozome 9.0)",
+        path:
+            "/data2/collections/genomeservices/1.0.0/phytozome/9.0/Theobroma_cacao.Matina_1-6/de_support/",
+        created_on: "1382790214000",
+        last_modified_on: "1382790214000",
+    };
+
+    const dogValue = {
+        created_by: "<public>",
+        id: "e38b6fae-2e4b-4217-8c1f-6badea3ff7fc",
+        last_modified_by: "vaughn@iplantcollaborative.org",
+        name: "Canis lupus familiaris [Dog] (Ensembl 14_67)",
+        path:
+            "/data2/collections/genomeservices/1.0.0/14_67/Canis_lupus_familiaris.CanFam_2.0/de_support/",
+        created_on: "1346948048000",
+        last_modified_on: "1378823110000",
+    };
+
+    const catValue = {
+        created_by: "<public>",
+        id: "41149e71-4328-4391-b1d2-25fdbdca5a54",
+        last_modified_by: "vaughn@iplantcollaborative.org",
+        name: "Felis catus [Domestic cat] (Ensembl 14_67)",
+        path:
+            "/data2/collections/genomeservices/1.0.0/14_67/Felis_catus.CAT/de_support/",
+        created_on: "1346948048000",
+        last_modified_on: "1378823157000",
+    };
+
+    const app = {
+        ...ReferenceGenomeApp,
+        description:
+            'This relaunch story should have the "[Cocoa bean]" preset for' +
+            ' the "Reference Genome" field,' +
+            ' "[Dog]" preset for the "Reference Sequence" field,' +
+            ' and "[Domestic cat]" preset for the "Reference Annotation" field.',
+        groups: [
+            {
+                ...listGroup,
+                parameters: parameters.map((param) => {
+                    if (param.label === "Reference Genome") {
+                        return {
+                            ...param,
+                            value: cacaoValue,
+                            defaultValue: cacaoValue,
+                        };
+                    }
+
+                    if (param.label === "Reference Sequence") {
+                        return {
+                            ...param,
+                            value: dogValue,
+                            defaultValue: dogValue,
+                        };
+                    }
+
+                    if (param.label === "Reference Annotation") {
+                        return {
+                            ...param,
+                            value: catValue,
+                            defaultValue: catValue,
+                        };
+                    }
+
+                    return param;
+                }),
+            },
+        ],
+    };
+
+    return <AppLaunchStoryBase app={app} />;
+};
+
+export default { title: "Apps / Launch / Relaunch" };

--- a/stories/apps/launch/relaunch/SelectParams.stories.js
+++ b/stories/apps/launch/relaunch/SelectParams.stories.js
@@ -1,0 +1,60 @@
+import React from "react";
+
+import AppLaunchStoryBase from "../AppLaunchStoryBase";
+import SelectParamsApp from "../data/SelectParamsApp";
+
+export const SelectParamsRelaunch = () => {
+    const [{ parameters, ...listGroup }] = SelectParamsApp.groups;
+
+    const requiredTextListValue = {
+        isDefault: true,
+        display: "Value 3",
+        id: "abc0c332-5ce1-11ea-8af3-008cfa5ae621",
+        name: "--required-list",
+        value: "val3",
+    };
+
+    const intListValue = {
+        name: "--int-list",
+        isDefault: false,
+        id: "e9de1a06-5ce2-11ea-aa6d-008cfa5ae621",
+        display: "3",
+        value: "Value 3",
+    };
+
+    const app = {
+        ...SelectParamsApp,
+        description:
+            'This relaunch story should have "3" preset for the' +
+            ' "Integer List" field, when the app default is normally "2",' +
+            ' and "Value 3" preset for the "Required Text List" field.',
+        groups: [
+            {
+                ...listGroup,
+                parameters: parameters.map((param) => {
+                    if (param.label === "Required Text List") {
+                        return {
+                            ...param,
+                            value: requiredTextListValue,
+                            defaultValue: requiredTextListValue,
+                        };
+                    }
+
+                    if (param.label === "Integer List") {
+                        return {
+                            ...param,
+                            value: intListValue,
+                            defaultValue: intListValue,
+                        };
+                    }
+
+                    return param;
+                }),
+            },
+        ],
+    };
+
+    return <AppLaunchStoryBase app={app} />;
+};
+
+export default { title: "Apps / Launch / Relaunch" };


### PR DESCRIPTION
This PR will add an analysis relaunch page and update the analyses listing `Relaunch` actions to route to this page.
It also adds a route to the `/analyses/relauncher` endpoint and adds multi-relaunch support to the analyses listing component.

This PR also includes bug fixes for app integrator default input file/folder values and default reference genome values.