### PR TITLE
Mobile launch

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,10 @@
         "moduleNameMapper": {
             "\\.(jpg|png|svg)$": "<rootDir>/src/__mocks__/imageMock.js"
         },
-        "moduleDirectories": ["node_modules", "src"]
+        "moduleDirectories": [
+            "node_modules",
+            "src"
+        ]
     },
     "lint-staged": {
         "*.js": [

--- a/src/components/apps/launch/AnalysisInfoForm.js
+++ b/src/components/apps/launch/AnalysisInfoForm.js
@@ -1,5 +1,5 @@
 /**
- * @author psarando
+ * @author psarando, sriram
  *
  * An App Launch form for collecting top-level analysis info,
  * such as analysis name, comments, and output folder.

--- a/src/components/apps/launch/AppLaunchForm.js
+++ b/src/components/apps/launch/AppLaunchForm.js
@@ -52,6 +52,7 @@ import {
 import {
     Box,
     Button,
+    Container,
     MobileStepper,
     Stepper,
     Step,
@@ -80,7 +81,7 @@ const useStyles = makeStyles(styles);
 const NAVIGATION_BAR_HEIGHT = 105;
 
 //include mobile stepper navigation height
-const MOBILE_NAVIGATION_BAR_HEIGHT = 135;
+const MOBILE_NAVIGATION_BAR_HEIGHT = 155;
 
 const ReferenceGenomeParamTypes = [
     constants.PARAM_TYPE.REFERENCE_GENOME,
@@ -95,7 +96,10 @@ const StepContent = ({ id, hidden, step, label, children, offsetHeight }) => {
         <PageWrapper appBarHeight={offsetHeight}>
             <fieldset id={id} hidden={hidden}>
                 <legend>
-                    <Typography variant={isMobile? "subtitle2": "caption"} color={isMobile ? "primary" : "inherit"}>
+                    <Typography
+                        variant={isMobile ? "subtitle2" : "caption"}
+                        color={isMobile ? "primary" : "inherit"}
+                    >
                         {getMessage("stepLabel", {
                             values: { step: step + 1, label },
                         })}
@@ -123,13 +127,10 @@ const StepperBottomNavigation = React.forwardRef((props, ref) => {
     if (isMobile) {
         if (showSubmitButton) {
             return (
-                <Toolbar
-                    variant="dense"
-                    className={classes.bottomNavigation}
-                    ref={ref}
-                >
+                <Container ref={ref}>
                     {showSaveQuickLaunchButton && (
                         <Button
+                            color="primary"
                             className={classes.bottomNavigationAction}
                             id={buildDebugId(
                                 formId,
@@ -137,21 +138,24 @@ const StepperBottomNavigation = React.forwardRef((props, ref) => {
                             )}
                             startIcon={<Save />}
                             size="small"
+                            variant="contained"
                             onClick={handleSaveQuickLaunch}
                         >
                             {getMessage("saveAsQuickLaunch")}
                         </Button>
                     )}
                     <Button
+                        color="primary"
                         className={classes.bottomNavigationAction}
                         id={buildDebugId(formId, ids.BUTTONS.SUBMIT)}
                         startIcon={<PlayArrow />}
                         size="small"
+                        variant="contained"
                         onClick={(event) => handleSubmit(event)}
                     >
                         {getMessage("launchAnalysis")}
                     </Button>
-                </Toolbar>
+                </Container>
             );
         } else {
             return <div ref={ref} />;

--- a/src/components/apps/launch/AppLaunchForm.js
+++ b/src/components/apps/launch/AppLaunchForm.js
@@ -50,7 +50,7 @@ import {
 } from "@cyverse-de/ui-lib";
 
 import {
-    Container,
+    Box,
     Button,
     MobileStepper,
     Stepper,
@@ -80,7 +80,7 @@ const useStyles = makeStyles(styles);
 const NAVIGATION_BAR_HEIGHT = 105;
 
 //include mobile stepper navigation height
-const MOBILE_NAVIGATION_BAR_HEIGHT = 125;
+const MOBILE_NAVIGATION_BAR_HEIGHT = 135;
 
 const ReferenceGenomeParamTypes = [
     constants.PARAM_TYPE.REFERENCE_GENOME,
@@ -88,20 +88,24 @@ const ReferenceGenomeParamTypes = [
     constants.PARAM_TYPE.REFERENCE_ANNOTATION,
 ];
 
-const StepContent = ({ id, hidden, step, label, children, offsetHeight }) => (
-    <PageWrapper appBarHeight={offsetHeight}>
-        <fieldset id={id} hidden={hidden}>
-            <legend>
-                <Typography variant="caption">
-                    {getMessage("stepLabel", {
-                        values: { step: step + 1, label },
-                    })}
-                </Typography>
-            </legend>
-            {children}
-        </fieldset>
-    </PageWrapper>
-);
+const StepContent = ({ id, hidden, step, label, children, offsetHeight }) => {
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down("xs"));
+    return (
+        <PageWrapper appBarHeight={offsetHeight}>
+            <fieldset id={id} hidden={hidden}>
+                <legend>
+                    <Typography variant={isMobile? "subtitle2": "caption"} color={isMobile ? "primary" : "inherit"}>
+                        {getMessage("stepLabel", {
+                            values: { step: step + 1, label },
+                        })}
+                    </Typography>
+                </legend>
+                {children}
+            </fieldset>
+        </PageWrapper>
+    );
+};
 
 const StepperBottomNavigation = React.forwardRef((props, ref) => {
     const {
@@ -241,7 +245,7 @@ const LaunchStepper = React.forwardRef((props, ref) => {
                         id={buildDebugId(formId, ids.BUTTONS.STEP_NEXT)}
                         color="primary"
                     >
-                         {getMessage("next")}
+                        {getMessage("next")}
                         {theme.direction === "rtl" ? (
                             <KeyboardArrowLeft />
                         ) : (
@@ -738,10 +742,7 @@ const AppLaunchForm = (props) => {
                                 ref={stepperRef}
                             />
                         )}
-                        <Container
-                            component="div"
-                            className={classes.stepContainer}
-                        >
+                        <Box component="div" className={classes.stepContainer}>
                             <StepContent
                                 id={buildDebugId(
                                     formId,
@@ -840,7 +841,7 @@ const AppLaunchForm = (props) => {
                                     />
                                 )}
                             </StepContent>
-                        </Container>
+                        </Box>
                         <div className={classes.spacer}></div>
                         {isSubmitting ? (
                             <BottomNavigationSkeleton ref={bottomNavRef} />

--- a/src/components/apps/launch/AppLaunchForm.js
+++ b/src/components/apps/launch/AppLaunchForm.js
@@ -52,7 +52,7 @@ import {
 import {
     Container,
     Button,
-    Hidden,
+    MobileStepper,
     Stepper,
     Step,
     StepButton,
@@ -64,14 +64,23 @@ import {
     useTheme,
 } from "@material-ui/core";
 
-import { ArrowBack, ArrowForward, PlayArrow, Save } from "@material-ui/icons";
+import {
+    ArrowBack,
+    ArrowForward,
+    KeyboardArrowLeft,
+    KeyboardArrowRight,
+    PlayArrow,
+    Save,
+} from "@material-ui/icons";
 
 const useStyles = makeStyles(styles);
 
 // sonora appbar height.
 //Stepper height, appinfo height and bottom nav height is calculated dynamically.
 const NAVIGATION_BAR_HEIGHT = 105;
-const MOBILE_NAVIGATION_BAR_HEIGHT = 75;
+
+//include mobile stepper navigation height
+const MOBILE_NAVIGATION_BAR_HEIGHT = 125;
 
 const ReferenceGenomeParamTypes = [
     constants.PARAM_TYPE.REFERENCE_GENOME,
@@ -107,51 +116,194 @@ const StepperBottomNavigation = React.forwardRef((props, ref) => {
     const classes = useStyles();
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down("xs"));
-    return (
-        <Toolbar variant="dense" className={classes.bottomNavigation} ref={ref}>
-            <Button
-                id={buildDebugId(formId, ids.BUTTONS.STEP_BACK)}
-                className={classes.bottomNavigationAction}
-                startIcon={<ArrowBack />}
-                size="small"
-                onClick={handleBack}
+    if (isMobile) {
+        if (showSubmitButton) {
+            return (
+                <Toolbar
+                    variant="dense"
+                    className={classes.bottomNavigation}
+                    ref={ref}
+                >
+                    {showSaveQuickLaunchButton && (
+                        <Button
+                            className={classes.bottomNavigationAction}
+                            id={buildDebugId(
+                                formId,
+                                ids.BUTTONS.SAVE_AS_QUICK_LAUNCH
+                            )}
+                            startIcon={<Save />}
+                            size="small"
+                            onClick={handleSaveQuickLaunch}
+                        >
+                            {getMessage("saveAsQuickLaunch")}
+                        </Button>
+                    )}
+                    <Button
+                        className={classes.bottomNavigationAction}
+                        id={buildDebugId(formId, ids.BUTTONS.SUBMIT)}
+                        startIcon={<PlayArrow />}
+                        size="small"
+                        onClick={(event) => handleSubmit(event)}
+                    >
+                        {getMessage("launchAnalysis")}
+                    </Button>
+                </Toolbar>
+            );
+        } else {
+            return <div ref={ref} />;
+        }
+    } else {
+        return (
+            <Toolbar
+                variant="dense"
+                className={classes.bottomNavigation}
+                ref={ref}
             >
-                {isMobile ? "" : getMessage("back")}
-            </Button>
-            {showSaveQuickLaunchButton && (
                 <Button
+                    id={buildDebugId(formId, ids.BUTTONS.STEP_BACK)}
                     className={classes.bottomNavigationAction}
-                    id={buildDebugId(formId, ids.BUTTONS.SAVE_AS_QUICK_LAUNCH)}
-                    startIcon={<Save />}
+                    startIcon={<ArrowBack />}
                     size="small"
-                    onClick={handleSaveQuickLaunch}
+                    onClick={handleBack}
                 >
-                    {isMobile ? "" : getMessage("saveAsQuickLaunch")}
+                    {getMessage("back")}
                 </Button>
-            )}
-            {showSubmitButton ? (
-                <Button
-                    className={classes.bottomNavigationAction}
-                    id={buildDebugId(formId, ids.BUTTONS.SUBMIT)}
-                    startIcon={<PlayArrow />}
-                    size="small"
-                    onClick={(event) => handleSubmit(event)}
-                >
-                    {isMobile ? "" : getMessage("launchAnalysis")}
-                </Button>
-            ) : (
-                <Button
-                    className={classes.bottomNavigationAction}
-                    id={buildDebugId(formId, ids.BUTTONS.STEP_NEXT)}
-                    endIcon={<ArrowForward />}
-                    size="small"
-                    onClick={handleNext}
-                >
-                    {isMobile ? "" : getMessage("next")}
-                </Button>
-            )}
-        </Toolbar>
-    );
+                {showSaveQuickLaunchButton && (
+                    <Button
+                        className={classes.bottomNavigationAction}
+                        id={buildDebugId(
+                            formId,
+                            ids.BUTTONS.SAVE_AS_QUICK_LAUNCH
+                        )}
+                        startIcon={<Save />}
+                        size="small"
+                        onClick={handleSaveQuickLaunch}
+                    >
+                        {getMessage("saveAsQuickLaunch")}
+                    </Button>
+                )}
+                {showSubmitButton ? (
+                    <Button
+                        className={classes.bottomNavigationAction}
+                        id={buildDebugId(formId, ids.BUTTONS.SUBMIT)}
+                        startIcon={<PlayArrow />}
+                        size="small"
+                        onClick={(event) => handleSubmit(event)}
+                    >
+                        {getMessage("launchAnalysis")}
+                    </Button>
+                ) : (
+                    <Button
+                        className={classes.bottomNavigationAction}
+                        id={buildDebugId(formId, ids.BUTTONS.STEP_NEXT)}
+                        endIcon={<ArrowForward />}
+                        size="small"
+                        onClick={handleNext}
+                    >
+                        {getMessage("next")}
+                    </Button>
+                )}
+            </Toolbar>
+        );
+    }
+});
+
+const LaunchStepper = React.forwardRef((props, ref) => {
+    const {
+        steps,
+        handleStep,
+        handleNext,
+        handleBack,
+        isLastStep,
+        activeStep,
+        formId,
+        errors,
+        touched,
+        groups,
+    } = props;
+    const theme = useTheme();
+    const classes = useStyles();
+    const isMobile = useMediaQuery(theme.breakpoints.down("xs"));
+
+    if (isMobile) {
+        return (
+            <MobileStepper
+                activeStep={activeStep}
+                ref={ref}
+                steps={steps?.length}
+                position="bottom"
+                nextButton={
+                    <Button
+                        size="small"
+                        variant="contained"
+                        onClick={handleNext}
+                        disabled={isLastStep()}
+                        id={buildDebugId(formId, ids.BUTTONS.STEP_NEXT)}
+                        color="primary"
+                    >
+                         {getMessage("next")}
+                        {theme.direction === "rtl" ? (
+                            <KeyboardArrowLeft />
+                        ) : (
+                            <KeyboardArrowRight />
+                        )}
+                    </Button>
+                }
+                backButton={
+                    <Button
+                        size="small"
+                        variant="contained"
+                        onClick={handleBack}
+                        disabled={activeStep === 0}
+                        id={buildDebugId(formId, ids.BUTTONS.STEP_BACK)}
+                    >
+                        {theme.direction === "rtl" ? (
+                            <KeyboardArrowRight />
+                        ) : (
+                            <KeyboardArrowLeft />
+                        )}
+                        {getMessage("back")}
+                    </Button>
+                }
+            />
+        );
+    } else {
+        return (
+            <Stepper
+                alternativeLabel
+                nonLinear
+                activeStep={activeStep}
+                ref={ref}
+                className={classes.stepper}
+            >
+                {steps.map((step, index) => (
+                    <Step key={step.label}>
+                        <StepButton
+                            id={buildDebugId(
+                                formId,
+                                ids.BUTTONS.STEP,
+                                index + 1
+                            )}
+                            onClick={handleStep(index)}
+                        >
+                            <StepLabel
+                                error={
+                                    !!displayStepError(
+                                        index,
+                                        errors,
+                                        touched,
+                                        groups
+                                    )
+                                }
+                            >
+                                {step.label}
+                            </StepLabel>
+                        </StepButton>
+                    </Step>
+                ))}
+            </Stepper>
+        );
+    }
 });
 
 /**
@@ -572,41 +724,19 @@ const AppLaunchForm = (props) => {
                         {isSubmitting ? (
                             <StepperSkeleton baseId={formId} ref={stepperRef} />
                         ) : (
-                            <Stepper
-                                alternativeLabel
-                                nonLinear
+                            <LaunchStepper
+                                steps={steps}
+                                handleStep={handleStep}
+                                handleNext={handleNext}
+                                handleBack={handleBack}
                                 activeStep={activeStep}
+                                isLastStep={isLastStep}
+                                formId={formId}
+                                errors={errors}
+                                touched={touched}
+                                groups={groups}
                                 ref={stepperRef}
-                                className={classes.stepper}
-                            >
-                                {steps.map((step, index) => (
-                                    <Step key={step.label}>
-                                        <StepButton
-                                            id={buildDebugId(
-                                                formId,
-                                                ids.BUTTONS.STEP,
-                                                index + 1
-                                            )}
-                                            onClick={handleStep(index)}
-                                        >
-                                            <StepLabel
-                                                error={
-                                                    !!displayStepError(
-                                                        index,
-                                                        errors,
-                                                        touched,
-                                                        groups
-                                                    )
-                                                }
-                                            >
-                                                <Hidden xsDown>
-                                                    {step.label}
-                                                </Hidden>
-                                            </StepLabel>
-                                        </StepButton>
-                                    </Step>
-                                ))}
-                            </Stepper>
+                            />
                         )}
                         <Container
                             component="div"

--- a/src/components/apps/launch/AppLaunchFormSkeleton.js
+++ b/src/components/apps/launch/AppLaunchFormSkeleton.js
@@ -11,6 +11,7 @@ import styles from "./styles";
 import { build as buildDebugId } from "@cyverse-de/ui-lib";
 
 import {
+    Box,
     Button,
     Container,
     MobileStepper,
@@ -79,7 +80,7 @@ export default ({ baseId }) => {
     return (
         <>
             <StepperSkeleton baseId={baseId} />
-            <Container component="div" className={classes.stepContainer}>
+            <Box component="div" className={classes.stepContainer}>
                 <Container component="fieldset">
                     <Typography variant="h3" gutterBottom>
                         <Skeleton variant="text" />
@@ -93,7 +94,7 @@ export default ({ baseId }) => {
                         <Skeleton variant="text" />
                     </Typography>
                 </Container>
-            </Container>
+            </Box>
             {!isMobile && <BottomNavigationSkeleton />}
         </>
     );

--- a/src/components/apps/launch/AppLaunchFormSkeleton.js
+++ b/src/components/apps/launch/AppLaunchFormSkeleton.js
@@ -6,13 +6,14 @@
 import React from "react";
 
 import ids from "./ids";
-
 import styles from "./styles";
 
 import { build as buildDebugId } from "@cyverse-de/ui-lib";
 
 import {
+    Button,
     Container,
+    MobileStepper,
     Step,
     Stepper,
     StepButton,
@@ -20,24 +21,50 @@ import {
     Toolbar,
     Typography,
     makeStyles,
+    useMediaQuery,
+    useTheme,
 } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
 
 const useStyles = makeStyles(styles);
 
-export const StepperSkeleton = React.forwardRef(({ baseId }, ref) => (
-    <Skeleton
-        id={buildDebugId(baseId, ids.LOADING_SKELETON)}
-        width="100%"
-        ref={ref}
-    >
-        <Stepper alternativeLabel nonLinear>
-            <Step>
-                <StepButton>&nbsp;</StepButton>
-            </Step>
-        </Stepper>
-    </Skeleton>
-));
+export const StepperSkeleton = React.forwardRef(({ baseId }, ref) => {
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down("xs"));
+
+    if (isMobile) {
+        return (
+            <Skeleton
+                id={buildDebugId(baseId, ids.LOADING_SKELETON)}
+                width="100%"
+                ref={ref}
+            >
+                <MobileStepper
+                    activeStep={0}
+                    ref={ref}
+                    steps={4}
+                    position="bottom"
+                    nextButton={<Button size="small">&nbsp;</Button>}
+                    backButton={<Button size="small">&nbps;</Button>}
+                />
+            </Skeleton>
+        );
+    } else {
+        return (
+            <Skeleton
+                id={buildDebugId(baseId, ids.LOADING_SKELETON)}
+                width="100%"
+                ref={ref}
+            >
+                <Stepper alternativeLabel nonLinear>
+                    <Step>
+                        <StepButton>&nbsp;</StepButton>
+                    </Step>
+                </Stepper>
+            </Skeleton>
+        );
+    }
+});
 
 export const BottomNavigationSkeleton = React.forwardRef((props, ref) => (
     <Skeleton variant="rect" width="100%" ref={ref}>
@@ -47,15 +74,12 @@ export const BottomNavigationSkeleton = React.forwardRef((props, ref) => (
 
 export default ({ baseId }) => {
     const classes = useStyles();
-
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down("xs"));
     return (
         <>
             <StepperSkeleton baseId={baseId} />
-            <Container
-                component="div"
-                className={classes.stepContent}
-                maxWidth="md"
-            >
+            <Container component="div" className={classes.stepContainer}>
                 <Container component="fieldset">
                     <Typography variant="h3" gutterBottom>
                         <Skeleton variant="text" />
@@ -70,7 +94,7 @@ export default ({ baseId }) => {
                     </Typography>
                 </Container>
             </Container>
-            <BottomNavigationSkeleton />
+            {!isMobile && <BottomNavigationSkeleton />}
         </>
     );
 };

--- a/src/components/apps/launch/AppLaunchFormSkeleton.js
+++ b/src/components/apps/launch/AppLaunchFormSkeleton.js
@@ -1,5 +1,5 @@
 /**
- * @author psarando
+ * @author psarando, sriram
  *
  * A Loading Mask for the App Launch Form.
  */

--- a/src/components/apps/launch/InputSelector.js
+++ b/src/components/apps/launch/InputSelector.js
@@ -1,5 +1,5 @@
 /**
- * @author psarando
+ * @author psarando, sriram
  *
  * Input Selector form field for picking a path from the data store.
  */
@@ -22,7 +22,13 @@ import {
     FormTextField,
 } from "@cyverse-de/ui-lib";
 
-import { Button, Grid, IconButton, makeStyles } from "@material-ui/core";
+import {
+    Button,
+    Grid,
+    IconButton,
+    InputAdornment,
+    makeStyles,
+} from "@material-ui/core";
 
 import ClearIcon from "@material-ui/icons/Clear";
 
@@ -40,7 +46,6 @@ const BrowseButton = (props) => {
         onConfirm,
     } = props;
 
-    const classes = useStyles();
     const [open, setOpen] = React.useState(false);
 
     return (
@@ -50,7 +55,6 @@ const BrowseButton = (props) => {
                 size="small"
                 variant="outlined"
                 onClick={() => setOpen(true)}
-                className={classes.inputSelectorBrowseButton}
             >
                 {getMessage("browse")}
             </Button>
@@ -84,6 +88,19 @@ const InputSelector = ({ intl, acceptedType, startingPath, ...props }) => {
 
     const inputProps = {
         readOnly: true,
+        endAdornment:
+            <InputAdornment position="end">
+                <BrowseButton
+                    baseId={id}
+                    startingPath={startingPath}
+                    acceptedType={acceptedType}
+                    multiSelect={false}
+                    name={field.name}
+                    onConfirm={(selections) => {
+                        setFieldValue(field.name, selections);
+                    }}
+                />
+            </InputAdornment>
     };
 
     if (field.value && !required) {
@@ -112,18 +129,6 @@ const InputSelector = ({ intl, acceptedType, startingPath, ...props }) => {
                     size="small"
                     className={classes.inputSelectorTextFiled}
                     {...props}
-                />
-            </Grid>
-            <Grid item>
-                <BrowseButton
-                    baseId={id}
-                    startingPath={startingPath}
-                    acceptedType={acceptedType}
-                    multiSelect={false}
-                    name={field.name}
-                    onConfirm={(selections) => {
-                        setFieldValue(field.name, selections);
-                    }}
                 />
             </Grid>
         </Grid>

--- a/src/components/apps/launch/InputSelector.js
+++ b/src/components/apps/launch/InputSelector.js
@@ -88,7 +88,7 @@ const InputSelector = ({ intl, acceptedType, startingPath, ...props }) => {
 
     const inputProps = {
         readOnly: true,
-        endAdornment:
+        endAdornment: (
             <InputAdornment position="end">
                 <BrowseButton
                     baseId={id}
@@ -101,6 +101,7 @@ const InputSelector = ({ intl, acceptedType, startingPath, ...props }) => {
                     }}
                 />
             </InputAdornment>
+        ),
     };
 
     if (field.value && !required) {

--- a/src/components/apps/launch/styles.js
+++ b/src/components/apps/launch/styles.js
@@ -3,19 +3,10 @@ export default (theme) => ({
 
     stepper: {
         padding: theme.spacing(1),
-        [theme.breakpoints.down("xs")]: {
-            margin: theme.spacing(0.3),
-        },
     },
     stepContainer: {
         overflow: "auto",
-    },
-    stepContent: {
-        overflow: "auto",
-        padding: theme.spacing(1),
-        [theme.breakpoints.down("xs")]: {
-            padding: theme.spacing(0.3),
-        },
+
     },
     spacer: {
         margin: theme.spacing(1),

--- a/src/components/apps/launch/styles.js
+++ b/src/components/apps/launch/styles.js
@@ -48,13 +48,13 @@ export default (theme) => ({
     inputSelectorBrowseButton: {
         marginLeft: theme.spacing(1),
         [theme.breakpoints.down("xs")]: {
-            marginLeft: theme.spacing(0.3),
+            marginLeft: theme.spacing(0.1),
         },
     },
     inputSelectorTextFiled: {
         paddingRight: theme.spacing(1),
         [theme.breakpoints.down("xs")]: {
-            paddingRight: theme.spacing(0.3),
+            paddingRight: theme.spacing(0.1),
         },
     },
 });

--- a/src/components/apps/launch/styles.js
+++ b/src/components/apps/launch/styles.js
@@ -6,7 +6,6 @@ export default (theme) => ({
     },
     stepContainer: {
         overflow: "auto",
-
     },
     spacer: {
         margin: theme.spacing(1),
@@ -29,8 +28,14 @@ export default (theme) => ({
         backgroundColor: theme.palette.primary.main,
     },
     bottomNavigationAction: {
-        flexGrow: 1,
-        color: theme.palette.primary.contrastText,
+        [theme.breakpoints.down("xs")]: {
+            width: "100%",
+            margin: theme.spacing(0.5),
+        },
+        [theme.breakpoints.up("sm")]: {
+            flexGrow: 1,
+            color: theme.palette.primary.contrastText,
+        },
     },
     paramsReview: {
         margin: theme.spacing(1),


### PR DESCRIPTION
UX improvements to Analyses launch.
- Use `MobileStepper` for mobile screen. This makes the `Back` and `Next` Button stay put at the bottom.
- Fix issues with `Browse` button.
- Last step will show `Save as Quick Launch` and `Launch Analysis` options.

- iPhone 5 / SE
![image](https://user-images.githubusercontent.com/1250790/89193459-03821200-d574-11ea-96c2-bd4f56ef0162.png)

![image](https://user-images.githubusercontent.com/1250790/89193494-0da41080-d574-11ea-9a6c-cae52fada2f9.png)

- Agave Launch

![image](https://user-images.githubusercontent.com/1250790/89193526-1ac0ff80-d574-11ea-9aaf-c88e3de24497.png)

- DE Launch

![image](https://user-images.githubusercontent.com/1250790/89193874-9b7ffb80-d574-11ea-98e6-90c7530a155c.png)


