### PR TITLE
Match only exact matches or prefixes with a slash at the end based on NavigationConstants, to avoid static files

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -45,7 +45,7 @@ function buildNavigationRouteRegexp() {
         .join("|");
 
     // Build and compile the full regular expression.
-    return new RegExp(`^/(${routeAlternation})`);
+    return new RegExp(`^/(${routeAlternation})(/|$)`);
 }
 
 // Configure the Keycloak client.


### PR DESCRIPTION
Because `apps`, `analyses`, etc. appear in NavigationConstants, `apps_selected.png`, `analyses_selected.png`, etc. were getting checked for SSO based on the regex that the function I changed produced. By adding `(/|$)` to the end, we require the path to either end immediately after the matched string, or have a slash there, meaning that the images with an underscore there no longer match.

I don't _think_ there's stuff this'll pull out of checking SSO that should be checked, but if anyone can think of any then we can amend further, of course!