### PR TITLE
Fix issue where logged in users still see anonymous's data roots

### DIFF
--- a/src/components/data/toolbar/Navigation.js
+++ b/src/components/data/toolbar/Navigation.js
@@ -328,6 +328,7 @@ function Navigation(props) {
     const [userProfile] = useUserProfile();
     const [config] = useConfig();
     const irodsHomePath = config?.irods?.home_path;
+    const rootsQueryKeyArray = [DATA_ROOTS_QUERY_KEY, userProfile?.id];
 
     const preProcessData = (respData) => {
         if (respData) {
@@ -373,12 +374,8 @@ function Navigation(props) {
         }
     }, [dataRoots, handlePathChange, path]);
 
-    useEffect(() => {
-        queryCache.invalidateQueries(DATA_ROOTS_QUERY_KEY);
-    }, [userProfile]);
-
     const { error } = useQuery({
-        queryKey: DATA_ROOTS_QUERY_KEY,
+        queryKey: rootsQueryKeyArray,
         queryFn: getFilesystemRoots,
         config: {
             enabled: true,
@@ -444,7 +441,7 @@ function Navigation(props) {
     };
 
     if (dataRoots.length === 0) {
-        const cacheRoots = queryCache.getQueryData(DATA_ROOTS_QUERY_KEY);
+        const cacheRoots = queryCache.getQueryData(rootsQueryKeyArray);
         if (cacheRoots) {
             preProcessData(cacheRoots);
         }

--- a/src/components/data/toolbar/Navigation.js
+++ b/src/components/data/toolbar/Navigation.js
@@ -373,6 +373,10 @@ function Navigation(props) {
         }
     }, [dataRoots, handlePathChange, path]);
 
+    useEffect(() => {
+        queryCache.invalidateQueries(DATA_ROOTS_QUERY_KEY);
+    }, [userProfile]);
+
     const { error } = useQuery({
         queryKey: DATA_ROOTS_QUERY_KEY,
         queryFn: getFilesystemRoots,


### PR DESCRIPTION
Small change.  I think having the `staleTime: Infinity, cacheTime: Infinity,` was causing this bug, so now I'm just invalidating the results whenever the userprofile changes. Still not sure why this was only happening sometimes, but it seems to happen more consistently for me now that anonymous doesn't have a home directory and is returning an error.  