### PR TITLE
Require users to be logged in to view the VICE admin page

### DIFF
--- a/src/components/vice/admin/constants.js
+++ b/src/components/vice/admin/constants.js
@@ -63,3 +63,4 @@ export const INGRESS_COLUMNS = {
 export const LOADING = "loading";
 export const ERROR = "error";
 export const REFETCH_INTERVAL = 10000;
+export const BASE_ID = "admin.vice";

--- a/src/components/vice/admin/index.js
+++ b/src/components/vice/admin/index.js
@@ -6,11 +6,7 @@ import { useQuery, useMutation, queryCache } from "react-query";
 import { makeStyles } from "@material-ui/styles";
 import WrappedErrorHandler from "../../utils/error/WrappedErrorHandler";
 
-import {
-    build as buildID,
-    // announce,
-    // AnnouncerConstants,
-} from "@cyverse-de/ui-lib";
+import { build as buildID } from "@cyverse-de/ui-lib";
 
 import getData, {
     saveOutputFiles,
@@ -31,6 +27,7 @@ import {
     COMMON_COLUMNS,
     SERVICE_COLUMNS,
     POD_COLUMNS,
+    BASE_ID,
 } from "./constants";
 import { Skeleton, TabList, TabContext, TabPanel } from "@material-ui/lab";
 
@@ -384,7 +381,7 @@ const VICEAdmin = () => {
     );
 
     if (hasErrored) {
-        return <WrappedErrorHandler errorObject={error} baseId="admin.vice" />;
+        return <WrappedErrorHandler errorObject={error} baseId={BASE_ID} />;
     }
 
     return (

--- a/src/components/vice/admin/index.js
+++ b/src/components/vice/admin/index.js
@@ -4,11 +4,12 @@ import { useTranslation } from "i18n";
 import { useQuery, useMutation, queryCache } from "react-query";
 
 import { makeStyles } from "@material-ui/styles";
+import WrappedErrorHandler from "../../utils/error/WrappedErrorHandler";
 
 import {
     build as buildID,
-    announce,
-    AnnouncerConstants,
+    // announce,
+    // AnnouncerConstants,
 } from "@cyverse-de/ui-lib";
 
 import getData, {
@@ -36,7 +37,6 @@ import { Skeleton, TabList, TabContext, TabPanel } from "@material-ui/lab";
 import { JSONPath } from "jsonpath-plus";
 import efcs from "./filter/efcs";
 import { AppBar, Tab } from "@material-ui/core";
-import constants from "../../../constants";
 
 const id = (...values) => buildID(ids.ROOT, ...values);
 
@@ -350,10 +350,10 @@ const VICEAdminTabs = ({ data = {} }) => {
 const VICEAdmin = () => {
     const classes = useStyles();
 
-    const { status, data, error } = useQuery(VICE_ADMIN_QUERY_KEY, getData);
-
-    const isLoading = status === constants.LOADING;
-    const hasErrored = status === constants.ERROR;
+    const { isError: hasErrored, isLoading, data, error } = useQuery(
+        VICE_ADMIN_QUERY_KEY,
+        getData
+    );
 
     const [filters, setFilters] = useState({});
 
@@ -383,14 +383,9 @@ const VICEAdmin = () => {
         data
     );
 
-    useEffect(() => {
-        if (hasErrored) {
-            announce({
-                text: error.message,
-                variant: AnnouncerConstants.ERROR,
-            });
-        }
-    }, [hasErrored, error]);
+    if (hasErrored) {
+        return <WrappedErrorHandler errorObject={error} baseId="admin.vice" />;
+    }
 
     return (
         <div id={id(ids.ROOT)} className={classes.root}>


### PR DESCRIPTION
Don't worry, the VICE admin page wasn't accessible before to logged out users, it just errored out strangely rather than give good feedback. This PR makes it show the same error component used elsewhere in Sonora when a logged out user tries to access the page.