### PR TITLE
Make next dynamic imports work with jest, and dynamically load VideoViewer and TextViewer

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,5 +11,12 @@
         }
       }
     ]
-  ]
+  ],
+  "env": {
+    "test": {
+      "plugins": [
+        "babel-plugin-dynamic-import-node"
+      ]
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14211,6 +14211,12 @@
                 "@jest/types": "^24.9.0"
             }
         },
+        "jest-next-dynamic": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/jest-next-dynamic/-/jest-next-dynamic-1.0.1.tgz",
+            "integrity": "sha512-peo9yRvUn8u6PZro9AzzjxpgUc+1NZhZMan+1xzk7Bz1vA0d5IC2Iw8E7bkC2cwl9AG3XxTaqPVAXbC3aMbVkw==",
+            "dev": true
+        },
         "jest-pnp-resolver": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
         "fetch-mock": "^9.5.0",
         "husky": "^4.0.10",
         "jest": "^24.9.0",
+        "jest-next-dynamic": "^1.0.1",
         "jsdoc": "^3.6.3",
         "lint-staged": "^10.2.2",
         "nodemon": "^2.0.2",

--- a/src/__tests__/data.js
+++ b/src/__tests__/data.js
@@ -1,9 +1,14 @@
 import React from "react";
+import preloadAll from "jest-next-dynamic";
 import renderer from "react-test-renderer";
 import { DataTableViewTest } from "../../stories/data/TableView.stories";
 import { PathListFileViewerTest } from "../../stories/data/viewers/PathListViewer.stories";
 import { PlainTextFileViewerTest } from "../../stories/data/viewers/TextViewer.stories";
 import { I18nProviderWrapper } from "../i18n";
+
+beforeAll(async () => {
+    await preloadAll();
+});
 
 test("Data Table View renders", () => {
     const component = renderer.create(

--- a/src/components/data/viewers/FileViewer.js
+++ b/src/components/data/viewers/FileViewer.js
@@ -7,6 +7,7 @@
  */
 
 import React, { useEffect, useMemo, useState } from "react";
+import dynamic from "next/dynamic";
 
 import { useConfig } from "contexts/config";
 import { useTranslation } from "i18n";
@@ -32,9 +33,7 @@ import ImageViewer from "./ImageViewer";
 import PathListViewer from "./PathListViewer";
 import { refreshViewer, useFileManifest, useReadChunk } from "./queries";
 import StructuredTextViewer from "./StructuredTextViewer";
-import TextViewer from "./TextViewer";
 import { flattenStructureData } from "./utils";
-import VideoViewer from "./VideoViewer";
 import { parseNameFromPath } from "../utils";
 
 import { build } from "@cyverse-de/ui-lib";
@@ -44,6 +43,10 @@ import {
     Toolbar,
     Typography,
 } from "@material-ui/core";
+
+// these are at the bottom so eslint doesn't complain
+const TextViewer = dynamic(() => import("./TextViewer"));
+const VideoViewer = dynamic(() => import("./VideoViewer"));
 
 const VIEWER_TYPE = {
     PLAIN: "plain",


### PR DESCRIPTION
This is another thing I decided to take a stab at while I was thinking about sonora bundle sizes and performance. Without this PR, every data listing and file view loads all the viewers, which includes several hundred kilobytes of `highlight.js` (and the smaller but still notable 45-ish kilobytes that are the `react-player` File player). Previously, this didn't work, because jest would get tripped up on the `next/dynamic` imports, but with the other additions here, dynamic imports can work correctly for jest too. The changes in `FileViewer.js` are the ones that improve performance, the rest of the files are changes to make dynamic imports work with jest.