### PR TITLE
Move default data page ordering to listing

### DIFF
--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -49,6 +49,8 @@ import { useTranslation } from "i18n";
 import { queryCache, useMutation, useQuery } from "react-query";
 
 import { Button, Typography, useTheme } from "@material-ui/core";
+import constants from "constants.js";
+import dataFields from "../dataFields";
 
 function Listing(props) {
     const {
@@ -67,16 +69,22 @@ function Listing(props) {
         selectedOrderBy,
         onRouteToListing,
     } = props;
+    const { t } = useTranslation("data");
+    const dataRecordFields = dataFields(t);
 
     const uploadTracker = useUploadTrackingState();
     const theme = useTheme();
     const [isGridView, setGridView] = useState(false);
-    const [order, setOrder] = useState(selectedOrder);
-    const [orderBy, setOrderBy] = useState(selectedOrderBy);
+    const [order, setOrder] = useState(
+        selectedOrder || constants.SORT_ASCENDING
+    );
+    const [orderBy, setOrderBy] = useState(
+        selectedOrderBy || dataRecordFields.NAME.key
+    );
     const [selected, setSelected] = useState([]);
     const [lastSelectIndex, setLastSelectIndex] = useState(-1);
-    const [page, setPage] = useState(selectedPage);
-    const [rowsPerPage, setRowsPerPage] = useState(selectedRowsPerPage);
+    const [page, setPage] = useState(selectedPage || 0);
+    const [rowsPerPage, setRowsPerPage] = useState(selectedRowsPerPage || 100);
     const [data, setData] = useState({ total: 0, listing: [] });
     const [detailsEnabled, setDetailsEnabled] = useState(false);
     const [detailsOpen, setDetailsOpen] = useState(false);
@@ -103,7 +111,6 @@ function Listing(props) {
     const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
     const [importDialogOpen, setImportDialogOpen] = useState(false);
     const [sharingDlgOpen, setSharingDlgOpen] = useState(false);
-    const { t } = useTranslation("data");
 
     const onCloseImportDialog = () => setImportDialogOpen(false);
 
@@ -240,7 +247,8 @@ function Listing(props) {
             selectedPage !== page ||
             selectedRowsPerPage !== rowsPerPage
         ) {
-            onRouteToListing(path, order, orderBy, page, rowsPerPage);
+            onRouteToListing &&
+                onRouteToListing(path, order, orderBy, page, rowsPerPage);
         }
     }, [
         onRouteToListing,

--- a/src/pages/data/ds/[...pathItems].js
+++ b/src/pages/data/ds/[...pathItems].js
@@ -3,7 +3,6 @@
  *
  */
 import React, { useCallback } from "react";
-import { useTranslation } from "i18n";
 import { useRouter } from "next/router";
 
 import constants from "../../../constants";
@@ -15,7 +14,6 @@ import { getEncodedPath } from "components/data/utils";
 import FileViewer from "components/data/viewers/FileViewer";
 import infoTypes from "components/models/InfoTypes";
 import ResourceTypes from "components/models/ResourceTypes";
-import dataFields from "components/data/dataFields";
 
 /**
  * This variable value needs to match the name of this file for the routing to work
@@ -33,17 +31,15 @@ const dynamicPathName = "/[...pathItems]";
  *
  */
 export default function DataStore() {
-    const { t } = useTranslation("data");
     const router = useRouter();
     const query = router.query;
-    const dataRecordFields = dataFields(t);
 
-    const selectedPage = parseInt(query.selectedPage) || 0;
-    const selectedRowsPerPage =
-        parseInt(getLocalStorage(constants.LOCAL_STORAGE.DATA.PAGE_SIZE)) ||
-        100;
-    const selectedOrder = query.selectedOrder || constants.SORT_ASCENDING;
-    const selectedOrderBy = query.selectedOrderBy || dataRecordFields.NAME.key;
+    const selectedPage = parseInt(query.selectedPage);
+    const selectedRowsPerPage = parseInt(
+        getLocalStorage(constants.LOCAL_STORAGE.DATA.PAGE_SIZE)
+    );
+    const selectedOrder = query.selectedOrder;
+    const selectedOrderBy = query.selectedOrderBy;
 
     const isFile = query.type === ResourceTypes.FILE;
     const resourceId = query.resourceId;


### PR DESCRIPTION
This should fix the errors the data selection drawer was getting.  I just moved the default values that were in the page over to the listing directly to handle (since both the page and the selection drawer need those values).