### PR TITLE
Remove react-table from initial loading dependencies.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,5 +11,12 @@
         }
       }
     ]
-  ]
+  ],
+  "env": {
+    "test": {
+      "plugins": [
+        "babel-plugin-dynamic-import-node"
+      ]
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14211,6 +14211,12 @@
                 "@jest/types": "^24.9.0"
             }
         },
+        "jest-next-dynamic": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/jest-next-dynamic/-/jest-next-dynamic-1.0.1.tgz",
+            "integrity": "sha512-peo9yRvUn8u6PZro9AzzjxpgUc+1NZhZMan+1xzk7Bz1vA0d5IC2Iw8E7bkC2cwl9AG3XxTaqPVAXbC3aMbVkw==",
+            "dev": true
+        },
         "jest-pnp-resolver": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
         "fetch-mock": "^9.5.0",
         "husky": "^4.0.10",
         "jest": "^24.9.0",
+        "jest-next-dynamic": "^1.0.1",
         "jsdoc": "^3.6.3",
         "lint-staged": "^10.2.2",
         "nodemon": "^2.0.2",

--- a/src/__tests__/data.js
+++ b/src/__tests__/data.js
@@ -1,9 +1,14 @@
 import React from "react";
+import preloadAll from "jest-next-dynamic";
 import renderer from "react-test-renderer";
 import { DataTableViewTest } from "../../stories/data/TableView.stories";
 import { PathListFileViewerTest } from "../../stories/data/viewers/PathListViewer.stories";
 import { PlainTextFileViewerTest } from "../../stories/data/viewers/TextViewer.stories";
 import { I18nProviderWrapper } from "../i18n";
