### PR TITLE
CORE-1143: partial wiring of app listings on the dashboard.

### DIFF
--- a/public/static/locales/en/dashboard.json
+++ b/public/static/locales/en/dashboard.json
@@ -35,5 +35,6 @@
     "facebookAria": "facebook",
     "openAria": "open",
     "showLinkAria": "show link",
-    "addToCalendarAria": "add to calendar"
+    "addToCalendarAria": "add to calendar",
+    "favoritesUpdateError": "Unable to update favorites: {{error}}"
 }

--- a/src/components/Dashboard/DashboardItem/AppItem.js
+++ b/src/components/Dashboard/DashboardItem/AppItem.js
@@ -5,6 +5,8 @@ import { IconButton, MenuItem } from "@material-ui/core";
 
 import { formatDate } from "@cyverse-de/ui-lib";
 
+import NavigationConstants from "common/NavigationConstants";
+
 import * as constants from "../constants";
 
 import ItemBase, { ItemAction } from "./ItemBase";
@@ -24,32 +26,40 @@ class AppItem extends ItemBase {
     static create(props) {
         const item = new AppItem(props);
         const { t } = useTranslation("dashboard");
+
+        // Functions to build keys and links.
+        const app = props.content;
+        const buildKey = (keyType) =>
+            `${constants.KIND_APPS}-${app.system_id}-${app.id}-${keyType}`;
+        const buildRef = (refType) =>
+            `${NavigationConstants.APPS}/${app.system_id}/${app.id}/${refType}`;
+
         return item
             .addActions([
                 <ItemAction
                     arialLabel={t("favoriteAria")}
-                    key={`${constants.KIND_APPS}-${props.content.id}-favorite`}
+                    key={buildKey("favorite")}
                     tooltipKey="favoriteAction"
                 >
-                    <IconButton>
+                    <IconButton href={buildRef("favorite")}>
                         <Favorite />
                     </IconButton>
                 </ItemAction>,
                 <ItemAction
                     ariaLabel={t("launchAria")}
-                    key={`${constants.KIND_APPS}-${props.content.id}-launch`}
+                    key={buildKey("launch")}
                     tooltipKey="launchAction"
                 >
-                    <IconButton>
+                    <IconButton href={buildRef("launch")}>
                         <Launch />
                     </IconButton>
                 </ItemAction>,
                 <ItemAction
                     arialLabel={t("shareAria")}
-                    key={`${constants.KIND_APPS}-${props.content.id}-share`}
+                    key={buildKey("share")}
                     tooltipKey="shareAction"
                 >
-                    <IconButton>
+                    <IconButton href={buildRef("share")}>
                         <People />
                     </IconButton>
                 </ItemAction>,

--- a/src/components/Dashboard/DashboardItem/AppItem.js
+++ b/src/components/Dashboard/DashboardItem/AppItem.js
@@ -1,12 +1,8 @@
 import React, { useState } from "react";
-
 import { useMutation } from "react-query";
 
 import { Launch, Info, People, Apps } from "@material-ui/icons";
 import { IconButton, MenuItem } from "@material-ui/core";
-
-import FavoriteIcon from "@material-ui/icons/Favorite";
-import UnFavoriteIcon from "@material-ui/icons/FavoriteBorderOutlined";
 
 import { formatDate } from "@cyverse-de/ui-lib";
 
@@ -17,6 +13,7 @@ import { appFavorite } from "serviceFacades/apps";
 import * as constants from "../constants";
 import ItemBase, { ItemAction } from "./ItemBase";
 import { useTranslation } from "i18n";
+import AppFavorite from "components/apps/AppFavorite";
 
 class AppItem extends ItemBase {
     constructor(props) {
@@ -31,6 +28,7 @@ class AppItem extends ItemBase {
 
     static create(props) {
         const item = new AppItem(props);
+        const { showErrorAnnouncer } = props;
         const { t } = useTranslation(["dashboard", "apps"]);
 
         // Extract app details. Note: dashboard-aggregator only queries the DE database.
@@ -52,7 +50,7 @@ class AppItem extends ItemBase {
                 setIsFavorite(!isFavorite);
             },
             onError: (e) => {
-                console.log(e);
+                showErrorAnnouncer(t("favoritesUpdateError", { error: e }), e);
             },
         });
 
@@ -71,17 +69,12 @@ class AppItem extends ItemBase {
                     key={buildKey("favorite")}
                     tooltipKey={getFavoriteActionKey()}
                 >
-                    <IconButton
-                        id={buildKey("favorite-toggleFavorite")}
-                        onClick={onFavoriteClick}
-                        size="small"
-                    >
-                        {isFavorite ? (
-                            <FavoriteIcon color="primary" />
-                        ) : (
-                            <UnFavoriteIcon color="primary" />
-                        )}
-                    </IconButton>
+                    <AppFavorite
+                        isFavorite={isFavorite}
+                        isExternal={false}
+                        onFavoriteClick={onFavoriteClick}
+                        baseId={buildKey("favorite")}
+                    />
                 </ItemAction>,
                 <ItemAction
                     ariaLabel={t("launchAria")}

--- a/src/components/Dashboard/DashboardItem/AppItem.js
+++ b/src/components/Dashboard/DashboardItem/AppItem.js
@@ -34,10 +34,12 @@ class AppItem extends ItemBase {
         const buildRef = (refType) =>
             `${NavigationConstants.APPS}/${app.system_id}/${app.id}/${refType}`;
 
+        console.log(props);
+
         return item
             .addActions([
                 <ItemAction
-                    arialLabel={t("favoriteAria")}
+                    ariaLabel={t("favoriteAria")}
                     key={buildKey("favorite")}
                     tooltipKey="favoriteAction"
                 >
@@ -55,7 +57,7 @@ class AppItem extends ItemBase {
                     </IconButton>
                 </ItemAction>,
                 <ItemAction
-                    arialLabel={t("shareAria")}
+                    ariaLabel={t("shareAria")}
                     key={buildKey("share")}
                     tooltipKey="shareAction"
                 >
@@ -69,7 +71,7 @@ class AppItem extends ItemBase {
                     key={`${constants.KIND_APPS}-${props.content.id}-details`}
                 >
                     <ItemAction
-                        arialLabel={t("openDetailsAria")}
+                        ariaLabel={t("openDetailsAria")}
                         key={`${constants.KIND_APPS}-${props.content.id}-details`}
                         tooltipKey="detailsAction"
                     >

--- a/src/components/Dashboard/DashboardItem/ItemBase.js
+++ b/src/components/Dashboard/DashboardItem/ItemBase.js
@@ -66,7 +66,7 @@ const DashboardItem = ({ item }) => {
         color,
     });
 
-    const { t } = useTranslation("dashboard");
+    const { t } = useTranslation(["dashboard", "apps"]);
 
     const isMediumOrLarger = useMediaQuery(theme.breakpoints.up("md"));
 
@@ -156,7 +156,7 @@ const DashboardItem = ({ item }) => {
 
 export const DashboardFeedItem = ({ item }) => {
     const classes = useStyles({ width: item.width, height: item.height });
-    const { t } = useTranslation("dashboard");
+    const { t } = useTranslation(["dashboard", "apps"]);
 
     const [origination, date] = item.getOrigination(t);
     const description = fns.cleanDescription(item.content.description);
@@ -210,7 +210,7 @@ export const DashboardVideoItem = ({ item }) => {
 };
 
 export const ItemAction = ({ children, tooltipKey, ariaLabel }) => {
-    const { t } = useTranslation("dashboard");
+    const { t } = useTranslation(["dashboard", "apps"]);
 
     // The nested div prevents props from the Tooltip from getting propagated
     // down to components that may not support them, like Next.js's Link.
@@ -227,7 +227,7 @@ export const MenuAction = ({
     handleClick,
     tooltipKey,
 }) => {
-    const { t } = useTranslation("dashboard");
+    const { t } = useTranslation(["dashboard", "apps"]);
     return (
         <Tooltip title={t(tooltipKey)}>
             <MenuItem onClick={handleClick} aria-label={ariaLabel}>

--- a/src/components/Dashboard/DashboardSection.js
+++ b/src/components/Dashboard/DashboardSection.js
@@ -21,6 +21,7 @@ const DashboardSection = ({
     cardHeight,
     limit,
     numColumns,
+    showErrorAnnouncer,
 }) => {
     const classes = useStyles();
     const { t } = useTranslation("dashboard");
@@ -43,6 +44,7 @@ const DashboardSection = ({
             height: cardHeight,
             width: cardWidth,
             classes,
+            showErrorAnnouncer,
         }).component(index);
 
     const uncollapsed = items.slice(0, limit).map(itemComponent);
@@ -103,6 +105,7 @@ class SectionBase {
         showDivider,
         numColumns,
         limit,
+        showErrorAnnouncer,
     }) {
         const sorted = data[this.kind][this.name].sort((first, second) => {
             const firstParsed = Date.parse(first.date_added);
@@ -134,6 +137,7 @@ class SectionBase {
                 cardHeight={cardHeight}
                 numColumns={numColumns}
                 limit={limit}
+                showErrorAnnouncer={showErrorAnnouncer}
             />
         );
     }

--- a/src/components/Dashboard/index.js
+++ b/src/components/Dashboard/index.js
@@ -34,6 +34,8 @@ import {
     DASHBOARD_QUERY_KEY,
 } from "../../serviceFacades/dashboard";
 
+import withErrorAnnouncer from "components/utils/error/withErrorAnnouncer";
+
 const DashboardSkeleton = () => {
     const classes = useStyles();
     const numSkellies = [0, 1, 2];
@@ -59,7 +61,8 @@ const DashboardSkeleton = () => {
     return <div id={fns.makeID(ids.LOADING)}>{skellies}</div>;
 };
 
-const Dashboard = () => {
+const Dashboard = (props) => {
+    const { showErrorAnnouncer } = props;
     const classes = useStyles();
     const { t } = useTranslation("dashboard");
 
@@ -105,6 +108,7 @@ const Dashboard = () => {
                       cardWidth,
                       cardHeight,
                       numColumns,
+                      showErrorAnnouncer,
                   })
               )
         : [];
@@ -131,4 +135,4 @@ const Dashboard = () => {
     );
 };
 
-export default Dashboard;
+export default withErrorAnnouncer(Dashboard);

--- a/src/pages/dashboard.js
+++ b/src/pages/dashboard.js
@@ -7,7 +7,7 @@ function DashboardPage() {
 }
 
 DashboardPage.getInitialProps = async () => ({
-    namespacesRequired: ["dashboard"],
+    namespacesRequired: ["dashboard", "apps"],
 });
 
 export default DashboardPage;

--- a/stories/dashboard/Dashboard.stories.js
+++ b/stories/dashboard/Dashboard.stories.js
@@ -11,7 +11,10 @@ export default {
 };
 
 export const DashboardTest = () => {
+    const favoriteUriRegexp = /\/api\/apps\/[^/]+\/[^/]+\/favorite/;
     mockAxios.onGet("/api/dashboard?limit=8").reply(200, testData);
+    mockAxios.onPut(favoriteUriRegexp).reply(200);
+    mockAxios.onDelete(favoriteUriRegexp).reply(200);
 
     return <Dashboard />;
 };

--- a/stories/dashboard/data.js
+++ b/stories/dashboard/data.js
@@ -10,6 +10,7 @@ export default {
                 integration_date: null,
                 username: "ipctest@iplantcollaborative.org",
                 edited_date: "2020-02-03T22:30:53.789Z",
+                is_favorite: false,
             },
             {
                 id: "a25da189-ffe6-4f61-9a91-704711f36bd7",
@@ -20,6 +21,7 @@ export default {
                 integration_date: null,
                 username: "ipctest@iplantcollaborative.org",
                 edited_date: "2014-12-08T06:01:37.242Z",
+                is_favorite: false,
             },
             {
                 id: "9ed50f34-fa8f-11e9-9bfc-008cfa5ae621",
@@ -30,6 +32,7 @@ export default {
                 integration_date: null,
                 username: "ipctest@iplantcollaborative.org",
                 edited_date: "2019-10-29T21:04:26.403Z",
+                is_favorite: false,
             },
             {
                 id: "39896e30-3b5c-11e7-90ce-008cfa5ae621",
@@ -40,6 +43,7 @@ export default {
                 integration_date: null,
                 username: "ipctest@iplantcollaborative.org",
                 edited_date: "2017-05-17T23:54:54.624Z",
+                is_favorite: false,
             },
             {
                 id: "b390f5f0-4f13-11e9-8949-008cfa5ae621",
@@ -51,6 +55,7 @@ export default {
                 integration_date: null,
                 username: "ipctest@iplantcollaborative.org",
                 edited_date: "2019-03-25T15:36:04.700Z",
+                is_favorite: false,
             },
             {
                 id: "8bc52f58-4ff6-11e9-adb1-008cfa5ae621",
@@ -61,6 +66,7 @@ export default {
                 integration_date: null,
                 username: "ipctest@iplantcollaborative.org",
                 edited_date: "2019-03-26T18:39:53.693Z",
+                is_favorite: false,
             },
             {
                 id: "d3ec0a42-6142-11e9-b580-008cfa5ae621",
@@ -71,6 +77,7 @@ export default {
                 integration_date: null,
                 username: "ipctest@iplantcollaborative.org",
                 edited_date: "2019-04-17T18:58:46.260Z",
+                is_favorite: false,
             },
             {
                 id: "a74b9840-7b23-11e9-86f2-008cfa5ae621",
@@ -82,6 +89,7 @@ export default {
                 integration_date: null,
                 username: "ipctest@iplantcollaborative.org",
                 edited_date: "2019-05-20T17:21:07.223Z",
+                is_favorite: false,
             },
         ],
         public: [
@@ -94,6 +102,7 @@ export default {
                 integration_date: "2020-03-16T07:14:46.656Z",
                 username: "ipctest@iplantcollaborative.org",
                 edited_date: "2020-03-16T07:14:56.813Z",
+                is_favorite: true,
             },
             {
                 id: "c81731dc-6755-11ea-908b-c2a97b34bb42",
@@ -104,6 +113,7 @@ export default {
                 integration_date: "2020-03-16T07:14:35.636Z",
                 username: "ipctest@iplantcollaborative.org",
                 edited_date: "2020-03-16T07:14:35.636Z",
+                is_favorite: true,
             },
             {
                 id: "9e989f50-6109-11ea-ab9d-008cfa5ae621",
@@ -115,6 +125,7 @@ export default {
                 integration_date: "2020-03-10T21:48:05.803Z",
                 username: "ipctest@iplantcollaborative.org",
                 edited_date: "2020-03-10T21:48:05.803Z",
+                is_favorite: false,
             },
             {
                 id: "b91ffda4-4df0-11ea-bd40-008cfa5ae621",
@@ -126,6 +137,7 @@ export default {
                 integration_date: "2020-03-09T21:13:54.884Z",
                 username: "ipctest@iplantcollaborative.org",
                 edited_date: "2020-03-09T21:13:54.884Z",
+                is_favorite: false,
             },
             {
                 id: "aee316c6-15d5-11ea-933d-008cfa5ae621",
@@ -137,6 +149,7 @@ export default {
                 integration_date: "2020-03-04T18:40:22.199Z",
                 username: "ipctest@iplantcollaborative.org",
                 edited_date: "2020-03-04T18:40:22.199Z",
+                is_favorite: false,
             },
             {
                 id: "58f783bc-5c95-11ea-b10d-008cfa5ae621",
@@ -147,6 +160,7 @@ export default {
                 integration_date: "2020-03-02T15:36:48.063Z",
                 username: "ipctest@iplantcollaborative.org",
                 edited_date: "2020-03-02T15:36:48.063Z",
+                is_favorite: false,
             },
             {
                 id: "6ff82cda-5c98-11ea-aad3-008cfa5ae621",
@@ -158,6 +172,7 @@ export default {
                 integration_date: "2020-03-02T15:33:49.287Z",
                 username: "ipctest@iplantcollaborative.org",
                 edited_date: "2020-03-02T15:33:49.287Z",
+                is_favorite: false,
             },
             {
                 id: "a847402e-ff2a-11e9-815d-008cfa5ae621",
@@ -169,6 +184,7 @@ export default {
                 integration_date: "2020-02-17T22:20:28.291Z",
                 username: "ipctest@iplantcollaborative.org",
                 edited_date: "2020-02-17T22:20:28.291Z",
+                is_favorite: false,
             },
         ],
     },

--- a/stories/dashboard/data.js
+++ b/stories/dashboard/data.js
@@ -3,6 +3,7 @@ export default {
         recentlyAdded: [
             {
                 id: "d6bda456-46d4-11ea-a4de-008cfa5ae621",
+                system_id: "de",
                 name: "Copy of Rstudio-DESeq2",
                 description: "Rstudio DESeq2 VICE image",
                 wiki_url: null,
@@ -12,6 +13,7 @@ export default {
             },
             {
                 id: "a25da189-ffe6-4f61-9a91-704711f36bd7",
+                system_id: "de",
                 name: "New app",
                 description: "asdf",
                 wiki_url: null,
@@ -21,6 +23,7 @@ export default {
             },
             {
                 id: "9ed50f34-fa8f-11e9-9bfc-008cfa5ae621",
+                system_id: "de",
                 name: "Copy of sequenceserver",
                 description: "sequenceserver test app",
                 wiki_url: null,
@@ -30,6 +33,7 @@ export default {
             },
             {
                 id: "39896e30-3b5c-11e7-90ce-008cfa5ae621",
+                system_id: "de",
                 name: "Copy of New app",
                 description: "asdf",
                 wiki_url: null,
@@ -39,6 +43,7 @@ export default {
             },
             {
                 id: "b390f5f0-4f13-11e9-8949-008cfa5ae621",
+                system_id: "de",
                 name: "test-vice-delay",
                 description:
                     "A test app for testing a tool that has a significant delay or amount of processing to perform in its entrpoint.",
@@ -49,6 +54,7 @@ export default {
             },
             {
                 id: "8bc52f58-4ff6-11e9-adb1-008cfa5ae621",
+                system_id: "de",
                 name: "wheee",
                 description: "testing testing testing",
                 wiki_url: null,
@@ -58,6 +64,7 @@ export default {
             },
             {
                 id: "d3ec0a42-6142-11e9-b580-008cfa5ae621",
+                system_id: "de",
                 name: "test-vice-potree-entwine",
                 description: "testing",
                 wiki_url: null,
@@ -67,6 +74,7 @@ export default {
             },
             {
                 id: "a74b9840-7b23-11e9-86f2-008cfa5ae621",
+                system_id: "de",
                 name: "Copy of GEA RNA-Seq QC Demo 0.1",
                 description:
                     "This is a demonstration application for the genomics education alliance RNA-Seq pipeline",
@@ -79,6 +87,7 @@ export default {
         public: [
             {
                 id: "0dfe3e35-0000-4995-bc31-24b94ee7eada",
+                system_id: "de",
                 name: "QA_App-Endpoint-Test-Mod5_QA",
                 description: "Testing new app endpoints.  Modified.",
                 wiki_url: null,
@@ -88,6 +97,7 @@ export default {
             },
             {
                 id: "c81731dc-6755-11ea-908b-c2a97b34bb42",
+                system_id: "de",
                 name: "QA_TestForMultiplePanelsTerrain_QA",
                 description: "This is a new description for the shared app.",
                 wiki_url: null,
@@ -97,6 +107,7 @@ export default {
             },
             {
                 id: "9e989f50-6109-11ea-ab9d-008cfa5ae621",
+                system_id: "de",
                 name: "Snakemake-VICE",
                 description:
                     "VICE app with jupyter lab and snakemake-minimal. Also conda and RNAseq analysis tools",
@@ -107,6 +118,7 @@ export default {
             },
             {
                 id: "b91ffda4-4df0-11ea-bd40-008cfa5ae621",
+                system_id: "de",
                 name: "HTSeqQC 1.0",
                 description:
                     "HTSeqQC is an automated quality control analysis tool for a single and paired-end high-throughput sequencing data (HTS) generated from Illumina sequencing platforms.",
@@ -117,6 +129,7 @@ export default {
             },
             {
                 id: "aee316c6-15d5-11ea-933d-008cfa5ae621",
+                system_id: "de",
                 name: "Sequence Properties Analyser",
                 description:
                     "Compares statistical properties of two sets of protein sequences.",
@@ -127,6 +140,7 @@ export default {
             },
             {
                 id: "58f783bc-5c95-11ea-b10d-008cfa5ae621",
+                system_id: "de",
                 name: "ALLMAPS",
                 description: "Performs ALLMAPS merge and path",
                 wiki_url: null,
@@ -136,6 +150,7 @@ export default {
             },
             {
                 id: "6ff82cda-5c98-11ea-aad3-008cfa5ae621",
+                system_id: "de",
                 name: "ALLMAPS merge",
                 description:
                     "ALLMAPS orders scaffolds by maximizing colinearity to a collection of genetic/genomic maps into the final chromosome build.  This is step one: merging maps into a bed file and generating the weights file. http://goo.gl/KI61Ow",
@@ -146,6 +161,7 @@ export default {
             },
             {
                 id: "a847402e-ff2a-11e9-815d-008cfa5ae621",
+                system_id: "de",
                 name: "QGIS Xpra Desktop",
                 description:
                     "desktop running Xpra with QGIS, SAGA-GIS, GRASS, GDAL, PDAL",


### PR DESCRIPTION
Not everything is done here, but I wanted to submit a PR now just because I'm inexperienced when it comes to UI work, and I want to catch any errors early. The dashboard cards for apps now look like this:

![image](https://user-images.githubusercontent.com/415143/96192021-12812b00-0efa-11eb-84d3-de72ca5f43ec.png)

Clicking on the `Favorite` icon when a user is not logged in will display a message indicating that an error occurred. attempting to obtain more details will display the usual login required dialog:

![image](https://user-images.githubusercontent.com/415143/96192236-773c8580-0efa-11eb-90a2-468d51a30472.png)

Clicking an app's `Launch` icon will now navigate to the launch screen for that app.

The `AppFavorite` component from the app details panel is being reused, so the icon color has changed to the primary color. Should the other icons be modified to use the primary color as well?