### PR TITLE
Use react-player light mode to improve performance of dashboard page

### DIFF
--- a/src/common/NavigationConstants.js
+++ b/src/common/NavigationConstants.js
@@ -17,5 +17,5 @@ export default {
     SEARCH: "search",
     SETTINGS: "settings",
     VICE: "vice",
-    YOUTUBE_EMBED_BASE: "https://www.youtube-nocookie.com/embed",
+    YOUTUBE_EMBED_BASE: "https://youtu.be",
 };

--- a/src/components/dashboard/dashboardItem/ItemBase.js
+++ b/src/components/dashboard/dashboardItem/ItemBase.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import clsx from "clsx";
 import { useTranslation } from "i18n";
+import ReactPlayer from "react-player/youtube";
 
 import {
     Avatar,
@@ -203,18 +204,22 @@ export const DashboardVideoItem = ({ item }) => {
     const classes = useStyles(item);
 
     return (
-        <iframe
+        <div
             className={classes.dashboardVideo}
             aria-label={item.content.name}
             title={item.content.name}
             width="100%"
             height="100%"
-            src={item.getLinkTarget()}
-            frameBorder="0"
-            controls="1"
-            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; fullscreen"
-            allowFullScreen
-        ></iframe>
+        >
+            <ReactPlayer
+                url={item.getLinkTarget()}
+                light={true}
+                width="100%"
+                height="100%"
+                playing={true}
+                controls={true}
+            />
+        </div>
     );
 };
 


### PR DESCRIPTION
Not a super huge amount to this. Mostly just changes the iframe to a div (which then adopts the width/height/etc), and inside it puts a `ReactPlayer` with the `light` option set, which uses noembed.com to fetch a thumbnail and uses that, superimposing a play button that loads the actual full player.

Here's how it looks:

![Screenshot_2020-11-12 Discovery Environment](https://user-images.githubusercontent.com/106004/98995563-be646900-24ee-11eb-9765-644cee73495f.png)
