### PR TITLE
Attempt to only build Chromatic CI for PRs and pushes in main repo

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,9 +1,13 @@
 name: Chromatic CI
 
-on: [push]
+on:
+  push
+  pull_request:
+    types: [synchronize]
 
 jobs:
   build:
+    if: github.repository == 'cyverse-de/sonora'
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Hopefully this will prevent Chromatic builds for pushes in fork repos, except when a PR is open against our main repo.

I'm not sure how to test this except to merge it and see what happens 🤷‍♂️ 

Also, perhaps something to consider is their warning that "The pull-request event requires special consideration": https://www.chromatic.com/docs/github-actions#recommended-configuration-for-build-events.
I'm not exactly sure if that will apply to this change, since we will still include the `push` event.