### PR TITLE
First load niceties

### DIFF
--- a/src/components/Bag/index.js
+++ b/src/components/Bag/index.js
@@ -23,6 +23,7 @@ import {
     Typography,
     FormControl,
     InputLabel,
+    useTheme,
 } from "@material-ui/core";
 import {
     Delete,
@@ -53,7 +54,6 @@ import {
     APP_TYPE,
 } from "./classes";
 import { useTranslation } from "i18n";
-import { useTheme } from "@material-ui/styles";
 import { useUserProfile } from "contexts/userProfile";
 
 const SharingView = dynamic(() => import("components/sharing"));

--- a/src/components/apps/AgaveAuthPromptDialog.js
+++ b/src/components/apps/AgaveAuthPromptDialog.js
@@ -14,7 +14,7 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import useMediaQuery from "@material-ui/core/useMediaQuery";
-import { useTheme } from "@material-ui/core/styles";
+import { useTheme } from "@material-ui/core";
 import { build } from "@cyverse-de/ui-lib";
 
 import ids from "./ids";

--- a/src/components/dashboard/dashboardItem/ItemBase.js
+++ b/src/components/dashboard/dashboardItem/ItemBase.js
@@ -16,11 +16,10 @@ import {
     IconButton,
     Tooltip,
     MenuItem,
+    useTheme,
 } from "@material-ui/core";
 
 import { MoreVert } from "@material-ui/icons";
-
-import { useTheme } from "@material-ui/styles";
 
 import { build as buildID } from "@cyverse-de/ui-lib";
 

--- a/src/components/layout/CyVerseAppBar.js
+++ b/src/components/layout/CyVerseAppBar.js
@@ -610,7 +610,12 @@ function CyverseAppBar(props) {
                             target="_blank"
                             rel="noopener noreferrer"
                         >
-                            <img src="/de_white.png" alt={t("cyverse")}></img>
+                            <img
+                                width={190}
+                                height={39}
+                                src="/de_white.png"
+                                alt={t("cyverse")}
+                            ></img>
                         </a>
                     </Hidden>
                     <Hidden xsDown>

--- a/src/components/layout/CyVerseAppBar.js
+++ b/src/components/layout/CyVerseAppBar.js
@@ -206,12 +206,7 @@ const useStyles = makeStyles((theme) => ({
 const BagMenu = () => {
     const classes = useStyles();
 
-    // Removing the <Hidden> causes the unit tests to fail for some strange reason.
-    return (
-        <Hidden only={[]}>
-            <Bag menuIconClass={classes.menuIcon} />
-        </Hidden>
-    );
+    return <Bag menuIconClass={classes.menuIcon} />;
 };
 
 function CyverseAppBar(props) {

--- a/src/components/layout/Notifications.js
+++ b/src/components/layout/Notifications.js
@@ -32,8 +32,8 @@ import {
     IconButton,
     Tooltip,
     Typography,
+    useTheme,
 } from "@material-ui/core";
-import { useTheme } from "@material-ui/core/styles";
 import NotificationsIcon from "@material-ui/icons/Notifications";
 
 const GotoOutputFolderButton = React.forwardRef((props, ref) => {

--- a/src/components/layout/PageWrapper.js
+++ b/src/components/layout/PageWrapper.js
@@ -6,7 +6,7 @@
  */
 
 import React from "react";
-import { makeStyles, useTheme } from "@material-ui/core/styles";
+import { makeStyles, useTheme } from "@material-ui/core";
 
 const useStyles = makeStyles((theme) => ({
     wrapper: {

--- a/src/components/uploads/dialog/index.js
+++ b/src/components/uploads/dialog/index.js
@@ -16,11 +16,11 @@ import {
     DialogTitle,
     IconButton,
     useMediaQuery,
+    useTheme,
+    makeStyles,
 } from "@material-ui/core";
 
 import { Close as CloseIcon } from "@material-ui/icons";
-
-import { useTheme, makeStyles } from "@material-ui/styles";
 
 import { getMessage, withI18N, build as buildID } from "@cyverse-de/ui-lib";
 

--- a/src/components/uploads/queue/index.js
+++ b/src/components/uploads/queue/index.js
@@ -18,6 +18,8 @@ import {
     ListItemSecondaryAction,
     ListItemText,
     useMediaQuery,
+    useTheme,
+    makeStyles,
 } from "@material-ui/core";
 
 import {
@@ -34,8 +36,6 @@ import {
     useUploadTrackingState,
     useUploadTrackingDispatch,
 } from "../../../contexts/uploadTracking";
-
-import { useTheme, makeStyles } from "@material-ui/core/styles";
 
 import { build, getMessage, withI18N } from "@cyverse-de/ui-lib";
 

--- a/src/components/utils/DEPagination.js
+++ b/src/components/utils/DEPagination.js
@@ -9,7 +9,6 @@ import { setLocalStorage } from "components/utils/localStorage";
 import constants from "../../constants";
 import NavigationConstants from "common/NavigationConstants";
 
-import { makeStyles, useTheme } from "@material-ui/core/styles";
 import Pagination from "@material-ui/lab/Pagination";
 import {
     Button,
@@ -22,6 +21,8 @@ import {
     Popper,
     Tooltip,
     useMediaQuery,
+    useTheme,
+    makeStyles,
 } from "@material-ui/core";
 import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown";
 


### PR DESCRIPTION
Basically, three (small) changes here I found as I was nosily poking around, as usual:

 * make it so `useTheme` is always imported from `@material-ui/core`. This makes a test work when an otherwise-useless `Hidden` is removed, which makes it so the Bag icon is server-side rendered. I also went through the rest of the code to import it consistently, though.
 * remove aforementioned `Hidden`
 * add a width and height to the DE logo `img`, so that there isn't a layout shift as it loads