### PR TITLE
Sharing improvements.

### DIFF
--- a/public/static/locales/en/sharing.json
+++ b/public/static/locales/en/sharing.json
@@ -3,7 +3,7 @@
     "dataGroupSharingDisabled": "Data and/or analyses resources cannot be shared with groups at this time",
     "fetchPermissionsError": "Failed to fetch resource permissions",
     "fetchUserInfoError": "Failed to fetch user information",
-    "noUsersFound": "No users found",
+    "noUsersFound": "No user(s) found. Enter the full CyVerse username or email of the user you wish to share.",
     "own": "Own",
     "permission": "Permission",
     "read": "Read",


### PR DESCRIPTION
- Feedback when no matching users / group found
![image](https://user-images.githubusercontent.com/1250790/99690118-c4f66180-2a55-11eb-8904-6098c2143df9.png)
     We can provide a search field prompt label (above the search field) instead of this long feedback. 
- Custom renderer for options (group vs user)
![image](https://user-images.githubusercontent.com/1250790/99690189-dccde580-2a55-11eb-8190-3fb2cd6e65cb.png)
