### PR TITLE
CORE-1139 Only validate non-empty app launch fields when not required.

### DIFF
--- a/src/components/apps/launch/validate.js
+++ b/src/components/apps/launch/validate.js
@@ -233,8 +233,10 @@ const validate = (t) => (values) => {
                 group.parameters.forEach((param, paramIndex) => {
                     let valueError = null;
 
-                    if (param.required && isEmptyParamValue(param.value)) {
-                        valueError = t("required");
+                    if (isEmptyParamValue(param.value)) {
+                        if (param.required) {
+                            valueError = t("required");
+                        }
                     } else {
                         switch (param.type) {
                             case constants.PARAM_TYPE.TEXT:

--- a/stories/apps/launch/data/TextParamsApp.js
+++ b/stories/apps/launch/data/TextParamsApp.js
@@ -32,15 +32,11 @@ export default {
                     required: false,
                 },
                 {
-                    description: "single line text",
+                    description: "single line text (10 chars max)",
                     arguments: [],
                     name: "--text",
                     type: "Text",
                     validators: [
-                        {
-                            type: "Regex",
-                            params: ["[a-zA-Z]+"],
-                        },
                         {
                             type: "CharacterLimit",
                             params: [10],
@@ -50,8 +46,27 @@ export default {
                     id:
                         "17794ff6-5a83-11ea-9e38-008cfa5ae621_8a4cf0fa-5a83-11ea-9e38-008cfa5ae621",
                     isVisible: true,
-                    defaultValue: "defaultxt",
+                    defaultValue: "defaultext",
                     required: true,
+                },
+                {
+                    description:
+                        "single line text (regex validation: no numbers)",
+                    arguments: [],
+                    name: "--text",
+                    type: "Text",
+                    validators: [
+                        {
+                            type: "Regex",
+                            params: ["^[a-zA-Z\\W]+$"],
+                        },
+                    ],
+                    label: "Single-line Text",
+                    id:
+                        "17794ff6-5a83-11ea-9e38-008cfa5ae621_8a4cf0fa-5a83-11ea-9e38-008cfa5ae621",
+                    isVisible: true,
+                    defaultValue: "No Numbers",
+                    required: false,
                 },
                 {
                     description: "Multiple lines",


### PR DESCRIPTION
Regex validators could display an error for blank fields, even when they were not marked as required.

This PR will update the app launch forms to only validate non-empty fields when not required.