### PR TITLE
CORE-1009 User can view community data without logging in

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -42,6 +42,7 @@ analysis:
 
 irods:
     home_path: /iplant/home
+    trash_path: /iplant/trash/home/de-irods
 
 fileIdentifier:
   htPathList: "# application/vnd.de.path-list+csv; version=1"

--- a/public/static/locales/en/data.json
+++ b/public/static/locales/en/data.json
@@ -48,6 +48,7 @@
     "fileSaveError": "Unable to save {{fileName}}",
     "fileSaveSuccess": "{{fileName}} saved successfully.",
     "gridView": "Grid View",
+    "home": "Home",
     "importCoge": "Import Genome from CoGe",
     "importUrl": "Import from URL",
     "infoType": "Info Type",

--- a/src/components/data/toolbar/Navigation.js
+++ b/src/components/data/toolbar/Navigation.js
@@ -43,6 +43,7 @@ import {
     Tooltip,
     Typography,
 } from "@material-ui/core";
+import { useConfig } from "contexts/config";
 
 const useStyles = makeStyles(styles);
 
@@ -325,13 +326,18 @@ function Navigation(props) {
     const [communityDataPath, setCommunityDataPath] = useState("");
     const dataNavId = build(baseId, ids.DATA_NAVIGATION);
     const [userProfile] = useUserProfile();
+    const [config] = useConfig();
+    const irodsHomePath = config?.irods?.home_path;
 
     const preProcessData = (respData) => {
-        if (respData && userProfile) {
+        if (respData) {
             const respRoots = respData.roots;
-            const home = respRoots.find(
-                (root) => root.label === userProfile.id
-            );
+            const home = userProfile
+                ? respRoots.find((root) => root.label === userProfile.id)
+                : {
+                      label: t("home"),
+                      path: `${irodsHomePath}/${constants.ANONYMOUS_USER}`,
+                  };
             home.icon = <HomeIcon fontSize="small" />;
             const sharedWithMe = respRoots.find(
                 (root) => root.label === constants.SHARED_WITH_ME
@@ -351,7 +357,11 @@ function Navigation(props) {
             const basePaths = respData["base-paths"];
             setUserHomePath(basePaths["user_home_path"]);
             setUserTrashPath(basePaths["user_trash_path"]);
-            setDataRoots([home, sharedWithMe, communityData, trash]);
+            setDataRoots(
+                userProfile
+                    ? [home, sharedWithMe, communityData, trash]
+                    : [communityData, home, sharedWithMe, trash]
+            );
             handleDataNavError(null);
         }
     };

--- a/src/constants.js
+++ b/src/constants.js
@@ -61,4 +61,5 @@ export default {
         SPECIAL_CHARS:
             "https://cyverse.atlassian.net/wiki/spaces/DEmanual/pages/242027163/Troubleshooting+an+Analysis#TroubleshootinganAnalysis-3.Checktheinputfilesandparameter",
     },
+    ANONYMOUS_USER: "anonymous",
 };

--- a/src/server/api/data.js
+++ b/src/server/api/data.js
@@ -119,7 +119,7 @@ export default function dataRouter() {
         auth.authnTokenMiddleware,
         terrainHandler({
             method: "GET",
-            pathname: "/secured/filetypes/type-list",
+            pathname: "/filetypes/type-list",
         })
     );
 

--- a/src/server/api/data.js
+++ b/src/server/api/data.js
@@ -44,7 +44,7 @@ export default function dataRouter() {
     api.get(
         "/filesystem/root",
         auth.authnTokenMiddleware,
-        terrainHandler({ method: "GET", pathname: "/secured/filesystem/root" })
+        terrainHandler({ method: "GET", pathname: "/filesystem/root" })
     );
 
     logger.info(

--- a/src/server/api/data.js
+++ b/src/server/api/data.js
@@ -142,7 +142,7 @@ export default function dataRouter() {
         auth.authnTokenMiddleware,
         terrainHandler({
             method: "POST",
-            pathname: "/secured/filesystem/search",
+            pathname: "/filesystem/search",
             headers: {
                 "Content-Type": "application/json",
             },

--- a/src/server/api/data.js
+++ b/src/server/api/data.js
@@ -165,7 +165,7 @@ export default function dataRouter() {
         auth.authnTokenMiddleware,
         terrainHandler({
             method: "POST",
-            pathname: "/secured/filesystem/read-chunk",
+            pathname: "/filesystem/read-chunk",
             headers: {
                 "Content-Type": "application/json",
             },
@@ -178,7 +178,7 @@ export default function dataRouter() {
         auth.authnTokenMiddleware,
         terrainHandler({
             method: "POST",
-            pathname: "/secured/filesystem/read-csv-chunk",
+            pathname: "/filesystem/read-csv-chunk",
             headers: {
                 "Content-Type": "application/json",
             },

--- a/src/server/configuration.js
+++ b/src/server/configuration.js
@@ -99,6 +99,7 @@ const validate = () => {
 
     //irods settings
     validateConfigSetting("irods.home_path");
+    validateConfigSetting("irods.trash_path");
 };
 
 validate();
@@ -245,3 +246,15 @@ export const amqpUri = config.get("amqp.amqp_uri");
  *
  */
 export const amqpExchangeName = config.get("amqp.exchange_name");
+
+/**
+ * iRods home path
+ * @type {string}
+ */
+export const iRodsHome = config.get("irods.home_path");
+
+/**
+ * iRods trash path
+ * @type {string}
+ */
+export const iRodsTrash = config.get("irods.trash_path");

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -84,7 +84,16 @@ app.prepare()
 
         logger.info("adding the /login/* handler");
         server.get("/login/*", keycloakClient.protect(), (req, res) => {
-            res.redirect(req.url.replace(/^\/login/, ""));
+            // Remove login from the url
+            // Remove paths specific to the anonymous user, like the anonymous user's
+            // home folder, to prevent sign-in from redirecting the authenticated
+            // user back to anonymous's folders again
+            res.redirect(
+                req.url
+                    .replace(/^\/login/, "")
+                    .replace(`${config.iRodsHome}/anonymous`, "")
+                    .replace(`${config.iRodsTrash}/anonymous`, "")
+            );
         });
 
         //get notifications from amqp


### PR DESCRIPTION
NOTE: Requires [terrain #177](https://github.com/cyverse-de/terrain/pull/177) to be merged first.  Also needs config changes in k8s-resources

These are the Sonora changes to enable logged out users to browse community data, read public files, and search community data.  The breadcrumbs when logged out are slightly changed so that Community Data comes first, and what would have been the user's home folder is now generically named "Home".  Clicking on any breadcrumb other than Community Data will take the user to the "please sign in" page:

<img width="439" alt="image" src="https://user-images.githubusercontent.com/8909156/97042917-9d7baa00-1526-11eb-9284-20787fa4a853.png">
