### PR TITLE
Fix when dot menu items are displayed.

### DIFF
--- a/src/components/data/toolbar/DataDotMenu.js
+++ b/src/components/data/toolbar/DataDotMenu.js
@@ -64,23 +64,7 @@ function DataDotMenu(props) {
                 render={(onClose) => [
                     isSmall
                         ? [
-                              detailsEnabled && (
-                                  <DetailsMenuItem
-                                      key={build(baseId, ids.DETAILS_MENU_ITEM)}
-                                      baseId={baseId}
-                                      onClose={onClose}
-                                      onDetailsSelected={onDetailsSelected}
-                                  />
-                              ),
-                              detailsEnabled && (
-                                  <Divider
-                                      key={build(
-                                          baseId,
-                                          ids.DETAILS_MENU_ITEM_DIVIDER
-                                      )}
-                                  />
-                              ),
-                              isWritable(permission) && [
+                              isWritable(permission) && (
                                   <MenuItem
                                       key={build(baseId, ids.CREATE_FOLDER_MI)}
                                       id={build(baseId, ids.CREATE_FOLDER_MI)}
@@ -93,48 +77,16 @@ function DataDotMenu(props) {
                                           <CreateNewFolder fontSize="small" />
                                       </ListItemIcon>
                                       <ListItemText primary={t("folder")} />
-                                  </MenuItem>,
-                                  <MenuItem
-                                      key={build(baseId, ids.CREATE_HT_FILE_MI)}
-                                      id={build(baseId, ids.CREATE_HT_FILE_MI)}
-                                      onClick={() => {
-                                          onClose();
-                                          onCreateHTFileSelected();
-                                      }}
-                                  >
-                                      <ListItemIcon>
-                                          <ListAlt fontSize="small" />
-                                      </ListItemIcon>
-                                      <ListItemText
-                                          primary={t(
-                                              "newHTAnalysisPathListFile"
-                                          )}
-                                      />
-                                  </MenuItem>,
-                                  <MenuItem
-                                      key={build(
-                                          baseId,
-                                          ids.CREATE_MULTI_INPUT_MI
-                                      )}
-                                      id={build(
-                                          baseId,
-                                          ids.CREATE_MULTI_INPUT_MI
-                                      )}
-                                      onClick={() => {
-                                          onClose();
-                                          onCreateMultiInputFileSelected();
-                                      }}
-                                  >
-                                      <ListItemIcon>
-                                          <ListAlt fontSize="small" />
-                                      </ListItemIcon>
-                                      <ListItemText
-                                          primary={t(
-                                              "newMultiInputPathListFile"
-                                          )}
-                                      />
-                                  </MenuItem>,
-                              ],
+                                  </MenuItem>
+                              ),
+                              detailsEnabled && (
+                                  <DetailsMenuItem
+                                      key={build(baseId, ids.DETAILS_MENU_ITEM)}
+                                      baseId={baseId}
+                                      onClose={onClose}
+                                      onDetailsSelected={onDetailsSelected}
+                                  />
+                              ),
                               canShare && (
                                   <SharingMenuItem
                                       key={build(
@@ -185,6 +137,38 @@ function DataDotMenu(props) {
                                   onDeleteSelected={onDeleteSelected}
                               />
                           ),
+                    isWritable(permission) && [
+                        <MenuItem
+                            key={build(baseId, ids.CREATE_HT_FILE_MI)}
+                            id={build(baseId, ids.CREATE_HT_FILE_MI)}
+                            onClick={() => {
+                                onClose();
+                                onCreateHTFileSelected();
+                            }}
+                        >
+                            <ListItemIcon>
+                                <ListAlt fontSize="small" />
+                            </ListItemIcon>
+                            <ListItemText
+                                primary={t("newHTAnalysisPathListFile")}
+                            />
+                        </MenuItem>,
+                        <MenuItem
+                            key={build(baseId, ids.CREATE_MULTI_INPUT_MI)}
+                            id={build(baseId, ids.CREATE_MULTI_INPUT_MI)}
+                            onClick={() => {
+                                onClose();
+                                onCreateMultiInputFileSelected();
+                            }}
+                        >
+                            <ListItemIcon>
+                                <ListAlt fontSize="small" />
+                            </ListItemIcon>
+                            <ListItemText
+                                primary={t("newMultiInputPathListFile")}
+                            />
+                        </MenuItem>,
+                    ],
                 ]}
             />
             <CreateFolderDialog

--- a/src/components/data/toolbar/Toolbar.js
+++ b/src/components/data/toolbar/Toolbar.js
@@ -71,7 +71,8 @@ function DataToolbar(props) {
     const theme = useTheme();
     const isSmall = useMediaQuery(theme.breakpoints.down("sm"));
     const hasDotMenu =
-        isSmall || (selectedResources && selectedResources.length > 0);
+        (isSmall && selectedResources && selectedResources.length > 0) ||
+        isWritable(permission);
 
     let toolbarId = build(baseId, ids.TOOLBAR);
     return (
@@ -134,6 +135,7 @@ function DataToolbar(props) {
                     />
                 )}
             </Hidden>
+
             {hasDotMenu && (
                 <DataDotMenu
                     baseId={toolbarId}
@@ -159,6 +161,7 @@ function DataToolbar(props) {
                     isSmall={isSmall}
                 />
             )}
+
             <CreateFolderDialog
                 path={path}
                 open={createFolderDlgOpen}


### PR DESCRIPTION
- iPhone 5
Note: When nothing is selected and browsing a folder thats is not writable, `dot menu` wouldn't show at all.
![image](https://user-images.githubusercontent.com/1250790/96158241-5156b700-0ee1-11eb-9f08-58c83191f310.png)

- iPad
![image](https://user-images.githubusercontent.com/1250790/96158337-6af7fe80-0ee1-11eb-96f8-fdb0dad12cc5.png)

- Desktop
![image](https://user-images.githubusercontent.com/1250790/96158448-882ccd00-0ee1-11eb-8f7b-743224f84a8a.png)

- Desktop 
![image](https://user-images.githubusercontent.com/1250790/96158544-a0045100-0ee1-11eb-9ebd-3a1dca8e1d26.png)


