### PR TITLE
Minor sharing updates

### DIFF
--- a/public/static/locales/en/sharing.json
+++ b/public/static/locales/en/sharing.json
@@ -1,6 +1,5 @@
 {
     "cannotAddSelf": "Cannot add yourself for sharing",
-    "cyverseId": "CyVerse ID: {{id}}",
     "dataGroupSharingDisabled": "Data and/or analyses resources cannot be shared with groups at this time",
     "fetchPermissionsError": "Failed to fetch resource permissions",
     "fetchUserInfoError": "Failed to fetch user information",
@@ -10,7 +9,7 @@
     "read": "Read",
     "remove": "Remove",
     "resources": "Resources",
-    "searchUsers": "Search By CyVerse ID, email, or group name...",
+    "searchUsers": "Search By CyVerse username, email, or group name...",
     "searchUsersMobile": "Search for users...",
     "share": "Share",
     "sharing": "Sharing",
@@ -19,6 +18,7 @@
     "sharingUnsuccessful": "Sharing failed. Please try again",
     "user": "User",
     "userAlreadyAdded": "User has already been added",
+    "username": "Username: {{id}}",
     "varies": "Varies",
     "write": "Write"
 }

--- a/public/static/locales/en/sharing.json
+++ b/public/static/locales/en/sharing.json
@@ -1,5 +1,6 @@
 {
     "cannotAddSelf": "Cannot add yourself for sharing",
+    "cyverseId": "CyVerse ID: {{id}}",
     "dataGroupSharingDisabled": "Data and/or analyses resources cannot be shared with groups at this time",
     "fetchPermissionsError": "Failed to fetch resource permissions",
     "fetchUserInfoError": "Failed to fetch user information",

--- a/src/components/sharing/UserTable.js
+++ b/src/components/sharing/UserTable.js
@@ -53,7 +53,7 @@ function UserTable(props) {
                                     >
                                         {!isGroup(user) && (
                                             <>
-                                                {t("cyverseId", {
+                                                {t("username", {
                                                     id: user.id,
                                                 })}
                                                 <br />

--- a/src/components/sharing/UserTable.js
+++ b/src/components/sharing/UserTable.js
@@ -16,12 +16,13 @@ import {
     TableHead,
     TableRow,
     TableSortLabel,
+    Typography,
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/styles";
 import { useSortBy, useTable } from "react-table";
 
 import { useTranslation } from "i18n";
-import { getUserPrimaryText, getUserSecondaryText } from "./util";
+import { getUserPrimaryText, getUserSecondaryText, isGroup } from "./util";
 import ids from "./ids";
 import SharingPermissionSelector from "./SharingPermissionSelector";
 import styles from "./styles";
@@ -39,14 +40,32 @@ function UserTable(props) {
             {
                 Header: t("user"),
                 accessor: getUserPrimaryText,
-                Cell: ({ row, value }) => (
-                    <ListItem classes={{ root: classes.listItem }}>
-                        <ListItemText
-                            primary={value}
-                            secondary={getUserSecondaryText(row.original)}
-                        />
-                    </ListItem>
-                ),
+                Cell: ({ row, value }) => {
+                    const user = row.original;
+                    return (
+                        <ListItem classes={{ root: classes.listItem }}>
+                            <ListItemText
+                                primary={value}
+                                secondary={
+                                    <Typography
+                                        variant="body2"
+                                        color="textSecondary"
+                                    >
+                                        {!isGroup(user) && (
+                                            <>
+                                                {t("cyverseId", {
+                                                    id: user.id,
+                                                })}
+                                                <br />
+                                            </>
+                                        )}
+                                        {getUserSecondaryText(user)}
+                                    </Typography>
+                                }
+                            />
+                        </ListItem>
+                    );
+                },
             },
             {
                 Header: t("permission"),

--- a/src/components/sharing/index.js
+++ b/src/components/sharing/index.js
@@ -188,6 +188,16 @@ function Sharing(props) {
         setUserMap(updated);
     };
 
+    const handleClose = () => {
+        setPermissions([]);
+        setUserMap({});
+        setOriginalUsers({});
+        setUserIdList([]);
+        setErrorDetails(null);
+
+        onClose();
+    };
+
     const [sendSharingUpdates, { isLoading: isSaving }] = useMutation(
         doSharingUpdates,
         {
@@ -212,7 +222,7 @@ function Sharing(props) {
                         error: failures,
                     });
                 } else {
-                    onClose();
+                    handleClose();
                 }
             },
             onError: (error) => {
@@ -239,7 +249,7 @@ function Sharing(props) {
     return (
         <Dialog
             open={open}
-            onClose={onClose}
+            onClose={handleClose}
             maxWidth="lg"
             fullWidth
             id={baseId}
@@ -248,7 +258,7 @@ function Sharing(props) {
                 {tSharing("sharing")}
                 <IconButton
                     aria-label={tCommon("cancel")}
-                    onClick={onClose}
+                    onClick={handleClose}
                     size="small"
                     classes={{ root: classes.closeButton }}
                     id={build(baseId, ids.TITLE_BAR, ids.BUTTONS.CANCEL)}
@@ -344,10 +354,7 @@ function Sharing(props) {
             <DialogActions>
                 <Button
                     id={build(baseId, ids.BUTTONS.CANCEL)}
-                    onClick={() => {
-                        setErrorDetails(null);
-                        onClose();
-                    }}
+                    onClick={handleClose}
                 >
                     {tCommon("cancel")}
                 </Button>
@@ -355,10 +362,7 @@ function Sharing(props) {
                     id={build(baseId, ids.BUTTONS.SAVE)}
                     color="primary"
                     type="submit"
-                    onClick={() => {
-                        setErrorDetails(null);
-                        onSave();
-                    }}
+                    onClick={onSave}
                 >
                     {tCommon("done")}
                 </Button>


### PR DESCRIPTION
This should add the user's CyVerse ID to the sharing dialog's user table.  It didn't make sense that you could search for user ID but not see the user ID in the table.

![image](https://user-images.githubusercontent.com/8909156/97765823-f7edab00-1ad0-11eb-83a1-7a285765fa16.png)

This will also fix the issue where you could make some modifications to the sharing dialog (add or remove some users, for example), then hit cancel, reopen the sharing dialog, and see all the modifications again as if they had saved.