### PR TITLE
CORE-1140 Add Notifications listing page

### DIFF
--- a/src/__tests__/notifications.js
+++ b/src/__tests__/notifications.js
@@ -1,0 +1,36 @@
+import React from "react";
+
+import TestRenderer from "react-test-renderer";
+
+import { I18nProviderWrapper } from "../i18n";
+
+import { mockAxios } from "../../stories/axiosMock";
+
+import { Listing } from "../../stories/notifications/Listing.stories";
+import { NotificationsPreviewTest } from "../../stories/notifications/Notifications.stories";
+
+beforeEach(() => {
+    mockAxios.reset();
+});
+
+afterEach(() => {
+    mockAxios.reset();
+});
+
+test("renders Notifications Listing without crashing", () => {
+    const component = TestRenderer.create(
+        <I18nProviderWrapper>
+            <Listing />
+        </I18nProviderWrapper>
+    );
+    component.unmount();
+});
+
+test("renders Notifications Menu without crashing", () => {
+    const component = TestRenderer.create(
+        <I18nProviderWrapper>
+            <NotificationsPreviewTest />
+        </I18nProviderWrapper>
+    );
+    component.unmount();
+});

--- a/src/common/NavigationConstants.js
+++ b/src/common/NavigationConstants.js
@@ -10,6 +10,7 @@ export default {
     LOGIN: "login",
     LOGOUT: "logout",
     MORE: "more",
+    NOTIFICATIONS: "notifications",
     NOTIFICATION_WS: "/websocket/notifications",
     REF_GENOMES: "refgenomes",
     RELAUNCH: "relaunch",

--- a/src/components/notifications/NotificationsMenu.js
+++ b/src/components/notifications/NotificationsMenu.js
@@ -47,24 +47,38 @@ function getTimeStamp(time) {
 }
 
 const NotificationsListingButton = React.forwardRef((props, ref) => {
-    const { handleClose, href, onClick } = props;
+    const { isMobile, handleClose, href, onClick } = props;
     const { t } = useTranslation("common");
+    const buttonId = build(
+        ids.BASE_DEBUG_ID,
+        ids.NOTIFICATIONS_MENU,
+        ids.VIEW_ALL_NOTIFICATIONS
+    );
 
-    return (
-        <Button
-            id={build(
-                ids.BASE_DEBUG_ID,
-                ids.NOTIFICATIONS_MENU,
-                ids.VIEW_ALL_NOTIFICATIONS
-            )}
-            color="primary"
+    return isMobile ? (
+        <IconButton
+            className={useStyles().viewAll}
+            id={buttonId}
+            ref={ref}
             href={href}
             onClick={(event) => {
                 onClick(event);
                 handleClose();
             }}
-            ref={ref}
+        >
+            <OpenInNewIcon size="small" />
+        </IconButton>
+    ) : (
+        <Button
+            id={buttonId}
+            color="primary"
             startIcon={<OpenInNewIcon size="small" />}
+            ref={ref}
+            href={href}
+            onClick={(event) => {
+                onClick(event);
+                handleClose();
+            }}
         >
             {t("viewAllNotifications")}
         </Button>
@@ -72,12 +86,11 @@ const NotificationsListingButton = React.forwardRef((props, ref) => {
 });
 
 function NotificationsListingLink(props) {
-    const { handleClose } = props;
     const href = `/${NavigationConstants.NOTIFICATIONS}`;
 
     return (
         <Link href={href} as={href} passHref>
-            <NotificationsListingButton handleClose={handleClose} />
+            <NotificationsListingButton {...props} />
         </Link>
     );
 }
@@ -158,18 +171,13 @@ function NotificationsMenu(props) {
                     {t("notifications")}
                 </Typography>
                 {isMobile && [
+                    <NotificationsListingLink
+                        key={ids.VIEW_ALL_NOTIFICATIONS}
+                        handleClose={handleClose}
+                        isMobile={isMobile}
+                    />,
                     <IconButton
-                        className={classes.viewAll}
-                        onClick={handleClose}
-                        id={build(
-                            ids.BASE_DEBUG_ID,
-                            ids.NOTIFICATIONS_MENU,
-                            ids.VIEW_ALL_NOTIFICATIONS
-                        )}
-                    >
-                        <OpenInNewIcon size="small" />
-                    </IconButton>,
-                    <IconButton
+                        key={ids.MARK_ALL_READ}
                         className={classes.markSeen}
                         onClick={handleClick}
                         id={build(
@@ -263,6 +271,7 @@ function NotificationsMenu(props) {
                 <NotificationsListingLink
                     key={ids.VIEW_ALL_NOTIFICATIONS}
                     handleClose={handleClose}
+                    isMobile={isMobile}
                 />,
                 <Button
                     key={ids.MARK_ALL_READ}

--- a/src/components/notifications/NotificationsMenu.js
+++ b/src/components/notifications/NotificationsMenu.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useQuery } from "react-query";
+import Link from "next/link";
 import { formatDistance, fromUnixTime } from "date-fns";
 import classnames from "classnames";
 
@@ -10,7 +11,13 @@ import {
 import { useTranslation } from "../../i18n";
 import ids from "./ids";
 import NotificationStyles from "./styles";
+
+import NavigationConstants from "common/NavigationConstants";
+
 import { getDisplayMessage } from "components/layout/Notifications";
+
+import ExternalLink from "components/utils/ExternalLink";
+import ErrorTypographyWithDialog from "components/utils/error/ErrorTypographyWithDialog";
 
 import { build } from "@cyverse-de/ui-lib";
 import {
@@ -19,7 +26,6 @@ import {
     IconButton,
     ListItem,
     ListItemText,
-    Link,
     makeStyles,
     Menu,
     Typography,
@@ -29,7 +35,6 @@ import {
 import { Skeleton } from "@material-ui/lab";
 import DoneAllIcon from "@material-ui/icons/DoneAll";
 import OpenInNewIcon from "@material-ui/icons/OpenInNew";
-import ErrorTypographyWithDialog from "components/utils/error/ErrorTypographyWithDialog";
 
 const useStyles = makeStyles(NotificationStyles);
 
@@ -41,18 +46,50 @@ function getTimeStamp(time) {
     }
 }
 
+const NotificationsListingButton = React.forwardRef((props, ref) => {
+    const { handleClose, href, onClick } = props;
+    const { t } = useTranslation("common");
+
+    return (
+        <Button
+            id={build(
+                ids.BASE_DEBUG_ID,
+                ids.NOTIFICATIONS_MENU,
+                ids.VIEW_ALL_NOTIFICATIONS
+            )}
+            color="primary"
+            href={href}
+            onClick={(event) => {
+                onClick(event);
+                handleClose();
+            }}
+            ref={ref}
+            startIcon={<OpenInNewIcon size="small" />}
+        >
+            {t("viewAllNotifications")}
+        </Button>
+    );
+});
+
+function NotificationsListingLink(props) {
+    const { handleClose } = props;
+    const href = `/${NavigationConstants.NOTIFICATIONS}`;
+
+    return (
+        <Link href={href} as={href} passHref>
+            <NotificationsListingButton handleClose={handleClose} />
+        </Link>
+    );
+}
+
 function InteractiveAnalysisUrl(props) {
     const { t } = useTranslation(["common"]);
     return (
         <span>
             {". "}
-            <Link
-                href={props.notification.payload.access_url}
-                target="_blank"
-                rel="noopener noreferrer"
-            >
+            <ExternalLink href={props.notification.payload.access_url}>
                 {t("interactiveAnalysisUrl")}
-            </Link>
+            </ExternalLink>
         </span>
     );
 }
@@ -64,7 +101,7 @@ function NotificationsMenu(props) {
     const classes = useStyles();
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down("xs"));
-    const { t } = useTranslation(["common"]);
+    const { t } = useTranslation("common");
 
     const handleClose = () => {
         setAnchorEl();
@@ -223,29 +260,12 @@ function NotificationsMenu(props) {
                 ))}
             {!isMobile && [
                 <Divider light key="divider" />,
+                <NotificationsListingLink
+                    key={ids.VIEW_ALL_NOTIFICATIONS}
+                    handleClose={handleClose}
+                />,
                 <Button
-                    key={build(
-                        ids.BASE_DEBUG_ID,
-                        ids.NOTIFICATIONS_MENU,
-                        ids.VIEW_ALL_NOTIFICATIONS
-                    )}
-                    id={build(
-                        ids.BASE_DEBUG_ID,
-                        ids.NOTIFICATIONS_MENU,
-                        ids.VIEW_ALL_NOTIFICATIONS
-                    )}
-                    color="primary"
-                    onClick={handleClose}
-                    startIcon={<OpenInNewIcon size="small" />}
-                >
-                    {t("viewAllNotifications")}
-                </Button>,
-                <Button
-                    key={build(
-                        ids.BASE_DEBUG_ID,
-                        ids.NOTIFICATIONS_MENU,
-                        ids.MARK_ALL_READ
-                    )}
+                    key={ids.MARK_ALL_READ}
                     id={build(
                         ids.BASE_DEBUG_ID,
                         ids.NOTIFICATIONS_MENU,

--- a/src/components/notifications/Toolbar.js
+++ b/src/components/notifications/Toolbar.js
@@ -53,6 +53,7 @@ const NotificationToolbar = (props) => {
                 className={classes.filter}
                 variant="outlined"
                 select
+                size="small"
                 value={filter}
                 onChange={onFilterChange}
             >

--- a/src/components/notifications/listing/TableView.js
+++ b/src/components/notifications/listing/TableView.js
@@ -151,93 +151,105 @@ const TableView = (props) => {
     }
 
     return (
-        <TableContainer component={Paper} style={{ overflow: "auto" }}>
-            <Table stickyHeader={true} size="small">
-                {loading ? (
-                    <TableLoading
-                        baseId={baseId}
-                        numColumns={columnData.length + 1}
-                        numRows={25}
-                    />
-                ) : (
-                    <TableBody>
-                        {(!data || data.length === 0) && (
-                            <EmptyTable
-                                message={t("noNotifications")}
-                                numColumns={columnData.length}
-                            />
-                        )}
-                        {data?.length > 0 &&
-                            data.map((n) => {
-                                const isSelected = selected.includes(
-                                    n.message.id
-                                );
+        <>
+            <TableContainer component={Paper} style={{ overflow: "auto" }}>
+                <Table stickyHeader={true} size="small">
+                    {loading ? (
+                        <TableLoading
+                            baseId={baseId}
+                            numColumns={columnData.length + 1}
+                            numRows={25}
+                        />
+                    ) : (
+                        <TableBody>
+                            {(!data || data.length === 0) && (
+                                <EmptyTable
+                                    message={t("noNotifications")}
+                                    numColumns={columnData.length}
+                                />
+                            )}
+                            {data?.length > 0 &&
+                                data.map((n) => {
+                                    const isSelected = selected.includes(
+                                        n.message.id
+                                    );
 
-                                const className = n.seen
-                                    ? null
-                                    : classes.unSeenNotificationBackground;
+                                    const className = n.seen
+                                        ? null
+                                        : classes.unSeenNotificationBackground;
 
-                                return (
-                                    <TableRow
-                                        onClick={(event) =>
-                                            handleRowClick(event, n.message.id)
-                                        }
-                                        role="checkbox"
-                                        aria-checked={isSelected}
-                                        tabIndex={-1}
-                                        selected={isSelected}
-                                        hover
-                                        key={n.message.id}
-                                    >
-                                        <TableCell
-                                            className={className}
-                                            padding="checkbox"
+                                    return (
+                                        <TableRow
+                                            onClick={(event) =>
+                                                handleRowClick(
+                                                    event,
+                                                    n.message.id
+                                                )
+                                            }
+                                            role="checkbox"
+                                            aria-checked={isSelected}
+                                            tabIndex={-1}
+                                            selected={isSelected}
+                                            hover
+                                            key={n.message.id}
                                         >
-                                            <DECheckbox checked={isSelected} />
-                                        </TableCell>
-                                        <TableCell className={className}>
-                                            <Typography>
-                                                {
-                                                    notificationCategory[
-                                                        n.type
-                                                            .replace(/\s/g, "_")
-                                                            .toLowerCase()
-                                                    ]
-                                                }
-                                            </Typography>
-                                        </TableCell>
-                                        <Message
-                                            className={classnames(
-                                                classes.notification,
-                                                className
-                                            )}
-                                            message={n.message}
-                                            onMessageClicked={onMessageClicked}
-                                        />
-                                        <TableCell className={className}>
-                                            <Typography variant="body2">
-                                                {formatDate(
-                                                    n.message.timestamp
+                                            <TableCell
+                                                className={className}
+                                                padding="checkbox"
+                                            >
+                                                <DECheckbox
+                                                    checked={isSelected}
+                                                />
+                                            </TableCell>
+                                            <TableCell className={className}>
+                                                <Typography>
+                                                    {
+                                                        notificationCategory[
+                                                            n.type
+                                                                .replace(
+                                                                    /\s/g,
+                                                                    "_"
+                                                                )
+                                                                .toLowerCase()
+                                                        ]
+                                                    }
+                                                </Typography>
+                                            </TableCell>
+                                            <Message
+                                                className={classnames(
+                                                    classes.notification,
+                                                    className
                                                 )}
-                                            </Typography>
-                                        </TableCell>
-                                    </TableRow>
-                                );
-                            })}
-                    </TableBody>
-                )}
-                <EnhancedTableHead
-                    selectable={true}
-                    numSelected={selected.length}
-                    order={order}
-                    orderBy={orderBy}
-                    onSelectAllClick={handleSelectAllClick}
-                    onRequestSort={handleRequestSort}
-                    columnData={columnData}
-                    baseId={baseId}
-                    rowsInPage={data?.length || 0}
-                />
-            </Table>
+                                                message={n.message}
+                                                onMessageClicked={
+                                                    onMessageClicked
+                                                }
+                                            />
+                                            <TableCell className={className}>
+                                                <Typography variant="body2">
+                                                    {formatDate(
+                                                        n.message.timestamp
+                                                    )}
+                                                </Typography>
+                                            </TableCell>
+                                        </TableRow>
+                                    );
+                                })}
+                        </TableBody>
+                    )}
+                    <EnhancedTableHead
+                        selectable={true}
+                        numSelected={selected.length}
+                        order={order}
+                        orderBy={orderBy}
+                        onSelectAllClick={handleSelectAllClick}
+                        onRequestSort={handleRequestSort}
+                        columnData={columnData}
+                        baseId={baseId}
+                        rowsInPage={data?.length || 0}
+                    />
+                </Table>
+            </TableContainer>
             <DEPagination
                 baseId={baseId}
                 totalPages={Math.ceil(total / rowsPerPage)}
@@ -246,7 +258,7 @@ const TableView = (props) => {
                 onChange={handleChangePage}
                 onPageSizeChange={handleChangeRowsPerPage}
             />
-        </TableContainer>
+        </>
     );
 };
 

--- a/src/components/notifications/listing/TableView.js
+++ b/src/components/notifications/listing/TableView.js
@@ -30,9 +30,11 @@ import {
 
 import {
     makeStyles,
+    Paper,
     Table,
     TableBody,
     TableCell,
+    TableContainer,
     TableRow,
     Typography,
 } from "@material-ui/core";
@@ -149,7 +151,7 @@ const TableView = (props) => {
     }
 
     return (
-        <>
+        <TableContainer component={Paper} style={{ overflow: "auto" }}>
             <Table stickyHeader={true} size="small">
                 {loading ? (
                     <TableLoading
@@ -213,7 +215,7 @@ const TableView = (props) => {
                                             onMessageClicked={onMessageClicked}
                                         />
                                         <TableCell className={className}>
-                                            <Typography>
+                                            <Typography variant="body2">
                                                 {formatDate(
                                                     n.message.timestamp
                                                 )}
@@ -244,7 +246,7 @@ const TableView = (props) => {
                 onChange={handleChangePage}
                 onPageSizeChange={handleChangeRowsPerPage}
             />
-        </>
+        </TableContainer>
     );
 };
 

--- a/src/components/notifications/listing/index.js
+++ b/src/components/notifications/listing/index.js
@@ -62,7 +62,13 @@ const NotificationView = (props) => {
     React.useEffect(() => {
         setNotificationsKey([
             NOTIFICATIONS_MESSAGES_QUERY_KEY,
-            { filter, orderBy, order, limit: rowsPerPage, offset },
+            {
+                filter: filter === notificationCategory.all ? null : filter,
+                orderBy,
+                order,
+                limit: rowsPerPage,
+                offset,
+            },
         ]);
         setNotificationsMessagesQueryEnabled(true);
     }, [

--- a/src/pages/notifications.js
+++ b/src/pages/notifications.js
@@ -1,0 +1,24 @@
+/**
+ * Notifications listing page
+ *
+ * @author psarando
+ */
+import React from "react";
+
+import NotificationsListing from "components/notifications/listing";
+
+export default function Notifications() {
+    return (
+        <NotificationsListing
+            baseDebugId="notifications"
+            onMessageClicked={(message) =>
+                // TODO handle navigation to other pages
+                console.log("onMessageClicked", message)
+            }
+        />
+    );
+}
+
+Notifications.getInitialProps = async () => ({
+    namespacesRequired: ["notifications"],
+});


### PR DESCRIPTION
This PR will add the `/notifications` listing page.

The Notifications Menu "View All Notifications" button will now navigate to this new page.

Also the Notifications listing table view and toolbar styles were updated to better match styles in other listing tables (smaller filter select field, table container for overflow scrolling, etc).

I also added basic tests for the Notifications menu and listing.

### TODO

Navigating to other pages (data, apps, etc) when clicking a notification still needs to be implemented.