### PR TITLE
CORE-1116: detect when a user has logged out and update the CyVerseAppBar accordingly.

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -17,6 +17,7 @@ sessions:
     secret: "keyboard cat"
     secure_cookie: false
     ttl: 8
+    poll_interval_ms: 5000
 
 keycloak:
     server_url: "https://kc.cyverse.org/auth"

--- a/next.config.js
+++ b/next.config.js
@@ -15,6 +15,9 @@ module.exports = withBundleAnalyzer({
         ADMIN_GROUPS: config.get("admin.groups"),
         ADMIN_GROUP_ATTRIBUTE: config.get("admin.group_attribute_name"),
         IRODS_HOME_PATH: config.get("irods.home_path"),
+        SESSION_POLL_INTERVAL_MS: config.has("sessions.poll_interval_ms")
+            ? config.get("sessions.poll_interval_ms")
+            : null,
         TOOLS_PRIVATE_MAX_CPU_LIMIT: config.has("tools.private.max_cpu_limit")
             ? config.get("tools.private.max_cpu_limit")
             : 8,

--- a/next.config.js
+++ b/next.config.js
@@ -17,7 +17,7 @@ module.exports = withBundleAnalyzer({
         IRODS_HOME_PATH: config.get("irods.home_path"),
         SESSION_POLL_INTERVAL_MS: config.has("sessions.poll_interval_ms")
             ? config.get("sessions.poll_interval_ms")
-            : null,
+            : 5000,
         TOOLS_PRIVATE_MAX_CPU_LIMIT: config.has("tools.private.max_cpu_limit")
             ? config.get("tools.private.max_cpu_limit")
             : 8,

--- a/src/components/layout/CyVerseAppBar.js
+++ b/src/components/layout/CyVerseAppBar.js
@@ -27,7 +27,6 @@ import {
     bootstrap,
     BOOTSTRAP_KEY,
     USER_PROFILE_QUERY_KEY,
-    DEFAULT_USER_PROFILE_REFETCH_INTERVAL,
 } from "../../serviceFacades/users";
 
 import { build, CyVerseAnnouncer } from "@cyverse-de/ui-lib";
@@ -226,20 +225,13 @@ function CyverseAppBar(props) {
     const [bootstrapQueryKey, setBootstrapQueryKey] = useState(BOOTSTRAP_KEY);
     const [bootstrapQueryEnabled, setBootstrapQueryEnabled] = useState(false);
 
-    function getUserProfileRefetchInterval() {
-        return (
-            clientConfig?.sessions?.poll_interval_ms ||
-            DEFAULT_USER_PROFILE_REFETCH_INTERVAL
-        );
-    }
-
     useQuery({
         queryKey: USER_PROFILE_QUERY_KEY,
         queryFn: getUserProfile,
         config: {
             enabled: true,
             onSuccess: setUserProfile,
-            refetchInterval: getUserProfileRefetchInterval(),
+            refetchInterval: clientConfig.sessions.poll_interval_ms,
         },
     });
 

--- a/src/components/layout/CyVerseAppBar.js
+++ b/src/components/layout/CyVerseAppBar.js
@@ -27,6 +27,7 @@ import {
     bootstrap,
     BOOTSTRAP_KEY,
     USER_PROFILE_QUERY_KEY,
+    USER_PROFILE_REFETCH_INTERVAL,
 } from "../../serviceFacades/users";
 
 import { build, CyVerseAnnouncer } from "@cyverse-de/ui-lib";
@@ -231,8 +232,7 @@ function CyverseAppBar(props) {
         config: {
             enabled: true,
             onSuccess: setUserProfile,
-            cacheTime: Infinity,
-            staleTime: Infinity,
+            refetchInterval: USER_PROFILE_REFETCH_INTERVAL,
         },
     });
 

--- a/src/components/layout/CyVerseAppBar.js
+++ b/src/components/layout/CyVerseAppBar.js
@@ -27,7 +27,7 @@ import {
     bootstrap,
     BOOTSTRAP_KEY,
     USER_PROFILE_QUERY_KEY,
-    USER_PROFILE_REFETCH_INTERVAL,
+    DEFAULT_USER_PROFILE_REFETCH_INTERVAL,
 } from "../../serviceFacades/users";
 
 import { build, CyVerseAnnouncer } from "@cyverse-de/ui-lib";
@@ -226,13 +226,20 @@ function CyverseAppBar(props) {
     const [bootstrapQueryKey, setBootstrapQueryKey] = useState(BOOTSTRAP_KEY);
     const [bootstrapQueryEnabled, setBootstrapQueryEnabled] = useState(false);
 
+    function getUserProfileRefetchInterval() {
+        return (
+            clientConfig?.sessions?.poll_interval_ms ||
+            DEFAULT_USER_PROFILE_REFETCH_INTERVAL
+        );
+    }
+
     useQuery({
         queryKey: USER_PROFILE_QUERY_KEY,
         queryFn: getUserProfile,
         config: {
             enabled: true,
             onSuccess: setUserProfile,
-            refetchInterval: USER_PROFILE_REFETCH_INTERVAL,
+            refetchInterval: getUserProfileRefetchInterval(),
         },
     });
 

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -102,6 +102,9 @@ function MyApp({ Component, pageProps }) {
         const irods = {
             home_path: publicRuntimeConfig.IRODS_HOME_PATH,
         };
+        const sessions = {
+            poll_interval_ms: publicRuntimeConfig.SESSION_POLL_INTERVAL_MS,
+        };
         const tools = {
             private: {
                 max_cpu_limit: publicRuntimeConfig.TOOLS_PRIVATE_MAX_CPU_LIMIT,
@@ -112,8 +115,8 @@ function MyApp({ Component, pageProps }) {
             },
         };
 
-        if (intercom || admin || irods || tools) {
-            setConfig({ intercom, admin, irods, tools });
+        if (intercom || admin || irods || sessions || tools) {
+            setConfig({ intercom, admin, irods, sessions, tools });
         }
         const jssStyles = document.querySelector("#jss-server-side");
         if (jssStyles) {

--- a/src/serviceFacades/users.js
+++ b/src/serviceFacades/users.js
@@ -9,7 +9,7 @@ const BOOTSTRAP_KEY = "bootstrap";
  */
 
 const USER_PROFILE_QUERY_KEY = "fetchUserProfile";
-const USER_PROFILE_REFETCH_INTERVAL = 5000;
+const DEFAULT_USER_PROFILE_REFETCH_INTERVAL = 5000;
 const REDIRECT_URI_QUERY_KEY = "fetchRedirectURI";
 
 const getUserInfo = (key, { userIds }) => {
@@ -63,7 +63,7 @@ function getRedirectURIs() {
 export {
     BOOTSTRAP_KEY,
     USER_PROFILE_QUERY_KEY,
-    USER_PROFILE_REFETCH_INTERVAL,
+    DEFAULT_USER_PROFILE_REFETCH_INTERVAL,
     REDIRECT_URI_QUERY_KEY,
     getUserInfo,
     getUserProfile,

--- a/src/serviceFacades/users.js
+++ b/src/serviceFacades/users.js
@@ -9,6 +9,7 @@ const BOOTSTRAP_KEY = "bootstrap";
  */
 
 const USER_PROFILE_QUERY_KEY = "fetchUserProfile";
+const USER_PROFILE_REFETCH_INTERVAL = 5000;
 const REDIRECT_URI_QUERY_KEY = "fetchRedirectURI";
 
 const getUserInfo = (key, { userIds }) => {
@@ -62,6 +63,7 @@ function getRedirectURIs() {
 export {
     BOOTSTRAP_KEY,
     USER_PROFILE_QUERY_KEY,
+    USER_PROFILE_REFETCH_INTERVAL,
     REDIRECT_URI_QUERY_KEY,
     getUserInfo,
     getUserProfile,

--- a/src/serviceFacades/users.js
+++ b/src/serviceFacades/users.js
@@ -9,7 +9,6 @@ const BOOTSTRAP_KEY = "bootstrap";
  */
 
 const USER_PROFILE_QUERY_KEY = "fetchUserProfile";
-const DEFAULT_USER_PROFILE_REFETCH_INTERVAL = 5000;
 const REDIRECT_URI_QUERY_KEY = "fetchRedirectURI";
 
 const getUserInfo = (key, { userIds }) => {
@@ -63,7 +62,6 @@ function getRedirectURIs() {
 export {
     BOOTSTRAP_KEY,
     USER_PROFILE_QUERY_KEY,
-    DEFAULT_USER_PROFILE_REFETCH_INTERVAL,
     REDIRECT_URI_QUERY_KEY,
     getUserInfo,
     getUserProfile,

--- a/stories/configMock.js
+++ b/stories/configMock.js
@@ -5,6 +5,9 @@ export default {
         companyId: "companyId",
         companyName: "companyName",
     },
+    sessions: {
+        poll_interval_ms: 5000,
+    },
     admin: {
         groups: "test",
         group_attribute_name: "entitlement",


### PR DESCRIPTION
The one case that isn't handled at this time is the case where the user logs out and is on an authenticated page. We'd ideally like to leave the user on that page and display the login error. The catch is that we need to be able to detect when the user is on a page that requires authentication vs. one that doesn't. One idea might be to invalidate all `react-query` queries. I _think_ that would have the desired effect, I don't think that there's a good way to invalidate all queries without knowing the first element in every query key.

We could consolidate the query key definitions and then write code to invalidate each set of queries, but that's a big change. I'm not sure if now is the best time to tackle that or not.

At any rate, if anyone has any other ideas, I'd love to hear them.
