### PR TITLE
CORE-1104 Update Sonora for async tasks

### DIFF
--- a/public/static/locales/en/data.json
+++ b/public/static/locales/en/data.json
@@ -1,5 +1,5 @@
 {
-    "asyncDataDeletePending": "File(s)/Folder(s) deletion in progress",
+    "asyncDataDeletePending": "Deletion in progress. You will be notified when completed.",
     "deleteResourceError": "Unable to delete selected resources. Please try again.",
     "filesQueuedForUploadMsg": "{{count}} file queued for upload",
     "filesQueuedForUploadMsg_plural": "{{count}} files queued for upload",

--- a/public/static/locales/en/data.json
+++ b/public/static/locales/en/data.json
@@ -1,0 +1,8 @@
+{
+    "asyncDataDeletePending": "File(s)/Folder(s) deletion in progress",
+    "deleteResourceError": "Unable to delete selected resources. Please try again.",
+    "filesQueuedForUploadMsg": "{{count}} file queued for upload",
+    "filesQueuedForUploadMsg_plural": "{{count}} files queued for upload",
+    "infoTypeFetchError": "Unable to fetch info types",
+    "uploadQueue": "View Upload Queue"
+}

--- a/src/components/layout/Notifications.js
+++ b/src/components/layout/Notifications.js
@@ -28,6 +28,12 @@ import {
 import { useTheme } from "@material-ui/core/styles";
 import NotificationsIcon from "@material-ui/icons/Notifications";
 
+function getDisplayMessage(notification) {
+    return notification.type === "data"
+        ? notification.subject
+        : notification.message.text;
+}
+
 function Notifications(props) {
     const { t } = useTranslation("common");
     const [currentNotification] = useNotifications();
@@ -106,7 +112,7 @@ function Notifications(props) {
                 displayAnalysisNotification(notification, analysisStatus);
             } else {
                 announce({
-                    text: notification.message.text,
+                    text: getDisplayMessage(notification),
                 });
             }
         },

--- a/src/pages/data/ds/[...pathItems].js
+++ b/src/pages/data/ds/[...pathItems].js
@@ -48,3 +48,13 @@ export default function DataStore() {
         />
     );
 }
+
+DataStore.getInitialProps = async ({ Component, ctx }) => {
+    let pageProps = {};
+
+    if (Component.getInitialProps) {
+        pageProps = await Component.getInitialProps(ctx);
+    }
+
+    return { pageProps, namespacesRequired: ["data"] };
+};


### PR DESCRIPTION
The only move action from the DE we have right now in Sonora is delete.  I made the message shorter than what's in the DE because I wanted the announcer to be small enough for mobile.  Any wording suggestions there are welcome.

I also started converting Data over to using react-i18next.  This PR only has the Data Listing converted.  Next PR will have all of Data converted, just still need to validate nothing broke.