### PR TITLE
Allow logged out users to view public data details

### DIFF
--- a/public/static/locales/en/data.json
+++ b/public/static/locales/en/data.json
@@ -99,6 +99,7 @@
     "suggestionSelection_any_plural": "Select resources",
     "tableView": "Table View",
     "tags": "Tags",
+    "tagsSignInError": "Tags available after signing in",
     "type": "Type",
     "updateInfoTypeError": "Unable to update info type. Please try again.",
     "uploadQueue": "View Upload Queue",

--- a/src/components/data/TagSearch.js
+++ b/src/components/data/TagSearch.js
@@ -33,6 +33,7 @@ import styles from "./styles";
 import isQueryLoading from "../utils/isQueryLoading";
 import DEErrorDialog from "../utils/error/DEErrorDialog";
 import ErrorTypography from "../utils/error/ErrorTypography";
+import { useUserProfile } from "contexts/userProfile";
 
 const useStyles = makeStyles(styles);
 
@@ -50,6 +51,7 @@ function TagSearch(props) {
     const [errorMessage, setErrorMessage] = useState(null);
     const [errorDialogOpen, setErrorDialogOpen] = useState(false);
     const [errorObject, setErrorObject] = useState(null);
+    const [userProfile] = useUserProfile();
 
     const { isFetching: isFetchingTags } = useQuery({
         queryKey: fetchTagsQueryKey,
@@ -67,6 +69,7 @@ function TagSearch(props) {
         queryKey: { searchTerm },
         queryFn: getTagSuggestions,
         config: {
+            enabled: userProfile?.id,
             onSuccess: (resp) => {
                 setOptions(resp.tags);
             },

--- a/src/components/data/TagSearch.js
+++ b/src/components/data/TagSearch.js
@@ -60,7 +60,12 @@ function TagSearch(props) {
             onSuccess: (resp) => setSelectedTags(resp.tags),
             onError: (e) => {
                 setErrorObject(e);
-                setErrorMessage(t("fetchTagSuggestionsError"));
+                const status = e?.response?.status;
+                setErrorMessage(
+                    status === 401
+                        ? t("tagsSignInError")
+                        : t("fetchTagSuggestionsError")
+                );
             },
         },
     });

--- a/src/components/data/details/PermissionsPanel.js
+++ b/src/components/data/details/PermissionsPanel.js
@@ -267,7 +267,7 @@ function PermissionsTabPanel(props) {
             <Typography id={build(baseId, ids.SELF_PERMISSION)}>
                 {t("selfPermission", { permission: selfPermission })}
             </Typography>
-            {fetchResourcePermissionsKey && (
+            {selfPermission === Permissions.OWN && (
                 <List
                     className={classes.permissionsList}
                     id={build(baseId, ids.PERMISSION_LIST)}

--- a/src/server/api/data.js
+++ b/src/server/api/data.js
@@ -33,7 +33,7 @@ export default function dataRouter() {
         auth.authnTokenMiddleware,
         terrainHandler({
             method: "POST",
-            pathname: "/secured/filesystem/stat",
+            pathname: "/filesystem/stat",
             headers: {
                 "Content-Type": "application/json",
             },


### PR DESCRIPTION
NOTE: Requires https://github.com/cyverse-de/terrain/pull/182 to be merged first

Now users should be able to view the data details drawer within Community Data without logging in.  Since we don't have/support public tags, I effectively disabled that feature if no user is logged in and updated the error message to indicate that you need to be signed in to use it.

I also hid the `read`, `write`, and `own` labels in the Permissions panel since those really should only show up for users with `own` permission anyway. Showing `own (0), write (0), and read (0)` without this change was a bit misleading otherwise.

![image](https://user-images.githubusercontent.com/8909156/100027114-57299d00-2da9-11eb-92a9-3b4bded60fef.png)

![image](https://user-images.githubusercontent.com/8909156/100027125-5e50ab00-2da9-11eb-8ff6-8c5bcba884b6.png)
