### PR TITLE
Add Mark All as Seen functionality

### DIFF
--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -20,6 +20,7 @@
     "edit": "Edit",
     "email": "Email",
     "environment": "<b>E</b>nvironment",
+    "errorMarkAsSeen": "Unable to mark Notifications as seen.",
     "filter": "Filter",
     "help": "Help",
     "intercomAriaLabel": "Chat with CyVerse support",

--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -20,7 +20,7 @@
     "edit": "Edit",
     "email": "Email",
     "environment": "<b>E</b>nvironment",
-    "errorMarkAsSeen": "Unable to mark Notifications as seen.",
+    "errorMarkAsSeen": "Unable to mark notifications as read.",
     "filter": "Filter",
     "help": "Help",
     "intercomAriaLabel": "Chat with CyVerse support",

--- a/src/components/notifications/NotificationsMenu.js
+++ b/src/components/notifications/NotificationsMenu.js
@@ -7,9 +7,8 @@ import classnames from "classnames";
 import {
     getNotifications,
     markAllSeen,
-    NOTIFICATIONS_MARK_ALL_SEEN_KEY,
     NOTIFICATIONS_MESSAGES_QUERY_KEY,
-} from "serviceFacades/notifications";
+} from "../../serviceFacades/notifications";
 import { useTranslation } from "../../i18n";
 import ids from "./ids";
 import NotificationStyles from "./styles";
@@ -133,7 +132,6 @@ function NotificationsMenu(props) {
 
     const handleMarkAllAsSeenClick = () => {
         markAllSeenMutation();
-        setAllNotificationsSeen();
         handleClose();
     };
 
@@ -170,23 +168,19 @@ function NotificationsMenu(props) {
         },
     });
 
