### PR TITLE
Use absolute imports, without aliasing (for data listing component)

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,11 +1,5 @@
 {
-    "compilerOptions": {
-      "baseUrl": "./src",
-      "paths": {
-        "@/components/*": ["components/*"],
-        "@/contexts/*": ["contexts/*"],
-        "@/common/*": ["common/*"],
-        "@/serviceFacades/*":["@/serviceFacades/*"]
-      }
-    }
+  "compilerOptions": {
+    "baseUrl": "./src"
   }
+}

--- a/src/components/data/SelectionDrawer.js
+++ b/src/components/data/SelectionDrawer.js
@@ -24,7 +24,7 @@ import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 
 import ids from "./ids";
-import Listing from "./listing/Listing";
+import Listing from "components/data/listing/Listing";
 import ResourceTypes from "../models/ResourceTypes";
 
 import styles from "./styles";

--- a/src/pages/data/ds/[...pathItems].js
+++ b/src/pages/data/ds/[...pathItems].js
@@ -5,7 +5,7 @@
 
 import React from "react";
 import { useRouter } from "next/router";
-import Listing from "../../../components/data/listing/Listing";
+import Listing from "components/data/listing/Listing";
 import { getEncodedPath } from "../../../components/data/utils";
 
 /**


### PR DESCRIPTION
this reduces the number of places in our bundles the data Listing component is included

as discussed in slack!