### PR TITLE
Fix Chrome crashing while loading data

### DIFF
--- a/src/components/data/dataFields.js
+++ b/src/components/data/dataFields.js
@@ -1,7 +1,9 @@
+import { DEFAULT_PAGE_SETTINGS } from "./utils";
+
 const dataFields = (dataI18n) => ({
     NAME: {
         fieldName: dataI18n("name"),
-        key: "name",
+        key: DEFAULT_PAGE_SETTINGS.orderBy,
     },
     LAST_MODIFIED: {
         fieldName: dataI18n("modified"),

--- a/src/components/data/dataFields.js
+++ b/src/components/data/dataFields.js
@@ -1,9 +1,7 @@
-import { DEFAULT_PAGE_SETTINGS } from "./utils";
-
 const dataFields = (dataI18n) => ({
     NAME: {
         fieldName: dataI18n("name"),
-        key: DEFAULT_PAGE_SETTINGS.orderBy,
+        key: "name",
     },
     LAST_MODIFIED: {
         fieldName: dataI18n("modified"),

--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -28,6 +28,7 @@ import { camelcaseit } from "common/functions";
 import withErrorAnnouncer from "components/utils/error/withErrorAnnouncer";
 import Sharing from "components/sharing";
 import { formatSharedData } from "components/sharing/util";
+import { DEFAULT_PAGE_SETTINGS, getPageQueryParams } from "../utils";
 
 import {
     useUploadTrackingState,
@@ -50,8 +51,6 @@ import { useBagAddItems } from "serviceFacades/bags";
 import { queryCache, useMutation, useQuery } from "react-query";
 
 import { Button, Typography, useTheme } from "@material-ui/core";
-import constants from "constants.js";
-import dataFields from "../dataFields";
 
 function Listing(props) {
     const {
@@ -71,21 +70,24 @@ function Listing(props) {
         onRouteToListing,
     } = props;
     const { t } = useTranslation("data");
-    const dataRecordFields = dataFields(t);
 
     const uploadTracker = useUploadTrackingState();
     const theme = useTheme();
     const [isGridView, setGridView] = useState(false);
     const [order, setOrder] = useState(
-        selectedOrder || constants.SORT_ASCENDING
+        selectedOrder || DEFAULT_PAGE_SETTINGS.order
     );
     const [orderBy, setOrderBy] = useState(
-        selectedOrderBy || dataRecordFields.NAME.key
+        selectedOrderBy || DEFAULT_PAGE_SETTINGS.orderBy
     );
     const [selected, setSelected] = useState([]);
     const [lastSelectIndex, setLastSelectIndex] = useState(-1);
-    const [page, setPage] = useState(selectedPage || 0);
-    const [rowsPerPage, setRowsPerPage] = useState(selectedRowsPerPage || 100);
+    const [page, setPage] = useState(
+        selectedPage || DEFAULT_PAGE_SETTINGS.page
+    );
+    const [rowsPerPage, setRowsPerPage] = useState(
+        selectedRowsPerPage || DEFAULT_PAGE_SETTINGS.rowsPerPage
+    );
     const [data, setData] = useState({ total: 0, listing: [] });
     const [detailsEnabled, setDetailsEnabled] = useState(false);
     const [detailsOpen, setDetailsOpen] = useState(false);

--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -415,6 +415,16 @@ function Listing(props) {
         [setNavError]
     );
 
+    const onPathChange = (path, resourceType, id) => {
+        const queryParams = getPageQueryParams(
+            order,
+            orderBy,
+            page,
+            rowsPerPage
+        );
+        handlePathChange(path, queryParams, resourceType, id);
+    };
+
     const isLoading = isQueryLoading([isFetching, removeResourceStatus]);
     const localUploadId = build(baseId, ids.UPLOAD_MI, ids.UPLOAD_INPUT);
     return (
@@ -425,7 +435,7 @@ function Listing(props) {
                     path={path}
                     selected={selected}
                     getSelectedResources={getSelectedResources}
-                    handlePathChange={handlePathChange}
+                    handlePathChange={onPathChange}
                     permission={data?.permission}
                     refreshListing={refreshListing}
                     isGridView={isGridView}
@@ -454,7 +464,7 @@ function Listing(props) {
                         loading={isLoading}
                         error={error || navError}
                         path={path}
-                        handlePathChange={handlePathChange}
+                        handlePathChange={onPathChange}
                         listing={data?.listing}
                         baseId={baseId}
                         isInvalidSelection={isInvalidSelection}

--- a/src/components/data/utils.js
+++ b/src/components/data/utils.js
@@ -110,9 +110,27 @@ const useDataNavigationLink = (path, resourceId, type) => {
     return [href, as];
 };
 
+const DEFAULT_PAGE_SETTINGS = {
+    order: constants.SORT_ASCENDING,
+    orderBy: "name",
+    page: 0,
+    rowsPerPage: 100,
+};
+
+const getPageQueryParams = (order, orderBy, page, rowsPerPage) => {
+    const selectedOrder = order || DEFAULT_PAGE_SETTINGS.order;
+    const selectedOrderBy = orderBy || DEFAULT_PAGE_SETTINGS.orderBy;
+    const selectedPage = page || DEFAULT_PAGE_SETTINGS.page;
+    const selectedRowsPerPage =
+        rowsPerPage || DEFAULT_PAGE_SETTINGS.rowsPerPage;
+    return `selectedOrder=${selectedOrder}&selectedOrderBy=${selectedOrderBy}&selectedPage=${selectedPage}&selectedRowsPerPage=${selectedRowsPerPage}`;
+};
+
 export {
+    DEFAULT_PAGE_SETTINGS,
     getEncodedPath,
     getFolderPage,
+    getPageQueryParams,
     validateDiskResourceName,
     hasOwn,
     isOwner,

--- a/src/components/sharing/index.js
+++ b/src/components/sharing/index.js
@@ -101,6 +101,7 @@ function Sharing(props) {
         queryKey: [USER_INFO_QUERY_KEY, { userIds: userIdList }],
         queryFn: getUserInfo,
         config: {
+            enabled: userIdList && userIdList.length > 0,
             onSuccess: (results) => {
                 const userMap = getUserMap(permissions, results, resourceTotal);
 

--- a/src/pages/data/ds/[...pathItems].js
+++ b/src/pages/data/ds/[...pathItems].js
@@ -10,12 +10,10 @@ import constants from "../../../constants";
 import { getLocalStorage } from "components/utils/localStorage";
 import viewerConstants from "components/data/viewers/constants";
 import Listing from "components/data/listing/Listing";
-import { getEncodedPath, getPageQueryParams } from "components/data/utils";
+import { getEncodedPath } from "components/data/utils";
 import FileViewer from "components/data/viewers/FileViewer";
 import infoTypes from "components/models/InfoTypes";
 import ResourceTypes from "components/models/ResourceTypes";
-import { useUserProfile } from "contexts/userProfile";
-import { useConfig } from "contexts/config";
 
 /**
  * This variable value needs to match the name of this file for the routing to work
@@ -35,8 +33,6 @@ const dynamicPathName = "/[...pathItems]";
 export default function DataStore() {
     const router = useRouter();
     const query = router.query;
-    const [userProfile] = useUserProfile();
-    const [config] = useConfig();
 
     const selectedPage = parseInt(query.selectedPage);
     const selectedRowsPerPage = parseInt(
@@ -73,22 +69,6 @@ export default function DataStore() {
         },
         [baseRoutingPath, router]
     );
-
-    // Set a default path to prevent re-renders and redirects
-    // This should only run if the user goes to /data or /data/ds
-    if (!path) {
-        const username = userProfile?.id;
-        const irodsHomePath = config?.irods?.home_path;
-        if (irodsHomePath) {
-            const defaultParams = getPageQueryParams();
-            const defaultPath = getEncodedPath(
-                username
-                    ? `${irodsHomePath}/${username}`
-                    : `${irodsHomePath}/shared`
-            );
-            handlePathChange(defaultPath, defaultParams);
-        }
-    }
 
     const onCreateHTFileSelected = useCallback(
         (path) => {

--- a/src/pages/data/ds/index.js
+++ b/src/pages/data/ds/index.js
@@ -2,8 +2,11 @@
  *
  * @author sriram, aramsey
  */
-import React from "react";
-import DataStore from "./[...pathItems]";
+import React, { Fragment, useEffect } from "react";
+import { useUserProfile } from "contexts/userProfile";
+import { useConfig } from "contexts/config";
+import { getEncodedPath, getPageQueryParams } from "components/data/utils";
+import { useRouter } from "next/router";
 
 /**
  *
@@ -12,7 +15,26 @@ import DataStore from "./[...pathItems]";
  * Go directly to the dynamic path
  */
 export default function Data() {
-    return <DataStore />;
+    const router = useRouter();
+    const [userProfile] = useUserProfile();
+    const [config] = useConfig();
+
+    useEffect(() => {
+        const username = userProfile?.id;
+        const irodsHomePath = config?.irods?.home_path;
+
+        if (irodsHomePath) {
+            const defaultParams = getPageQueryParams();
+            const defaultPath = getEncodedPath(
+                username
+                    ? `${irodsHomePath}/${username}`
+                    : `${irodsHomePath}/shared`
+            );
+            router.push(`${router.pathname}${defaultPath}?${defaultParams}`);
+        }
+    }, [router, config, userProfile]);
+
+    return <Fragment />;
 }
 
 Data.getInitialProps = async () => ({

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -6,6 +6,12 @@ import React, { Fragment, useEffect } from "react";
 import { useRouter } from "next/router";
 
 import constants from "../../constants";
+import {
+    getEncodedPath,
+    getPageQueryParams,
+} from "../../components/data/utils";
+import { useUserProfile } from "../../contexts/userProfile";
+import { useConfig } from "../../contexts/config";
 
 /**
  *
@@ -15,12 +21,25 @@ import constants from "../../constants";
  */
 export default function Data() {
     const router = useRouter();
+    const [userProfile] = useUserProfile();
+    const [config] = useConfig();
 
     useEffect(() => {
-        router.push(
-            `${router.pathname}${constants.PATH_SEPARATOR}${constants.DATA_STORE_STORAGE_ID}`
-        );
-    }, [router]);
+        const username = userProfile?.id;
+        const irodsHomePath = config?.irods?.home_path;
+
+        if (irodsHomePath) {
+            const defaultParams = getPageQueryParams();
+            const defaultPath = getEncodedPath(
+                username
+                    ? `${irodsHomePath}/${username}`
+                    : `${irodsHomePath}/shared`
+            );
+            router.push(
+                `${router.pathname}${constants.PATH_SEPARATOR}${constants.DATA_STORE_STORAGE_ID}${defaultPath}?${defaultParams}`
+            );
+        }
+    }, [router, config, userProfile]);
 
     return <Fragment />;
 }


### PR DESCRIPTION
This should fix an extraneous call to userinfo happening, but more importantly fix an issue in Chrome that occurs when navigating to the Data page.  In the console, you get this warning over and over again:
```
Throttling navigation to prevent the browser from hanging. See https://crbug.com/882238. Command line switch --disable-ipc-flooding-protection can be used to bypass the protection
```

Now we're basically defining a default path with default order, orderBy, etc. to minimize the number of redirects that happen. 

Without this change, we have `/data` -> `/data/ds` ->`/data/ds/somePath` -> `/data/ds/somePath?someParams`.  
With this change we have `/data` ->`/data/ds/somePath?someParams`
Or `/data/ds` -> `/data/ds/somePath?someParams`