-    const [markAllSeenMutation] = useMutation({
-        queryKey: NOTIFICATIONS_MARK_ALL_SEEN_KEY,
-        queryFn: markAllSeen,
-        config: {
-            onSuccess: () => {
-                setAllNotificationsSeen();
-            },
-            onError: (error) => {
-                console.log("Error marking all notifications as Seen");
-                // *** Will add this after understanding HOC better. ***
-                // showErrorAnnouncer(
-                //     t("errorMarkAsSeen", {
-                //         count: notifications.length,
-                //     }),
-                //     error
-                // );
-            },
+    const [markAllSeenMutation] = useMutation(markAllSeen, {
+        onSuccess: () => {
+            setAllNotificationsSeen();
+        },
+        onError: (error) => {
+            console.log("Error marking all notifications as Seen");
+            // *** Will add this after understanding HOC better. ***
+            // showErrorAnnouncer(
+            //     t("errorMarkAsSeen", {
+            //         count: notifications.length,
+            //     }),
+            //     error
+            // );
         },
     });
 

--- a/src/components/notifications/NotificationsMenu.js
+++ b/src/components/notifications/NotificationsMenu.js
@@ -118,7 +118,13 @@ function InteractiveAnalysisUrl(props) {
 }
 
 function NotificationsMenu(props) {
-    const { setUnSeenCount, notificationMssg, setAnchorEl, anchorEl } = props;
+    const {
+        setUnSeenCount,
+        notificationMssg,
+        setAnchorEl,
+        anchorEl,
+        showErrorAnnouncer,
+    } = props;
     const [notifications, setNotifications] = useState([]);
     const [error, setError] = useState();
     const classes = useStyles();
@@ -173,14 +179,7 @@ function NotificationsMenu(props) {
             setAllNotificationsSeen();
         },
         onError: (error) => {
-            console.log("Error marking all notifications as Seen");
-            // *** Will add this after understanding HOC better. ***
-            // showErrorAnnouncer(
-            //     t("errorMarkAsSeen", {
-            //         count: notifications.length,
-            //     }),
-            //     error
-            // );
+            showErrorAnnouncer(t("errorMarkAsSeen"), error);
         },
     });
 

--- a/src/components/notifications/NotificationsMenu.js
+++ b/src/components/notifications/NotificationsMenu.js
@@ -18,6 +18,7 @@ import NavigationConstants from "common/NavigationConstants";
 
 import ExternalLink from "components/utils/ExternalLink";
 import ErrorTypographyWithDialog from "components/utils/error/ErrorTypographyWithDialog";
+import withErrorAnnouncer from "../utils/error/withErrorAnnouncer";
 
 import { build } from "@cyverse-de/ui-lib";
 import {
@@ -349,4 +350,4 @@ function NotificationsMenu(props) {
     );
 }
 
-export default NotificationsMenu;
+export default withErrorAnnouncer(NotificationsMenu);

--- a/src/components/notifications/NotificationsMenu.js
+++ b/src/components/notifications/NotificationsMenu.js
@@ -218,6 +218,11 @@ function NotificationsMenu(props) {
                 {isMobile && [
                     <NotificationsListingLink
                         key={ids.VIEW_ALL_NOTIFICATIONS}
+                        id={build(
+                            ids.BASE_DEBUG_ID,
+                            ids.NOTIFICATIONS_MENU,
+                            ids.VIEW_ALL_NOTIFICATIONS
+                        )}
                         handleClose={handleClose}
                         isMobile={isMobile}
                     />,
@@ -261,7 +266,11 @@ function NotificationsMenu(props) {
                 notifications.map((n, index) => (
                     <ListItem
                         onClick={handleClose}
-                        id={build(ids.BASE_DEBUG_ID, ids.NOTIFICATIONS_MENU)}
+                        id={build(
+                            ids.BASE_DEBUG_ID,
+                            ids.NOTIFICATIONS_MENU,
+                            index
+                        )}
                         key={n.message.id}
                         className={
                             !n.seen
@@ -280,7 +289,7 @@ function NotificationsMenu(props) {
                                     id={build(
                                         ids.BASE_DEBUG_ID,
                                         ids.NOTIFICATIONS_MENU,
-                                        n?.id
+                                        n?.message.id
                                     )}
                                     variant="subtitle2"
                                 >
@@ -315,6 +324,11 @@ function NotificationsMenu(props) {
                 <Divider light key="divider" />,
                 <NotificationsListingLink
                     key={ids.VIEW_ALL_NOTIFICATIONS}
+                    id={build(
+                        ids.BASE_DEBUG_ID,
+                        ids.NOTIFICATIONS_MENU,
+                        ids.VIEW_ALL_NOTIFICATIONS
+                    )}
                     handleClose={handleClose}
                     isMobile={isMobile}
                 />,

--- a/src/components/notifications/listing/TableView.js
+++ b/src/components/notifications/listing/TableView.js
@@ -247,7 +247,7 @@ const TableView = (props) => {
                                                     baseId={buildId(
                                                         baseId,
                                                         ids.MESSAGE,
-                                                        n.id
+                                                        n?.message.id
                                                     )}
                                                     notification={n}
                                                 />

--- a/src/server/api/notifications.js
+++ b/src/server/api/notifications.js
@@ -39,6 +39,19 @@ export default function notificationsRouter() {
         })
     );
 
+    logger.info("adding the POST /notifications/mark-all-seen handler");
+    api.post(
+        "/notifications/mark-all-seen",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "POST",
+            pathname: "/secured/notifications/mark-all-seen",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        })
+    );
+
     logger.info("adding the POST /notifications/delete handler");
     api.post(
         "/notifications/delete",

--- a/src/serviceFacades/notifications.js
+++ b/src/serviceFacades/notifications.js
@@ -4,6 +4,7 @@
 import callApi from "../common/callApi";
 
 const NOTIFICATIONS_MESSAGES_QUERY_KEY = "fetchNotificationsMessagesKey";
+const NOTIFICATIONS_MARK_ALL_SEEN_KEY = "markAllSeenKey";
 
 function getNotifications(key, { filter, orderBy, order, limit, offset }) {
     return callApi({
@@ -27,6 +28,13 @@ function markSeen(ids) {
     });
 }
 
+function markAllSeen() {
+    return callApi({
+        endpoint: "/api/notifications/mark-all-seen",
+        method: "POST",
+    });
+}
+
 function deleteNotifications(ids) {
     return callApi({
         endpoint: "/api/notifications/delete",
@@ -37,7 +45,9 @@ function deleteNotifications(ids) {
 
 export {
     NOTIFICATIONS_MESSAGES_QUERY_KEY,
+    NOTIFICATIONS_MARK_ALL_SEEN_KEY,
     deleteNotifications,
     getNotifications,
     markSeen,
+    markAllSeen,
 };


### PR DESCRIPTION
serviceFacades has the API function call added, notifications menu sets unSeenCount as 0 by making POST request, resets badge value and sets seen value of all notifications as true to change CSS after re-render.

I needed advice on how to get rid of es-lint error of having the unused variable isMarked from line 136. As of have a `console.log` to overcome it. So it will need changing before merge. 