### PR TITLE
CORE-733 Add sharing to Sonora

### DIFF
--- a/public/static/locales/en/sharing.json
+++ b/public/static/locales/en/sharing.json
@@ -10,6 +10,7 @@
     "resources": "Resources",
     "searchUsers": "Search By CyVerse ID, email, or group name...",
     "searchUsersMobile": "Search for users...",
+    "share": "Share",
     "sharing": "Sharing",
     "sharingAccess": "Who Has Access",
     "sharingError": "Sharing could not be completed",

--- a/src/components/analyses/listing/Listing.js
+++ b/src/components/analyses/listing/Listing.js
@@ -29,7 +29,7 @@ import {
     submitAnalysisSupportRequest,
 } from "serviceFacades/support";
 
-import { openInteractiveUrl } from "../utils";
+import { canShare, openInteractiveUrl } from "../utils";
 
 import constants from "../../../constants";
 import ConfirmationDialog from "../../utils/ConfirmationDialog";
@@ -627,6 +627,8 @@ function Listing(props) {
         );
     };
 
+    const sharingEnabled = canShare(getSelectedAnalyses());
+
     return (
         <>
             <AnalysesToolbar
@@ -652,6 +654,7 @@ function Listing(props) {
                 handleRename={handleRename}
                 handleSaveAndComplete={handleSaveAndComplete}
                 handleBatchIconClick={handleBatchIconClick}
+                canShare={sharingEnabled}
             />
             <TableView
                 loading={

--- a/src/components/analyses/toolbar/AnalysesDotMenu.js
+++ b/src/components/analyses/toolbar/AnalysesDotMenu.js
@@ -10,6 +10,7 @@ import { useTranslation } from "i18n";
 import Link from "next/link";
 
 import ids from "../ids";
+import shareIds from "components/sharing/ids";
 
 import {
     isInteractive,
@@ -46,6 +47,7 @@ import {
     Save as SaveIcon,
     UnfoldMore as UnfoldMoreIcon,
 } from "@material-ui/icons";
+import SharingMenuItem from "../../sharing/SharingMenuItem";
 
 const RelaunchMenuItem = React.forwardRef((props, ref) => {
     const { baseId, onClick, href } = props;
@@ -106,6 +108,8 @@ function DotMenuItems(props) {
         allowEdit,
         onClose,
         selectedAnalyses,
+        canShare,
+        setSharingDlgOpen,
         isSingleSelection,
         onFilterSelected,
     } = props;
@@ -131,6 +135,14 @@ function DotMenuItems(props) {
                 </ListItemIcon>
                 <ListItemText primary={t("details")} />
             </MenuItem>
+        ),
+        canShare && (
+            <SharingMenuItem
+                key={build(baseId, shareIds.SHARING_MENU_ITEM)}
+                baseId={baseId}
+                onClose={onClose}
+                setSharingDlgOpen={setSharingDlgOpen}
+            />
         ),
         isSingleSelection && (
             <Link href={outputFolderHref} as={outputFolderAs} passHref>
@@ -298,6 +310,8 @@ function AnalysesDotMenu({
     ButtonProps,
     username,
     getSelectedAnalyses,
+    canShare,
+    setSharingDlgOpen,
     ...props
 }) {
     // These props need to be spread down into DotMenuItems below.
@@ -344,6 +358,8 @@ function AnalysesDotMenu({
                     allowEdit={allowEdit}
                     onClose={onClose}
                     selectedAnalyses={selectedAnalyses}
+                    canShare={canShare}
+                    setSharingDlgOpen={setSharingDlgOpen}
                 />
             )}
         />

--- a/src/components/analyses/toolbar/AnalysesDotMenu.js
+++ b/src/components/analyses/toolbar/AnalysesDotMenu.js
@@ -26,6 +26,7 @@ import {
 
 import { build, DotMenu } from "@cyverse-de/ui-lib";
 import {
+    Hidden,
     ListItemIcon,
     ListItemText,
     MenuItem,
@@ -121,29 +122,31 @@ function DotMenuItems(props) {
         selectedAnalyses[0]
     );
     return [
-        isSingleSelection && (
-            <MenuItem
-                key={build(baseId, ids.MENUITEM_DETAILS)}
-                id={build(baseId, ids.MENUITEM_DETAILS)}
-                onClick={() => {
-                    onClose();
-                    onDetailsSelected();
-                }}
-            >
-                <ListItemIcon>
-                    <Info fontSize="small" />
-                </ListItemIcon>
-                <ListItemText primary={t("details")} />
-            </MenuItem>
-        ),
-        canShare && (
-            <SharingMenuItem
-                key={build(baseId, shareIds.SHARING_MENU_ITEM)}
-                baseId={baseId}
-                onClose={onClose}
-                setSharingDlgOpen={setSharingDlgOpen}
-            />
-        ),
+        <Hidden mdUp>
+            {isSingleSelection && (
+                <MenuItem
+                    key={build(baseId, ids.MENUITEM_DETAILS)}
+                    id={build(baseId, ids.MENUITEM_DETAILS)}
+                    onClick={() => {
+                        onClose();
+                        onDetailsSelected();
+                    }}
+                >
+                    <ListItemIcon>
+                        <Info fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText primary={t("details")} />
+                </MenuItem>
+            )}
+            {canShare && (
+                <SharingMenuItem
+                    key={build(baseId, shareIds.SHARING_MENU_ITEM)}
+                    baseId={baseId}
+                    onClose={onClose}
+                    setSharingDlgOpen={setSharingDlgOpen}
+                />
+            )}
+        </Hidden>,
         isSingleSelection && (
             <Link href={outputFolderHref} as={outputFolderAs} passHref>
                 <OutputFolderMenuItem baseId={baseId} />

--- a/src/components/analyses/toolbar/Toolbar.js
+++ b/src/components/analyses/toolbar/Toolbar.js
@@ -32,9 +32,9 @@ import {
 import Autocomplete from "@material-ui/lab/Autocomplete";
 
 import { Info, FilterList as FilterListIcon } from "@material-ui/icons";
-import SharingButton from "../../sharing/SharingButton";
-import Sharing from "../../sharing";
-import { formatSharedAnalyses } from "../../sharing/util";
+import SharingButton from "components/sharing/SharingButton";
+import Sharing from "components/sharing";
+import { formatSharedAnalyses } from "components/sharing/util";
 
 const useStyles = makeStyles((theme) => ({
     menuButton: {

--- a/src/components/analyses/toolbar/Toolbar.js
+++ b/src/components/analyses/toolbar/Toolbar.js
@@ -32,6 +32,9 @@ import {
 import Autocomplete from "@material-ui/lab/Autocomplete";
 
 import { Info, FilterList as FilterListIcon } from "@material-ui/icons";
+import SharingButton from "../../sharing/SharingButton";
+import Sharing from "../../sharing";
+import { formatSharedAnalyses } from "../../sharing/util";
 
 const useStyles = makeStyles((theme) => ({
     menuButton: {
@@ -174,11 +177,16 @@ function AnalysesToolbar(props) {
         handleRename,
         handleSaveAndComplete,
         handleBatchIconClick,
+        canShare,
     } = props;
     const classes = useStyles();
     const { t } = useTranslation("analyses");
     const analysesNavId = build(baseId, ids.ANALYSES_NAVIGATION);
     const [openFilterDialog, setOpenFilterDialog] = useState(false);
+    const [sharingDlgOpen, setSharingDlgOpen] = useState(false);
+
+    const sharingAnalyses = formatSharedAnalyses(getSelectedAnalyses());
+
     return (
         <>
             <Toolbar variant="dense" id={analysesNavId}>
@@ -227,6 +235,12 @@ function AnalysesToolbar(props) {
                         {t("details")}
                     </Button>
                 )}
+                {canShare && (
+                    <SharingButton
+                        baseId={baseId}
+                        setSharingDlgOpen={setSharingDlgOpen}
+                    />
+                )}
                 <AnalysesDotMenu
                     baseId={analysesNavId}
                     username={username}
@@ -242,6 +256,8 @@ function AnalysesToolbar(props) {
                     handleSaveAndComplete={handleSaveAndComplete}
                     handleBatchIconClick={handleBatchIconClick}
                     onFilterSelected={() => setOpenFilterDialog(true)}
+                    canShare={canShare}
+                    setSharingDlgOpen={setSharingDlgOpen}
                 />
             </Toolbar>
             <Dialog open={openFilterDialog}>
@@ -266,6 +282,11 @@ function AnalysesToolbar(props) {
                     </Button>
                 </DialogActions>
             </Dialog>
+            <Sharing
+                open={sharingDlgOpen}
+                onClose={() => setSharingDlgOpen(false)}
+                resources={sharingAnalyses}
+            />
         </>
     );
 }

--- a/src/components/analyses/toolbar/Toolbar.js
+++ b/src/components/analyses/toolbar/Toolbar.js
@@ -185,6 +185,9 @@ function AnalysesToolbar(props) {
     const [openFilterDialog, setOpenFilterDialog] = useState(false);
     const [sharingDlgOpen, setSharingDlgOpen] = useState(false);
 
+    const hasSelection = getSelectedAnalyses
+        ? getSelectedAnalyses().length > 0
+        : false;
     const sharingAnalyses = formatSharedAnalyses(getSelectedAnalyses());
 
     return (
@@ -222,43 +225,47 @@ function AnalysesToolbar(props) {
                 )}
 
                 <div className={classes.divider} />
-                {isSingleSelection && (
-                    <Button
-                        id={build(analysesNavId, ids.DETAILS_BTN)}
-                        className={classes.toolbarItems}
-                        variant="outlined"
-                        disableElevation
-                        color="primary"
-                        onClick={onDetailsSelected}
-                        startIcon={<Info />}
-                    >
-                        {t("details")}
-                    </Button>
-                )}
-                {canShare && (
-                    <SharingButton
-                        baseId={baseId}
+                <Hidden smDown>
+                    {isSingleSelection && (
+                        <Button
+                            id={build(analysesNavId, ids.DETAILS_BTN)}
+                            className={classes.toolbarItems}
+                            variant="outlined"
+                            disableElevation
+                            color="primary"
+                            onClick={onDetailsSelected}
+                            startIcon={<Info />}
+                        >
+                            {t("details")}
+                        </Button>
+                    )}
+                    {canShare && (
+                        <SharingButton
+                            baseId={baseId}
+                            setSharingDlgOpen={setSharingDlgOpen}
+                        />
+                    )}
+                </Hidden>
+                {hasSelection && (
+                    <AnalysesDotMenu
+                        baseId={analysesNavId}
+                        username={username}
+                        onDetailsSelected={onDetailsSelected}
+                        isSingleSelection={isSingleSelection}
+                        getSelectedAnalyses={getSelectedAnalyses}
+                        handleComments={handleComments}
+                        handleInteractiveUrlClick={handleInteractiveUrlClick}
+                        handleCancel={handleCancel}
+                        handleDelete={handleDelete}
+                        handleRelaunch={handleRelaunch}
+                        handleRename={handleRename}
+                        handleSaveAndComplete={handleSaveAndComplete}
+                        handleBatchIconClick={handleBatchIconClick}
+                        onFilterSelected={() => setOpenFilterDialog(true)}
+                        canShare={canShare}
                         setSharingDlgOpen={setSharingDlgOpen}
                     />
                 )}
-                <AnalysesDotMenu
-                    baseId={analysesNavId}
-                    username={username}
-                    onDetailsSelected={onDetailsSelected}
-                    isSingleSelection={isSingleSelection}
-                    getSelectedAnalyses={getSelectedAnalyses}
-                    handleComments={handleComments}
-                    handleInteractiveUrlClick={handleInteractiveUrlClick}
-                    handleCancel={handleCancel}
-                    handleDelete={handleDelete}
-                    handleRelaunch={handleRelaunch}
-                    handleRename={handleRename}
-                    handleSaveAndComplete={handleSaveAndComplete}
-                    handleBatchIconClick={handleBatchIconClick}
-                    onFilterSelected={() => setOpenFilterDialog(true)}
-                    canShare={canShare}
-                    setSharingDlgOpen={setSharingDlgOpen}
-                />
             </Toolbar>
             <Dialog open={openFilterDialog}>
                 <DialogContent>

--- a/src/components/analyses/utils.js
+++ b/src/components/analyses/utils.js
@@ -176,6 +176,14 @@ const useGotoOutputFolderLink = (analysis) => {
     return [href, as];
 };
 
+const canShare = (selectedAnalyses) => {
+    return selectedAnalyses && selectedAnalyses.length > 0
+        ? selectedAnalyses.reduce((acc, analysis) => {
+              return acc && analysis.can_share;
+          }, true)
+        : false;
+};
+
 export {
     getAnalysisUser,
     isInteractive,
@@ -185,6 +193,7 @@ export {
     allowAnalysesDelete,
     allowAnalysesRelaunch,
     allowAnalysisEdit,
+    canShare,
     getAnalysisRelaunchPage,
     getListingPath,
     openInteractiveUrl,

--- a/src/components/analyses/utils.js
+++ b/src/components/analyses/utils.js
@@ -177,11 +177,11 @@ const useGotoOutputFolderLink = (analysis) => {
 };
 
 const canShare = (selectedAnalyses) => {
-    return selectedAnalyses && selectedAnalyses.length > 0
-        ? selectedAnalyses.reduce((acc, analysis) => {
-              return acc && analysis.can_share;
-          }, true)
-        : false;
+    return (
+        selectedAnalyses &&
+        selectedAnalyses.length > 0 &&
+        !selectedAnalyses.find((analysis) => !analysis.can_share)
+    );
 };
 
 export {

--- a/src/components/apps/listing/Listing.js
+++ b/src/components/apps/listing/Listing.js
@@ -27,6 +27,7 @@ import {
 } from "serviceFacades/apps";
 
 import { useQuery } from "react-query";
+import { canShare } from "../utils";
 
 function Listing({
     baseId,
@@ -75,6 +76,12 @@ function Listing({
     ] = useState(false);
     const [allAppsQueryEnabled, setAllAppsQueryEnabled] = useState(false);
     const [appByIdQueryEnabled, setAppByIdQueryEnabled] = useState(false);
+
+    const getSelectedApps = () => {
+        return selected.map((id) => data?.apps.find((app) => app.id === id));
+    };
+
+    const shareEnabled = canShare(getSelectedApps());
 
     const {
         isFetching: appInCategoryStatus,
@@ -368,6 +375,8 @@ function Listing({
                 toggleDisplay={toggleDisplay}
                 detailsEnabled={detailsEnabled}
                 onDetailsSelected={onDetailsSelected}
+                canShare={shareEnabled}
+                selectedApps={getSelectedApps()}
             />
             <TableView
                 loading={

--- a/src/components/apps/toolbar/AppsDotMenu.js
+++ b/src/components/apps/toolbar/AppsDotMenu.js
@@ -18,7 +18,7 @@ import {
     useTheme,
 } from "@material-ui/core";
 import { FilterList, Info } from "@material-ui/icons";
-import SharingMenuItem from "../../sharing/SharingMenuItem";
+import SharingMenuItem from "components/sharing/SharingMenuItem";
 
 function AppsDotMenu(props) {
     const {

--- a/src/components/apps/toolbar/AppsDotMenu.js
+++ b/src/components/apps/toolbar/AppsDotMenu.js
@@ -7,6 +7,7 @@
 import React from "react";
 import { useTranslation } from "i18n";
 import ids from "../ids";
+import shareIds from "components/sharing/ids";
 
 import { build, DotMenu } from "@cyverse-de/ui-lib";
 import {
@@ -17,6 +18,7 @@ import {
     useTheme,
 } from "@material-ui/core";
 import { FilterList, Info } from "@material-ui/icons";
+import SharingMenuItem from "../../sharing/SharingMenuItem";
 
 function AppsDotMenu(props) {
     const {
@@ -25,6 +27,8 @@ function AppsDotMenu(props) {
         detailsEnabled,
         onDetailsSelected,
         onFilterSelected,
+        canShare,
+        setSharingDlgOpen,
     } = props;
     const { t } = useTranslation("apps");
     const theme = useTheme();
@@ -63,6 +67,14 @@ function AppsDotMenu(props) {
                         </ListItemIcon>
                         <ListItemText primary={t("filterLbl")} />
                     </MenuItem>
+                ),
+                canShare && (
+                    <SharingMenuItem
+                        key={build(baseId, shareIds.SHARING_MENU_ITEM)}
+                        baseId={baseId}
+                        onClose={onClose}
+                        setSharingDlgOpen={setSharingDlgOpen}
+                    />
                 ),
             ]}
         />

--- a/src/components/apps/toolbar/Toolbar.js
+++ b/src/components/apps/toolbar/Toolbar.js
@@ -104,7 +104,6 @@ function AppsToolbar(props) {
         onDetailsSelected,
         canShare,
         selectedApps,
-        intl,
         baseId,
     } = props;
     const { t } = useTranslation("apps");
@@ -149,7 +148,6 @@ function AppsToolbar(props) {
                     <AppsTypeFilter
                         baseId={appsToolbarId}
                         classes={classes}
-                        intl={intl}
                         filter={filter}
                         handleFilterChange={handleFilterChange}
                         selectedCategory={selectedCategory}
@@ -192,7 +190,6 @@ function AppsToolbar(props) {
                     <AppsTypeFilter
                         baseId={appsToolbarId}
                         classes={classes}
-                        intl={intl}
                         filter={filter}
                         handleFilterChange={handleFilterChange}
                         selectedCategory={selectedCategory}

--- a/src/components/apps/toolbar/Toolbar.js
+++ b/src/components/apps/toolbar/Toolbar.js
@@ -23,6 +23,9 @@ import {
 import Autocomplete from "@material-ui/lab/Autocomplete";
 import { makeStyles } from "@material-ui/core/styles";
 import { Info, FilterList as FilterListIcon } from "@material-ui/icons";
+import SharingButton from "../../sharing/SharingButton";
+import Sharing from "../../sharing";
+import { formatSharedApps } from "../../sharing/util";
 
 /**
  *
@@ -99,6 +102,8 @@ function AppsToolbar(props) {
         toggleDisplay,
         detailsEnabled,
         onDetailsSelected,
+        canShare,
+        selectedApps,
         intl,
         baseId,
     } = props;
@@ -106,6 +111,9 @@ function AppsToolbar(props) {
     const classes = useStyles();
     const appsToolbarId = build(baseId, ids.APPS_TOOLBAR);
     const [openFilterDialog, setOpenFilterDialog] = useState(false);
+    const [sharingDlgOpen, setSharingDlgOpen] = useState(false);
+
+    const sharingApps = formatSharedApps(selectedApps);
 
     return (
         <>
@@ -160,12 +168,20 @@ function AppsToolbar(props) {
                             {t("details")}
                         </Button>
                     )}
+                    {canShare && (
+                        <SharingButton
+                            baseId={baseId}
+                            setSharingDlgOpen={setSharingDlgOpen}
+                        />
+                    )}
                 </Hidden>
                 <AppsDotMenu
                     baseId={appsToolbarId}
                     detailsEnabled={detailsEnabled}
                     onDetailsSelected={onDetailsSelected}
                     onFilterSelected={() => setOpenFilterDialog(true)}
+                    canShare={canShare}
+                    setSharingDlgOpen={setSharingDlgOpen}
                 />
             </Toolbar>
             <Dialog open={openFilterDialog}>
@@ -185,6 +201,11 @@ function AppsToolbar(props) {
                     </Button>
                 </DialogActions>
             </Dialog>
+            <Sharing
+                open={sharingDlgOpen}
+                onClose={() => setSharingDlgOpen(false)}
+                resources={sharingApps}
+            />
         </>
     );
 }

--- a/src/components/apps/toolbar/Toolbar.js
+++ b/src/components/apps/toolbar/Toolbar.js
@@ -154,7 +154,8 @@ function AppsToolbar(props) {
                         handleFilterChange={handleFilterChange}
                         selectedCategory={selectedCategory}
                     />
-
+                </Hidden>
+                <Hidden smDown>
                     {detailsEnabled && (
                         <Button
                             id={build(appsToolbarId, ids.DETAILS_BTN)}
@@ -175,14 +176,16 @@ function AppsToolbar(props) {
                         />
                     )}
                 </Hidden>
-                <AppsDotMenu
-                    baseId={appsToolbarId}
-                    detailsEnabled={detailsEnabled}
-                    onDetailsSelected={onDetailsSelected}
-                    onFilterSelected={() => setOpenFilterDialog(true)}
-                    canShare={canShare}
-                    setSharingDlgOpen={setSharingDlgOpen}
-                />
+                <Hidden mdUp>
+                    <AppsDotMenu
+                        baseId={appsToolbarId}
+                        detailsEnabled={detailsEnabled}
+                        onDetailsSelected={onDetailsSelected}
+                        onFilterSelected={() => setOpenFilterDialog(true)}
+                        canShare={canShare}
+                        setSharingDlgOpen={setSharingDlgOpen}
+                    />
+                </Hidden>
             </Toolbar>
             <Dialog open={openFilterDialog}>
                 <DialogContent>

--- a/src/components/apps/toolbar/Toolbar.js
+++ b/src/components/apps/toolbar/Toolbar.js
@@ -23,9 +23,9 @@ import {
 import Autocomplete from "@material-ui/lab/Autocomplete";
 import { makeStyles } from "@material-ui/core/styles";
 import { Info, FilterList as FilterListIcon } from "@material-ui/icons";
-import SharingButton from "../../sharing/SharingButton";
-import Sharing from "../../sharing";
-import { formatSharedApps } from "../../sharing/util";
+import SharingButton from "components/sharing/SharingButton";
+import Sharing from "components/sharing";
+import { formatSharedApps } from "components/sharing/util";
 
 /**
  *

--- a/src/components/apps/utils.js
+++ b/src/components/apps/utils.js
@@ -48,9 +48,9 @@ export const useAppLaunchLink = (systemId, appId) => {
 };
 
 export const canShare = (apps) => {
-    return apps && apps.length > 0
-        ? apps.reduce((accumulator, app) => {
-              return accumulator && app.permission === Permissions.OWN;
-          }, true)
-        : false;
+    return (
+        apps &&
+        apps.length > 0 &&
+        !apps.find((app) => app.permission !== Permissions.OWN)
+    );
 };

--- a/src/components/apps/utils.js
+++ b/src/components/apps/utils.js
@@ -4,6 +4,7 @@
  * Apps related utility functions.
  */
 import NavigationConstants from "../../common/NavigationConstants";
+import Permissions from "../models/Permissions";
 
 /**
  * Builds a path to the App Launch Wizard for the app with the given IDs.
@@ -44,4 +45,12 @@ export const useAppLaunchLink = (systemId, appId) => {
     const href = `/${NavigationConstants.APPS}/[systemId]/[appId]/launch`;
     const as = `/${NavigationConstants.APPS}/${systemId}/${appId}/launch`;
     return [href, as];
+};
+
+export const canShare = (apps) => {
+    return apps && apps.length > 0
+        ? apps.reduce((accumulator, app) => {
+              return accumulator && app.permission === Permissions.OWN;
+          }, true)
+        : false;
 };

--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -28,6 +28,8 @@ import UploadDropTarget from "components/uploads/UploadDropTarget";
 import { camelcaseit } from "common/functions";
 import { getLocalStorage } from "components/utils/localStorage";
 import withErrorAnnouncer from "components/utils/error/withErrorAnnouncer";
+import Sharing from "components/sharing";
+import { formatSharedData } from "components/sharing/util";
 
 import {
     useUploadTrackingState,
@@ -49,8 +51,6 @@ import { useTranslation } from "i18n";
 import { queryCache, useMutation, useQuery } from "react-query";
 
 import { Button, Typography, useTheme } from "@material-ui/core";
-import Sharing from "../../sharing";
-import { formatSharedData } from "../../sharing/util";
 
 function Listing(props) {
     const uploadTracker = useUploadTrackingState();

--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -49,6 +49,8 @@ import { useTranslation } from "i18n";
 import { queryCache, useMutation, useQuery } from "react-query";
 
 import { Button, Typography, useTheme } from "@material-ui/core";
+import Sharing from "../../sharing";
+import { formatSharedData } from "../../sharing/util";
 
 function Listing(props) {
     const uploadTracker = useUploadTrackingState();
@@ -98,6 +100,7 @@ function Listing(props) {
 
     const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
     const [importDialogOpen, setImportDialogOpen] = useState(false);
+    const [sharingDlgOpen, setSharingDlgOpen] = useState(false);
     const { t } = useTranslation("data");
 
     const onCloseImportDialog = () => setImportDialogOpen(false);
@@ -351,6 +354,8 @@ function Listing(props) {
         );
     };
 
+    const sharingData = formatSharedData(getSelectedResources());
+
     if (!infoTypes || infoTypes.length === 0) {
         const infoTypesCache = queryCache.getQueryData("dataFetchInfoTypes");
         if (infoTypesCache) {
@@ -395,21 +400,17 @@ function Listing(props) {
                     onCreateMultiInputFileSelected={() =>
                         onCreateMultiInputFileSelected(path)
                     }
+                    setSharingDlgOpen={setSharingDlgOpen}
                 />
                 {!isGridView && (
                     <TableView
                         loading={isLoading}
                         error={error || navError}
                         path={path}
-                        permission={data?.permission}
                         handlePathChange={handlePathChange}
                         listing={data?.listing}
                         baseId={baseId}
-                        detailsEnabled={detailsEnabled}
                         isInvalidSelection={isInvalidSelection}
-                        onDownloadSelected={onDownloadSelected}
-                        onEditSelected={onEditSelected}
-                        onMetadataSelected={onMetadataSelected}
                         onDeleteSelected={onDeleteSelected}
                         handleRequestSort={handleRequestSort}
                         handleSelectAllClick={handleSelectAllClick}
@@ -419,14 +420,7 @@ function Listing(props) {
                         order={order}
                         orderBy={orderBy}
                         selected={selected}
-                        setUploadDialogOpen={setUploadDialogOpen}
-                        setImportDialogOpen={setImportDialogOpen}
-                        localUploadId={localUploadId}
-                        uploadMenuId={build(
-                            baseId,
-                            ids.LISTING_TABLE,
-                            ids.UPLOAD_MENU
-                        )}
+                        setSharingDlgOpen={setSharingDlgOpen}
                     />
                 )}
                 {isGridView && <span>Coming Soon!</span>}
@@ -462,6 +456,11 @@ function Listing(props) {
                 path={path}
                 open={importDialogOpen}
                 onClose={onCloseImportDialog}
+            />
+            <Sharing
+                open={sharingDlgOpen}
+                onClose={() => setSharingDlgOpen(false)}
+                resources={sharingData}
             />
         </>
     );

--- a/src/components/data/listing/RowDotMenu.js
+++ b/src/components/data/listing/RowDotMenu.js
@@ -1,0 +1,62 @@
+/**
+ * @author aramsey
+ *
+ * A dot menu only intended for showing options relevant to a single data resource
+ * i.e. an item or row in the data listing
+ */
+import React from "react";
+
+import { DotMenu } from "@cyverse-de/ui-lib";
+import DetailsMenuItem from "../menuItems/DetailsMenuItem";
+import DeleteMenuItem from "../menuItems/DeleteMenuItem";
+import SharingMenuItem from "../../sharing/SharingMenuItem";
+import { hasOwn } from "../utils";
+import ids from "../ids";
+import shareIds from "components/sharing/ids";
+import { build } from "@cyverse-de/ui-lib";
+
+function RowDotMenu(props) {
+    const {
+        baseId,
+        ButtonProps,
+        onDeleteSelected,
+        onDetailsSelected,
+        resource,
+        setSharingDlgOpen,
+    } = props;
+
+    const isOwner = hasOwn(resource.permission);
+
+    return (
+        <DotMenu
+            baseId={baseId}
+            ButtonProps={ButtonProps}
+            render={(onClose) => [
+                <DetailsMenuItem
+                    key={build(baseId, ids.DETAILS_MENU_ITEM)}
+                    baseId={baseId}
+                    onClose={onClose}
+                    onDetailsSelected={onDetailsSelected}
+                />,
+                isOwner && (
+                    <DeleteMenuItem
+                        key={build(baseId, ids.DELETE_MENU_ITEM)}
+                        baseId={baseId}
+                        onClose={onClose}
+                        onDeleteSelected={onDeleteSelected}
+                    />
+                ),
+                isOwner && (
+                    <SharingMenuItem
+                        key={build(baseId, shareIds.SHARING_MENU_ITEM)}
+                        baseId={baseId}
+                        onClose={onClose}
+                        setSharingDlgOpen={setSharingDlgOpen}
+                    />
+                ),
+            ]}
+        />
+    );
+}
+
+export default RowDotMenu;

--- a/src/components/data/listing/TableView.js
+++ b/src/components/data/listing/TableView.js
@@ -13,7 +13,6 @@ import SpanLink from "./SpanLink";
 import { getFileSize } from "./FileSize";
 
 import ids from "../ids";
-import DataDotMenu from "../toolbar/DataDotMenu";
 
 import TableLoading from "../../utils/TableLoading";
 import constants from "../../../constants";
@@ -38,6 +37,7 @@ import {
     TableContainer,
     TableRow,
 } from "@material-ui/core";
+import RowDotMenu from "./RowDotMenu";
 
 function SizeCell({ resource }) {
     return <TableCell>{getFileSize(resource.fileSize)}</TableCell>;
@@ -110,16 +110,12 @@ function TableView(props) {
     const {
         loading,
         path,
-        permission,
         error,
         handlePathChange,
         listing,
         baseId,
         isInvalidSelection = () => false,
         onDetailsSelected,
-        onDownloadSelected,
-        onEditSelected,
-        onMetadataSelected,
         onDeleteSelected,
         handleRequestSort,
         handleSelectAllClick,
@@ -128,11 +124,7 @@ function TableView(props) {
         order,
         orderBy,
         selected,
-        detailsEnabled,
-        setImportDialogOpen,
-        setUploadDialogOpen,
-        localUploadId,
-        uploadMenuId,
+        setSharingDlgOpen,
     } = props;
     const invalidRowClass = invalidRowStyles();
     const { t } = useTranslation("data");
@@ -379,43 +371,21 @@ function TableView(props) {
                                             )
                                         )}
                                         <TableCell align="right">
-                                            <DataDotMenu
+                                            <RowDotMenu
                                                 baseId={build(
                                                     tableId,
                                                     resourceName
                                                 )}
-                                                path={path}
-                                                permission={permission}
                                                 onDetailsSelected={
                                                     onDetailsSelected
-                                                }
-                                                detailsEnabled={detailsEnabled}
-                                                MenuProps={{ tabIndex: 0 }}
-                                                onDownloadSelected={() =>
-                                                    onDownloadSelected(
-                                                        resourceId
-                                                    )
-                                                }
-                                                onEditSelected={() =>
-                                                    onEditSelected(resourceId)
-                                                }
-                                                onMetadataSelected={() =>
-                                                    onMetadataSelected(
-                                                        resourceId
-                                                    )
                                                 }
                                                 onDeleteSelected={() =>
                                                     onDeleteSelected(resourceId)
                                                 }
-                                                setUploadDialogOpen={
-                                                    setUploadDialogOpen
+                                                resource={resource}
+                                                setSharingDlgOpen={
+                                                    setSharingDlgOpen
                                                 }
-                                                setImportDialogOpen={
-                                                    setImportDialogOpen
-                                                }
-                                                selected={selected}
-                                                localUploadId={localUploadId}
-                                                uploadMenuId={uploadMenuId}
                                             />
                                         </TableCell>
                                     </TableRow>

--- a/src/components/data/menuItems/DeleteMenuItem.js
+++ b/src/components/data/menuItems/DeleteMenuItem.js
@@ -1,0 +1,31 @@
+import React from "react";
+
+import { build } from "@cyverse-de/ui-lib";
+import { ListItemIcon, ListItemText, MenuItem } from "@material-ui/core";
+import { Delete as DeleteIcon } from "@material-ui/icons";
+
+import ids from "../ids";
+import { useTranslation } from "i18n";
+
+function DeleteMenuItem(props) {
+    const { baseId, onClose, onDeleteSelected } = props;
+    const { t } = useTranslation("data");
+
+    return (
+        <MenuItem
+            key={build(baseId, ids.DELETE_MENU_ITEM)}
+            id={build(baseId, ids.DELETE_MENU_ITEM)}
+            onClick={() => {
+                onClose();
+                onDeleteSelected();
+            }}
+        >
+            <ListItemIcon>
+                <DeleteIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText primary={t("delete")} />
+        </MenuItem>
+    );
+}
+
+export default DeleteMenuItem;

--- a/src/components/data/menuItems/DetailsMenuItem.js
+++ b/src/components/data/menuItems/DetailsMenuItem.js
@@ -1,0 +1,31 @@
+import React from "react";
+
+import { build } from "@cyverse-de/ui-lib";
+import { Info } from "@material-ui/icons";
+import { ListItemIcon, ListItemText, MenuItem } from "@material-ui/core";
+import { useTranslation } from "react-i18next";
+
+import ids from "../ids";
+
+function DetailsMenuItem(props) {
+    const { baseId, onDetailsSelected, onClose } = props;
+    const { t } = useTranslation("data");
+
+    return (
+        <MenuItem
+            key={build(baseId, ids.DETAILS_MENU_ITEM)}
+            id={build(baseId, ids.DETAILS_MENU_ITEM)}
+            onClick={() => {
+                onClose();
+                onDetailsSelected();
+            }}
+        >
+            <ListItemIcon>
+                <Info fontSize="small" />
+            </ListItemIcon>
+            <ListItemText primary={t("details")} />
+        </MenuItem>
+    );
+}
+
+export default DetailsMenuItem;

--- a/src/components/data/styles.js
+++ b/src/components/data/styles.js
@@ -90,10 +90,10 @@ export default (theme) => ({
     },
 
     selectionDrawer: {
-        [theme.breakpoints.up("sm")]: {
-            width: "50%",
+        [theme.breakpoints.up("md")]: {
+            minWidth: "50%",
         },
-        [theme.breakpoints.down("sm")]: {
+        [theme.breakpoints.down("md")]: {
             width: "90%",
         },
         overflow: "hidden",

--- a/src/components/data/toolbar/DataDotMenu.js
+++ b/src/components/data/toolbar/DataDotMenu.js
@@ -19,12 +19,7 @@ import {
     ListItemText,
     MenuItem,
 } from "@material-ui/core";
-import {
-    CreateNewFolder,
-    Delete as DeleteIcon,
-    Info,
-    ListAlt,
-} from "@material-ui/icons";
+import { CreateNewFolder, ListAlt } from "@material-ui/icons";
 import { useTranslation } from "i18n";
 import DetailsMenuItem from "../menuItems/DetailsMenuItem";
 import DeleteMenuItem from "../menuItems/DeleteMenuItem";

--- a/src/components/data/toolbar/DataDotMenu.js
+++ b/src/components/data/toolbar/DataDotMenu.js
@@ -28,7 +28,7 @@ import {
 import { useTranslation } from "i18n";
 import DetailsMenuItem from "../menuItems/DetailsMenuItem";
 import DeleteMenuItem from "../menuItems/DeleteMenuItem";
-import SharingMenuItem from "../../sharing/SharingMenuItem";
+import SharingMenuItem from "components/sharing/SharingMenuItem";
 
 function DataDotMenu(props) {
     const {

--- a/src/components/data/toolbar/DataDotMenu.js
+++ b/src/components/data/toolbar/DataDotMenu.js
@@ -7,6 +7,7 @@
 import React, { useState } from "react";
 
 import ids from "../ids";
+import shareIds from "components/sharing/ids";
 import { isOwner, isWritable } from "../utils";
 import CreateFolderDialog from "../CreateFolderDialog";
 import UploadMenuItems from "./UploadMenuItems";
@@ -24,7 +25,10 @@ import {
     Info,
     ListAlt,
 } from "@material-ui/icons";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "i18n";
+import DetailsMenuItem from "../menuItems/DetailsMenuItem";
+import DeleteMenuItem from "../menuItems/DeleteMenuItem";
+import SharingMenuItem from "../../sharing/SharingMenuItem";
 
 function DataDotMenu(props) {
     const {
@@ -44,6 +48,8 @@ function DataDotMenu(props) {
         getSelectedResources,
         onCreateHTFileSelected,
         onCreateMultiInputFileSelected,
+        canShare,
+        setSharingDlgOpen,
     } = props;
     const { t } = useTranslation("data");
     const [createFolderDlgOpen, setCreateFolderDlgOpen] = useState(false);
@@ -61,19 +67,12 @@ function DataDotMenu(props) {
                 ButtonProps={ButtonProps}
                 render={(onClose) => [
                     detailsEnabled && (
-                        <MenuItem
+                        <DetailsMenuItem
                             key={build(baseId, ids.DETAILS_MENU_ITEM)}
-                            id={build(baseId, ids.DETAILS_MENU_ITEM)}
-                            onClick={() => {
-                                onClose();
-                                onDetailsSelected();
-                            }}
-                        >
-                            <ListItemIcon>
-                                <Info fontSize="small" />
-                            </ListItemIcon>
-                            <ListItemText primary={t("details")} />
-                        </MenuItem>
+                            baseId={baseId}
+                            onClose={onClose}
+                            onDetailsSelected={onDetailsSelected}
+                        />
                     ),
                     detailsEnabled && (
                         <Divider
@@ -125,20 +124,21 @@ function DataDotMenu(props) {
                             />
                         </MenuItem>,
                     ],
+                    canShare && (
+                        <SharingMenuItem
+                            key={build(baseId, shareIds.SHARING_MENU_ITEM)}
+                            baseId={baseId}
+                            onClose={onClose}
+                            setSharingDlgOpen={setSharingDlgOpen}
+                        />
+                    ),
                     deleteMiEnabled && (
-                        <MenuItem
+                        <DeleteMenuItem
                             key={build(baseId, ids.DELETE_MENU_ITEM)}
-                            id={build(baseId, ids.DELETE_MENU_ITEM)}
-                            onClick={() => {
-                                onClose();
-                                onDeleteSelected();
-                            }}
-                        >
-                            <ListItemIcon>
-                                <DeleteIcon fontSize="small" />
-                            </ListItemIcon>
-                            <ListItemText primary={t("delete")} />
-                        </MenuItem>
+                            baseId={baseId}
+                            onClose={onClose}
+                            onDeleteSelected={onDeleteSelected}
+                        />
                     ),
                     <Divider
                         key={build(baseId, ids.UPLOAD_MENU_ITEM_DIVIDER)}

--- a/src/components/data/toolbar/Toolbar.js
+++ b/src/components/data/toolbar/Toolbar.js
@@ -18,6 +18,7 @@ import ids from "../ids";
 import styles from "../styles";
 import CreateFolderDialog from "../CreateFolderDialog";
 import { isOwner, isWritable } from "../utils";
+import SharingButton from "components/sharing/SharingButton";
 
 import DisplayTypeSelector from "../../utils/DisplayTypeSelector";
 
@@ -26,7 +27,6 @@ import { build } from "@cyverse-de/ui-lib";
 import { Button, Hidden, makeStyles, Toolbar } from "@material-ui/core";
 
 import { CreateNewFolder, Info } from "@material-ui/icons";
-import SharingButton from "../../sharing/SharingButton";
 
 const useStyles = makeStyles(styles);
 

--- a/src/components/data/toolbar/Toolbar.js
+++ b/src/components/data/toolbar/Toolbar.js
@@ -8,7 +8,7 @@
 
 import React, { useState } from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "i18n";
 
 import DataDotMenu from "./DataDotMenu";
 import UploadMenuBtn from "./UploadMenuBtn";
@@ -17,7 +17,7 @@ import Navigation from "./Navigation";
 import ids from "../ids";
 import styles from "../styles";
 import CreateFolderDialog from "../CreateFolderDialog";
-import { isWritable } from "../utils";
+import { isOwner, isWritable } from "../utils";
 
 import DisplayTypeSelector from "../../utils/DisplayTypeSelector";
 
@@ -26,6 +26,7 @@ import { build } from "@cyverse-de/ui-lib";
 import { Button, Hidden, makeStyles, Toolbar } from "@material-ui/core";
 
 import { CreateNewFolder, Info } from "@material-ui/icons";
+import SharingButton from "../../sharing/SharingButton";
 
 const useStyles = makeStyles(styles);
 
@@ -51,12 +52,15 @@ function DataToolbar(props) {
         uploadMenuId,
         onCreateHTFileSelected,
         onCreateMultiInputFileSelected,
+        setSharingDlgOpen,
     } = props;
 
     const { t } = useTranslation("data");
     const [createFolderDlgOpen, setCreateFolderDlgOpen] = useState(false);
     const onCreateFolderDlgClose = () => setCreateFolderDlgOpen(false);
     const onCreateFolderClicked = () => setCreateFolderDlgOpen(true);
+    const selectedResources = getSelectedResources();
+    const canShare = isOwner(selectedResources);
 
     let toolbarId = build(baseId, ids.TOOLBAR);
     return (
@@ -109,25 +113,37 @@ function DataToolbar(props) {
                         />
                     </>
                 )}
+                {canShare && (
+                    <SharingButton
+                        baseId={toolbarId}
+                        setSharingDlgOpen={setSharingDlgOpen}
+                    />
+                )}
             </Hidden>
-            <DataDotMenu
-                baseId={toolbarId}
-                path={path}
-                onDeleteSelected={onDeleteSelected}
-                onCreateFolderSelected={onCreateFolderClicked}
-                onDetailsSelected={onDetailsSelected}
-                permission={permission}
-                refreshListing={refreshListing}
-                detailsEnabled={detailsEnabled}
-                uploadMenuId={uploadMenuId}
-                localUploadId={localUploadId}
-                setUploadDialogOpen={setUploadDialogOpen}
-                setImportDialogOpen={setImportDialogOpen}
-                getSelectedResources={getSelectedResources}
-                selected={selected}
-                onCreateHTFileSelected={onCreateHTFileSelected}
-                onCreateMultiInputFileSelected={onCreateMultiInputFileSelected}
-            />
+            <Hidden mdUp>
+                <DataDotMenu
+                    baseId={toolbarId}
+                    path={path}
+                    onDeleteSelected={onDeleteSelected}
+                    onCreateFolderSelected={onCreateFolderClicked}
+                    onDetailsSelected={onDetailsSelected}
+                    permission={permission}
+                    refreshListing={refreshListing}
+                    detailsEnabled={detailsEnabled}
+                    uploadMenuId={uploadMenuId}
+                    localUploadId={localUploadId}
+                    setUploadDialogOpen={setUploadDialogOpen}
+                    setImportDialogOpen={setImportDialogOpen}
+                    getSelectedResources={getSelectedResources}
+                    selected={selected}
+                    onCreateHTFileSelected={onCreateHTFileSelected}
+                    onCreateMultiInputFileSelected={
+                        onCreateMultiInputFileSelected
+                    }
+                    canShare={canShare}
+                    setSharingDlgOpen={setSharingDlgOpen}
+                />
+            </Hidden>
             <CreateFolderDialog
                 path={path}
                 open={createFolderDlgOpen}

--- a/src/components/data/utils.js
+++ b/src/components/data/utils.js
@@ -76,7 +76,7 @@ const isReadable = (permission) => {
 };
 
 const isOwner = (selectedResources) => {
-    if (!selectedResources) {
+    if (!selectedResources || selectedResources.length === 0) {
         return false;
     }
     const notOwners = selectedResources.filter(

--- a/src/components/sharing/SharingButton.js
+++ b/src/components/sharing/SharingButton.js
@@ -1,0 +1,39 @@
+/**
+ * @author aramsey
+ *
+ * A button meant for controlling when the Sharing dialog opens
+ */
+
+import React from "react";
+
+import { build } from "@cyverse-de/ui-lib";
+import { Button, makeStyles } from "@material-ui/core";
+import { Share } from "@material-ui/icons";
+
+import { useTranslation } from "i18n";
+import ids from "./ids";
+import styles from "./styles";
+
+const useStyles = makeStyles(styles);
+
+function SharingButton(props) {
+    const { baseId, setSharingDlgOpen } = props;
+    const classes = useStyles();
+    const { t } = useTranslation("sharing");
+
+    return (
+        <Button
+            id={build(baseId, ids.SHARE_BTN)}
+            variant="outlined"
+            disableElevation
+            color="primary"
+            onClick={() => setSharingDlgOpen(true)}
+            className={classes.button}
+            startIcon={<Share />}
+        >
+            {t("share")}
+        </Button>
+    );
+}
+
+export default SharingButton;

--- a/src/components/sharing/SharingMenuItem.js
+++ b/src/components/sharing/SharingMenuItem.js
@@ -1,0 +1,35 @@
+/**
+ * @author aramsey
+ *
+ * A menu item meant for controlling when the Sharing dialog opens
+ */
+
+import React from "react";
+
+import { build } from "@cyverse-de/ui-lib";
+import { ListItemIcon, ListItemText, MenuItem } from "@material-ui/core";
+import { Share } from "@material-ui/icons";
+
+import ids from "./ids";
+import { useTranslation } from "i18n";
+
+function SharingMenuItem(props) {
+    const { baseId, onClose, setSharingDlgOpen } = props;
+    const { t } = useTranslation("sharing");
+
+    return (
+        <MenuItem
+            id={build(baseId, ids.SHARING_MENU_ITEM)}
+            onClick={() => {
+                onClose();
+                setSharingDlgOpen(true);
+            }}
+        >
+            <ListItemIcon>
+                <Share fontSize="small" />
+            </ListItemIcon>
+            <ListItemText primary={t("share")} />
+        </MenuItem>
+    );
+}
+export default SharingMenuItem;

--- a/src/components/sharing/SubjectSearchField.js
+++ b/src/components/sharing/SubjectSearchField.js
@@ -28,7 +28,7 @@ function SubjectSearchField(props) {
         queryKey: { searchTerm },
         queryFn: searchSubjects,
         config: {
-            enabled: !!searchTerm,
+            enabled: !!searchTerm && searchTerm.length > 2,
             onSuccess: (resp) => {
                 setOptions(resp.subjects);
             },

--- a/src/components/sharing/SubjectSearchField.js
+++ b/src/components/sharing/SubjectSearchField.js
@@ -28,7 +28,7 @@ function SubjectSearchField(props) {
         queryKey: { searchTerm },
         queryFn: searchSubjects,
         config: {
-            enabled: !!searchTerm && searchTerm.length > 2,
+            enabled: searchTerm && searchTerm.length > 2,
             onSuccess: (resp) => {
                 setOptions(resp.subjects);
             },

--- a/src/components/sharing/ids.js
+++ b/src/components/sharing/ids.js
@@ -2,10 +2,12 @@ export default {
     BUTTONS: {
         CANCEL: "cancelBtn",
         SAVE: "saveBtn",
+        SHARE: "shareBtn",
     },
     DIALOG: "sharingDialog",
     LOADING: "loadingSkeleton",
     PERMISSION_SELECTOR: "permissionSelector",
     SEARCH_FIELD: "userSearchField",
+    SHARING_MENU_ITEM: "sharingMI",
     TITLE_BAR: "titleBar",
 };

--- a/src/components/sharing/index.js
+++ b/src/components/sharing/index.js
@@ -284,8 +284,9 @@ function Sharing(props) {
                                         const permissionSelector = () => (
                                             <FormControl
                                                 className={
-                                                    isMobile &&
-                                                    classes.mobilePermission
+                                                    isMobile
+                                                        ? classes.mobilePermission
+                                                        : null
                                                 }
                                             >
                                                 <SharingPermissionSelector

--- a/src/components/sharing/index.js
+++ b/src/components/sharing/index.js
@@ -120,8 +120,17 @@ function Sharing(props) {
         }
     }, [resources]);
 
+    const getUserPrimaryText = (user) => {
+        const { email, id } = user;
+        return email ? email : id;
+    };
+
     const getUserAvatar = (user) => {
-        return isGroup(user) ? <Group /> : user.email[0].toUpperCase();
+        return isGroup(user) ? (
+            <Group />
+        ) : (
+            getUserPrimaryText(user)[0].toUpperCase()
+        );
     };
 
     const addUser = (user) => {
@@ -314,7 +323,9 @@ function Sharing(props) {
                                                     primaryText={
                                                         isGroup(user)
                                                             ? groupName(user)
-                                                            : user.email
+                                                            : getUserPrimaryText(
+                                                                  user
+                                                              )
                                                     }
                                                     secondaryText={
                                                         user.institution ||

--- a/src/components/sharing/index.js
+++ b/src/components/sharing/index.js
@@ -200,7 +200,8 @@ function Sharing(props) {
             onSuccess: (results) => {
                 let failures = [];
                 results.forEach((type) => {
-                    const sharing = type.sharing || type.unsharing;
+                    const sharing =
+                        type.sharing || type.unshare || type.unsharing;
                     sharing.forEach((shares) => {
                         const updates = getShareResponseValues(shares);
                         const successFalse = updates.filter(

--- a/src/components/sharing/index.js
+++ b/src/components/sharing/index.js
@@ -83,6 +83,7 @@ function Sharing(props) {
         queryKey: [GET_PERMISSIONS_QUERY_KEY, { resources }],
         queryFn: getPermissions,
         config: {
+            enabled: open && resources !== null,
             onSuccess: (results) => {
                 setPermissions(results);
                 setUserIdList(getUserSet(results));

--- a/src/components/sharing/index.js
+++ b/src/components/sharing/index.js
@@ -262,7 +262,7 @@ function Sharing(props) {
             <DialogContent>
                 {isLoading && (
                     <GridLoading
-                        rows={25}
+                        rows={5}
                         baseId={build(ids.DIALOG, ids.LOADING)}
                     />
                 )}

--- a/src/components/sharing/index.js
+++ b/src/components/sharing/index.js
@@ -123,7 +123,7 @@ function Sharing(props) {
 
     const getUserPrimaryText = (user) => {
         const { email, id } = user;
-        return email ? email : id;
+        return email || id;
     };
 
     const getUserAvatar = (user) => {

--- a/src/components/sharing/styles.js
+++ b/src/components/sharing/styles.js
@@ -1,4 +1,9 @@
 export default (theme) => ({
+    button: {
+        [theme.breakpoints.up("sm")]: {
+            margin: theme.spacing(1),
+        },
+    },
     chip: {
         marginBottom: theme.spacing(1),
     },

--- a/src/components/sharing/util.js
+++ b/src/components/sharing/util.js
@@ -225,7 +225,8 @@ export const getUserMap = (responses, userInfos, resourceTotal) => {
 
             return permissions.reduce((userMap, permission) => {
                 const userId = getUserId(permission);
-                const currentUser = userMap[userId] || userInfos[userId];
+                const currentUser = userMap[userId] ||
+                    userInfos[userId] || { id: userId };
                 const permissionValue = permission.permission;
 
                 // Create an obj with the resource details and the user's

--- a/src/components/sharing/util.js
+++ b/src/components/sharing/util.js
@@ -422,3 +422,16 @@ export const formatSharedData = (selectedData) => {
 
     return { [TYPE.DATA]: formattedData };
 };
+
+export const formatSharedApps = (selectedApps) => {
+    const formattedApps =
+        selectedApps?.map((app) => {
+            return {
+                name: app.name,
+                id: app.id,
+                system_id: app.system_id,
+            };
+        }) || [];
+
+    return { [TYPE.APPS]: formattedApps };
+};

--- a/src/components/sharing/util.js
+++ b/src/components/sharing/util.js
@@ -317,7 +317,8 @@ export const getResourceTotal = (resources) => {
  */
 export const getShareResponseValues = (resp) => {
     return (
-        resp[TYPE.DATA] ||
+        resp["sharing"] ||
+        resp["unshare"] ||
         resp[TYPE.APPS] ||
         resp[TYPE.ANALYSES] ||
         resp[TYPE.TOOLS]

--- a/src/components/sharing/util.js
+++ b/src/components/sharing/util.js
@@ -409,3 +409,16 @@ export const getUnsharingUpdates = (originalUsers, userMap) => {
         return acc;
     }, {});
 };
+
+export const formatSharedData = (selectedData) => {
+    const formattedData =
+        selectedData?.map((data) => {
+            return {
+                label: data.label,
+                path: data.path,
+                type: data.type,
+            };
+        }) || [];
+
+    return { [TYPE.DATA]: formattedData };
+};

--- a/src/components/sharing/util.js
+++ b/src/components/sharing/util.js
@@ -412,11 +412,11 @@ export const getUnsharingUpdates = (originalUsers, userMap) => {
 
 export const formatSharedData = (selectedData) => {
     const formattedData =
-        selectedData?.map((data) => {
+        selectedData?.map(({ label, path, type }) => {
             return {
-                label: data.label,
-                path: data.path,
-                type: data.type,
+                label,
+                path,
+                type,
             };
         }) || [];
 
@@ -425,11 +425,11 @@ export const formatSharedData = (selectedData) => {
 
 export const formatSharedApps = (selectedApps) => {
     const formattedApps =
-        selectedApps?.map((app) => {
+        selectedApps?.map(({ name, id, system_id }) => {
             return {
-                name: app.name,
-                id: app.id,
-                system_id: app.system_id,
+                name,
+                id,
+                system_id,
             };
         }) || [];
 
@@ -438,10 +438,10 @@ export const formatSharedApps = (selectedApps) => {
 
 export const formatSharedAnalyses = (selectedAnalyses) => {
     const formattedAnalyses =
-        selectedAnalyses?.map((analysis) => {
+        selectedAnalyses?.map(({ name, id }) => {
             return {
-                name: analysis.name,
-                id: analysis.id,
+                name,
+                id,
             };
         }) || [];
 

--- a/src/components/sharing/util.js
+++ b/src/components/sharing/util.js
@@ -435,3 +435,15 @@ export const formatSharedApps = (selectedApps) => {
 
     return { [TYPE.APPS]: formattedApps };
 };
+
+export const formatSharedAnalyses = (selectedAnalyses) => {
+    const formattedAnalyses =
+        selectedAnalyses?.map((analysis) => {
+            return {
+                name: analysis.name,
+                id: analysis.id,
+            };
+        }) || [];
+
+    return { [TYPE.ANALYSES]: formattedAnalyses };
+};

--- a/src/serviceFacades/sharing.js
+++ b/src/serviceFacades/sharing.js
@@ -41,7 +41,7 @@ export const dataSharing = ({ sharingReq: DataSharingBody }) => {
 
 export const dataUnsharing = ({ unsharingReq }) => {
     return callApi({
-        endpoint: "/api/share",
+        endpoint: "/api/unshare",
         method: "POST",
         body: unsharingReq,
     });

--- a/src/serviceFacades/sharing.js
+++ b/src/serviceFacades/sharing.js
@@ -103,20 +103,20 @@ export const searchSubjects = ({ searchTerm }) => {
 };
 
 export const doSharingUpdates = ({ sharing, unsharing }) => {
-    const { data, apps, analyses, tools } = sharing;
+    const { paths, apps, analyses, tools } = sharing;
     const {
-        data: dataUnshare,
+        paths: dataUnshare,
         apps: appsUnshare,
         analyses: analysesUnshare,
         tools: toolsUnshare,
     } = unsharing;
     let promises = [];
-    if (data && data.length > 0) {
-        promises.push(dataSharing({ sharingReq: { sharing: data } }));
+    if (paths && paths.length > 0) {
+        promises.push(dataSharing({ sharingReq: { sharing: paths } }));
     }
     if (dataUnshare && dataUnshare.length > 0) {
         promises.push(
-            dataUnsharing({ unsharingReq: { unsharing: dataUnshare } })
+            dataUnsharing({ unsharingReq: { unshare: dataUnshare } })
         );
     }
     if (apps && apps.length > 0) {

--- a/stories/apps/Listing.stories.js
+++ b/stories/apps/Listing.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 import { useTranslation } from "i18n";
 import { AXIOS_DELAY, mockAxios } from "../axiosMock";
 import testConfig from "../configMock";
-import { appDetails, appListing, categories } from "./AppMocks";
+import { appListing, categories } from "./AppMocks";
 
 import constants from "../../src/constants";
 import appFields from "../../src/components/apps/appFields";
@@ -10,6 +10,7 @@ import { getAppTypeFilters } from "../../src/components/apps/toolbar/AppNavigati
 import Listing from "../../src/components/apps/listing/Listing";
 import { ConfigProvider } from "../../src/contexts/config";
 import { UploadTrackingProvider } from "../../src/contexts/uploadTracking";
+import { UserProfileProvider } from "../../src/contexts/userProfile";
 
 export default {
     title: "Apps",
@@ -35,38 +36,40 @@ function ListingTest(props) {
 
     return (
         <UploadTrackingProvider>
-            <ConfigProvider config={testConfig}>
-                <Listing
-                    baseId="tableView"
-                    onRouteToApp={(systemId, appId) =>
-                        console.log("onRouteToApp", systemId, appId)
-                    }
-                    onRouteToListing={(
-                        order,
-                        orderBy,
-                        page,
-                        rowsPerPage,
-                        filter,
-                        category
-                    ) => {
-                        console.log(
-                            "onRouteToListing",
+            <UserProfileProvider>
+                <ConfigProvider config={testConfig}>
+                    <Listing
+                        baseId="tableView"
+                        onRouteToApp={(systemId, appId) =>
+                            console.log("onRouteToApp", systemId, appId)
+                        }
+                        onRouteToListing={(
                             order,
                             orderBy,
                             page,
                             rowsPerPage,
                             filter,
                             category
-                        );
-                    }}
-                    selectedPage={selectedPage}
-                    selectedRowsPerPage={selectedRowsPerPage}
-                    selectedOrder={selectedOrder}
-                    selectedOrderBy={selectedOrderBy}
-                    selectedFilter={selectedFilter}
-                    selectedCategory={selectedCategory}
-                />
-            </ConfigProvider>
+                        ) => {
+                            console.log(
+                                "onRouteToListing",
+                                order,
+                                orderBy,
+                                page,
+                                rowsPerPage,
+                                filter,
+                                category
+                            );
+                        }}
+                        selectedPage={selectedPage}
+                        selectedRowsPerPage={selectedRowsPerPage}
+                        selectedOrder={selectedOrder}
+                        selectedOrderBy={selectedOrderBy}
+                        selectedFilter={selectedFilter}
+                        selectedCategory={selectedCategory}
+                    />
+                </ConfigProvider>
+            </UserProfileProvider>
         </UploadTrackingProvider>
     );
 }

--- a/stories/sharing/SharingMocks.js
+++ b/stories/sharing/SharingMocks.js
@@ -68,7 +68,7 @@ export const dataShareResponse = {
     sharing: [
         {
             user: "joker",
-            paths: [
+            sharing: [
                 {
                     path: "/iplant/home/aramsey/CORE-9077-path.list",
                     permission: "read",
@@ -78,7 +78,7 @@ export const dataShareResponse = {
         },
         {
             user: "alfred",
-            paths: [
+            sharing: [
                 {
                     path: "/iplant/home/aramsey/CORE-9077-path.list",
                     permission: "own",
@@ -102,7 +102,7 @@ export const dataUnshareResponse = {
     unshare: [
         {
             user: "joker",
-            sharing: [
+            unshare: [
                 {
                     path: "/iplant/home/aramsey/CORE-9077-path.list",
                     success: true,


### PR DESCRIPTION
NOTE: All the UI changes discussed in #180 will be in the next PR. This is just for integrating the dialog into Sonora.

I've also updated the dot menus to be more consistent and only show additional options instead of repeating options that are already visible in the toolbar.

Data on desktop:
<img width="1032" alt="image" src="https://user-images.githubusercontent.com/8909156/94470809-0583de00-017d-11eb-9e9e-8fc2b7ba41ae.png">

Data on mobile with dot menu expanded:
<img width="322" alt="image" src="https://user-images.githubusercontent.com/8909156/94470885-1fbdbc00-017d-11eb-9b95-5e0950d42077.png">

Data's new row dot menu:
<img width="321" alt="image" src="https://user-images.githubusercontent.com/8909156/94470934-3237f580-017d-11eb-8755-e14dc20cc7da.png">

Apps on Desktop:
<img width="1030" alt="image" src="https://user-images.githubusercontent.com/8909156/94471030-57c4ff00-017d-11eb-8f98-a77afe8e1113.png">

Apps on mobile with dot menu expanded:
<img width="322" alt="image" src="https://user-images.githubusercontent.com/8909156/94471059-657a8480-017d-11eb-9665-1f04f3cb31c8.png">

Analyses on Desktop:
<img width="1031" alt="image" src="https://user-images.githubusercontent.com/8909156/94471122-7dea9f00-017d-11eb-8f7e-dc743e0650ae.png">

Analyses on Desktop with dot menu expanded:
<img width="1032" alt="image" src="https://user-images.githubusercontent.com/8909156/94471151-88a53400-017d-11eb-9978-b9f02803185b.png">

Analyses on mobile with dot menu expanded:
<img width="321" alt="image" src="https://user-images.githubusercontent.com/8909156/94471207-9bb80400-017d-11eb-821a-8a77460f8539.png">