+
+beforeAll(async () => {
+    await preloadAll();
+});
 
 test("Data Table View renders", () => {
     const component = renderer.create(

--- a/src/__tests__/layout.js
+++ b/src/__tests__/layout.js
@@ -1,8 +1,13 @@
 import React from "react";
+import preloadAll from "jest-next-dynamic";
 import renderer from "react-test-renderer";
 import { AppBar } from "../../stories/CyVerseAppBar.stories";
 import { I18nProviderWrapper } from "../i18n";
 import { PreferencesProvider } from "contexts/userPreferences";
+
+beforeAll(async () => {
+    await preloadAll();
+});
 
 test("App Bar renders", () => {
     const component = renderer.create(

--- a/src/components/Bag/index.js
+++ b/src/components/Bag/index.js
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 
+import dynamic from "next/dynamic";
+
 import {
     Badge,
     Dialog,
@@ -32,8 +34,6 @@ import {
     ShoppingBasket as ShoppingBasketIcon,
 } from "@material-ui/icons";
 
-import SharingView from "components/sharing";
-
 import { build as buildID } from "@cyverse-de/ui-lib";
 
 import constants from "./constants";
@@ -55,6 +55,8 @@ import {
 import { useTranslation } from "i18n";
 import { useTheme } from "@material-ui/styles";
 import { useUserProfile } from "contexts/userProfile";
+
+const SharingView = dynamic(() => import("components/sharing"));
 
 const useStyles = makeStyles((theme) => ({
     help: {

--- a/src/components/data/viewers/FileViewer.js
+++ b/src/components/data/viewers/FileViewer.js
@@ -7,6 +7,7 @@
  */
 
 import React, { useEffect, useMemo, useState } from "react";
+import dynamic from "next/dynamic";
 
 import { useConfig } from "contexts/config";
 import { useTranslation } from "i18n";
@@ -32,9 +33,7 @@ import ImageViewer from "./ImageViewer";
 import PathListViewer from "./PathListViewer";
 import { refreshViewer, useFileManifest, useReadChunk } from "./queries";
 import StructuredTextViewer from "./StructuredTextViewer";
-import TextViewer from "./TextViewer";
 import { flattenStructureData } from "./utils";
-import VideoViewer from "./VideoViewer";
 import { parseNameFromPath } from "../utils";
 
 import { build } from "@cyverse-de/ui-lib";
@@ -44,6 +43,10 @@ import {
     Toolbar,
     Typography,
 } from "@material-ui/core";
+
+// these are at the bottom so eslint doesn't complain
+const TextViewer = dynamic(() => import("./TextViewer"));
+const VideoViewer = dynamic(() => import("./VideoViewer"));
 
 const VIEWER_TYPE = {
     PLAIN: "plain",

--- a/src/components/search/GlobalSearchField.js
+++ b/src/components/search/GlobalSearchField.js
@@ -32,7 +32,7 @@ import appFields from "components/apps/appFields";
 import analysisFields from "components/analyses/analysisFields";
 
 import ids from "./ids";
-import { SEARCH_RESULTS_TABS } from "components/search/detailed/DetailedSearchResults";
+import SEARCH_RESULTS_TABS from "components/search/detailed/tabs";
 import { getDataSimpleSearchQuery } from "./dataSearchQueryBuilder";
 import { getAnalysesSearchQueryFilter } from "./analysesSearchQueryBuilder";
 

--- a/src/components/search/detailed/DetailedSearchResults.js
+++ b/src/components/search/detailed/DetailedSearchResults.js
@@ -19,6 +19,8 @@ import DataSearchResults from "./DataSearchResults";
 import AnalysesSearchResults from "./AnalysesSearchResults";
 import DETabPanel from "components/utils/DETabPanel";
 
+import SEARCH_RESULTS_TABS from "components/search/detailed/tabs";
+
 import {
     Divider,
     Paper,
@@ -66,12 +68,6 @@ const useStyles = makeStyles((theme) => ({
         margin: theme.spacing(0.25),
     },
 }));
-
-const SEARCH_RESULTS_TABS = {
-    data: "DATA",
-    apps: "APPS",
-    analyses: "ANALYSES",
-};
 
 function DetailedSearchResults(props) {
     const { baseId, searchTerm, selectedTab, onTabSelectionChange } = props;
@@ -235,5 +231,4 @@ function DetailedSearchResults(props) {
         </Paper>
     );
 }
-export { SEARCH_RESULTS_TABS };
 export default DetailedSearchResults;

--- a/src/components/search/detailed/tabs.js
+++ b/src/components/search/detailed/tabs.js
@@ -1,0 +1,5 @@
+export default {
+    data: "DATA",
+    apps: "APPS",
+    analyses: "ANALYSES",
+};

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 import { Hidden } from "@material-ui/core";
 import GlobalSearchField from "components/search/GlobalSearchField";
 import DetailedSearchResults from "components/search/detailed/DetailedSearchResults";
-import { SEARCH_RESULTS_TABS } from "components/search/detailed/DetailedSearchResults";
+import SEARCH_RESULTS_TABS from "components/search/detailed/tabs";
 import NavigationConstants from "common/NavigationConstants";
 
 export default function Search() {

--- a/stories/search/DetailedSearchResults.stories.js
+++ b/stories/search/DetailedSearchResults.stories.js
@@ -8,7 +8,7 @@
 import React from "react";
 import { mockAxios } from "../axiosMock";
 import DetailedSearchResults from "components/search/detailed/DetailedSearchResults";
-import { SEARCH_RESULTS_TABS } from "components/search/detailed/DetailedSearchResults";
+import SEARCH_RESULTS_TABS from "components/search/detailed/tabs";
 import {
     dataSearchResp,
     appsSearchResp,


### PR DESCRIPTION
Includes commits from #223 because this also uses `next/dynamic` and another test needed the appropriate treatment.

The core things here:

 * import SharingView dynamically in the Bag component. This is only used if the user is logged-in and it pulls in a whole bunch of stuff, so splitting it into a separate chunk seems warranted.
 * move some constants, `SEARCH_RESULTS_TABS`, into their own namespace. This way, their former namespace, `DetailedSearchResults`, doesn't need to all be brought into namespaces that require those constants, perhaps most notably the global search field that appears on every page.

With only the second of those (which I did first), the "shared by all pages" JS went from 350kB to 304kB. With both, it's down to 284kB. Ideally we could cut this down a lot more, but `next-i18next` and what it brings along is a bit more than 70k by itself, and next.js's main/normal stuff is also about 70k. A lot of the rest is material-ui stuff. The biggest remaining target would be getting rid of the old vestiges of `react-intl` and our `I18NWrapper`, I think.