### PR TITLE
CORE-779 Refactor ErrorTypography and usage in RenameAnalysisDialog

### DIFF
--- a/public/static/locales/en/util.json
+++ b/public/static/locales/en/util.json
@@ -1,3 +1,4 @@
 {
-    "details":"Details"
+    "details": "Details",
+    "viewDetails": "View Details"
 }

--- a/src/components/analyses/listing/Listing.js
+++ b/src/components/analyses/listing/Listing.js
@@ -39,8 +39,6 @@ import ErrorTypography from "components/utils/error/ErrorTypography";
 import { useUserProfile } from "contexts/userProfile";
 import { useNotifications } from "contexts/pushNotifications";
 
-import { Button, Typography } from "@material-ui/core";
-
 /**
  * Filters
  *
@@ -76,7 +74,7 @@ function Listing(props) {
         selectedTypeFilter,
         showErrorAnnouncer,
     } = props;
-    const { t } = useTranslation(["analyses", "util"]);
+    const { t } = useTranslation("analyses");
     const [isGridView, setGridView] = useState(false);
 
     const [order, setOrder] = useState(selectedOrder);
@@ -550,20 +548,10 @@ function Listing(props) {
                 isLoading={renameLoading}
                 submissionError={
                     renameError && (
-                        <>
-                            <ErrorTypography
-                                errorMessage={t("analysisRenameError")}
-                            />
-                            <Button
-                                size="small"
-                                variant="outlined"
-                                onClick={() => setErrorDialogOpen(true)}
-                            >
-                                <Typography variant="button" color="error">
-                                    {t("util:details")}
-                                </Typography>
-                            </Button>
-                        </>
+                        <ErrorTypography
+                            errorMessage={t("analysisRenameError")}
+                            onDetailsClick={() => setErrorDialogOpen(true)}
+                        />
                     )
                 }
                 onClose={() => setRenameDialogOpen(false)}

--- a/src/components/utils/error/ErrorTypography.js
+++ b/src/components/utils/error/ErrorTypography.js
@@ -1,20 +1,21 @@
 /**
- * @author sriram
+ * @author sriram, psarando
  *
- * A typography that displays error message with a button to view details
+ * A typography that displays an error message with a button to view details.
  *
  */
 
 import React from "react";
-import { Typography, useTheme } from "@material-ui/core";
-import Button from "@material-ui/core/Button";
-import { withI18N, getMessage } from "@cyverse-de/ui-lib";
-import { injectIntl } from "react-intl";
-import messages from "../messages";
+
+import { useTranslation } from "i18n";
+
+import { Button, Typography, useTheme } from "@material-ui/core";
 
 function ErrorTypography(props) {
     const { errorMessage, onDetailsClick } = props;
     const theme = useTheme();
+    const { t } = useTranslation("util");
+
     return (
         <Typography color="error" variant="caption">
             {errorMessage}
@@ -22,14 +23,11 @@ function ErrorTypography(props) {
                 <Button
                     variant="outlined"
                     onClick={onDetailsClick}
-                    style={{ color: theme.palette.error.main, margin: 1 }}
+                    style={{ marginLeft: theme.spacing(1) }}
                     size="small"
                 >
-                    <Typography
-                        variant="caption"
-                        style={{ color: theme.palette.error.main }}
-                    >
-                        {getMessage("viewDetails")}
+                    <Typography color="error" variant="caption">
+                        {t("viewDetails")}
                     </Typography>
                 </Button>
             )}
@@ -37,4 +35,4 @@ function ErrorTypography(props) {
     );
 }
 
-export default withI18N(injectIntl(ErrorTypography), messages);
+export default ErrorTypography;

--- a/src/components/utils/messages.js
+++ b/src/components/utils/messages.js
@@ -23,7 +23,6 @@ const intlData = {
         host: "Host",
         timestamp: "Timestamp",
         ok: "OK",
-        viewDetails: "View Details",
         close: "Close",
         gridView: "Grid View",
         tableView: "Table View",


### PR DESCRIPTION
This PR will make the following changes:

* Use `onDetailsClick` prop in `ErrorTypography` rather than providing a custom `Button` to the `RenameAnalysisDialog`.
* Update `ErrorTypography` with i18next.
* Add theme spacing to the `ErrorTypography` details button, left margin only.
* Remove extraneous theme color styles in `ErrorTypography`.

![Analysis Rename Dialog service error message](https://user-images.githubusercontent.com/996408/90946794-31c17780-e3e5-11ea-82f7-3823edabfa1a.png)
