### PR TITLE
Fix errors for logged out users viewing Data

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,6 +17,7 @@ module.exports = withBundleAnalyzer({
         ANALYSIS_SUPPORT_USER: config.get("analysis.support.user"),
         ANALYSIS_SUPPORT_SOURCE_ID: config.get("analysis.support.source_id"),
         IRODS_HOME_PATH: config.get("irods.home_path"),
+        IRODS_TRASH_PATH: config.get("irods.trash_path"),
         SESSION_POLL_INTERVAL_MS: config.has("sessions.poll_interval_ms")
             ? config.get("sessions.poll_interval_ms")
             : 5000,

--- a/src/components/data/toolbar/Navigation.js
+++ b/src/components/data/toolbar/Navigation.js
@@ -328,7 +328,13 @@ function Navigation(props) {
     const [userProfile] = useUserProfile();
     const [config] = useConfig();
     const irodsHomePath = config?.irods?.home_path;
-    const rootsQueryKeyArray = [DATA_ROOTS_QUERY_KEY, userProfile?.id];
+    const irodsTrashPath = config?.irods?.trash_path;
+    const [rootsQueryKeyArray, setRootsQueryKeyArray] = useState([
+        DATA_ROOTS_QUERY_KEY,
+        userProfile?.id,
+        irodsHomePath,
+        irodsTrashPath,
+    ]);
 
     const preProcessData = (respData) => {
         if (respData) {
@@ -373,6 +379,15 @@ function Navigation(props) {
             handlePathChange(dataRoots[0].path);
         }
     }, [dataRoots, handlePathChange, path]);
+
+    useEffect(() => {
+        setRootsQueryKeyArray([
+            DATA_ROOTS_QUERY_KEY,
+            userProfile?.id,
+            irodsHomePath,
+            irodsTrashPath,
+        ]);
+    }, [userProfile, irodsHomePath, irodsTrashPath]);
 
     const { error } = useQuery({
         queryKey: rootsQueryKeyArray,

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -148,6 +148,7 @@ function MyApp({ Component, pageProps }) {
         };
         const irods = {
             home_path: publicRuntimeConfig.IRODS_HOME_PATH,
+            trash_path: publicRuntimeConfig.IRODS_TRASH_PATH,
         };
         const sessions = {
             poll_interval_ms: publicRuntimeConfig.SESSION_POLL_INTERVAL_MS,

--- a/src/server/api/data.js
+++ b/src/server/api/data.js
@@ -44,7 +44,7 @@ export default function dataRouter() {
     api.get(
         "/filesystem/root",
         auth.authnTokenMiddleware,
-        terrainHandler({ method: "GET", pathname: "/filesystem/root" })
+        terrainHandler({ method: "GET", pathname: "/secured/filesystem/root" })
     );
 
     logger.info(

--- a/src/serviceFacades/filesystem.js
+++ b/src/serviceFacades/filesystem.js
@@ -1,6 +1,7 @@
 import callApi from "../common/callApi";
 import { getDataSimpleSearchQuery } from "components/search/dataSearchQueryBuilder";
 import viewerConstants from "components/data/viewers/constants";
+import constants from "constants.js";
 export const DATA_LISTING_QUERY_KEY = "fetchDataListing";
 export const USER_INFO_QUERY_KEY = "fetchUserInfo";
 export const RESOURCE_PERMISSIONS_KEY = "fetchResourcePermissions";
@@ -88,10 +89,36 @@ export const getPagedListing = (
  * Get the list of directory roots available to a user
  * @returns {Promise<any>}
  */
-export const getFilesystemRoots = () => {
-    return callApi({
-        endpoint: `/api/filesystem/root`,
-    });
+export const getFilesystemRoots = (key, userId, homePath, trashPath) => {
+    return userId
+        ? callApi({
+              endpoint: `/api/filesystem/root`,
+          })
+        : Promise.resolve({
+              roots: [
+                  {
+                      path: `${homePath}/${constants.ANONYMOUS_USER}`,
+                      label: constants.ANONYMOUS_USER,
+                  },
+                  {
+                      path: `${homePath}/shared`,
+                      label: constants.COMMUNITY_DATA,
+                  },
+                  {
+                      path: homePath,
+                      label: constants.SHARED_WITH_ME,
+                  },
+                  {
+                      path: `${trashPath}/${constants.ANONYMOUS_USER}`,
+                      label: constants.TRASH,
+                  },
+              ],
+              "base-paths": {
+                  user_home_path: `${homePath}/${constants.ANONYMOUS_USER}`,
+                  user_trash_path: `${trashPath}/${constants.ANONYMOUS_USER}`,
+                  base_trash_path: trashPath,
+              },
+          });
 };
 
 /**


### PR DESCRIPTION
NOTE: Depends on change from https://github.com/cyverse-de/terrain/pull/180

As discussed in Slack, we're moving towards not hitting the data roots endpoint anymore and having Sonora create the roots for the anonymous user.

Since the QA env is down, I went ahead and tested this directly against prod.