### PR TITLE
Enable compression for routes mapped by the custom express server

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "bowser": "^2.9.0",
         "camelcase": "^5.3.1",
         "clsx": "^1.1.0",
+        "compression": "^1.7.4",
         "config": "^3.3.1",
         "connect-pg-simple": "^6.1.0",
         "dataloader": "^2.0.0",

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -23,6 +23,8 @@ import viceRouter from "./api/vice";
 import * as authn from "./auth";
 import * as config from "./configuration";
 
+import compression from "compression";
+
 import logger, { errorLogger, requestLogger } from "./logging";
 
 import NavigationConstants from "../common/NavigationConstants";
@@ -108,6 +110,7 @@ app.prepare()
         logger.info(
             "$$$$$$$$ adding the api router to the express server $$$$$$$$$"
         );
+        server.use("/api", compression());
         server.use("/api", appsRouter());
         server.use("/api", analysesRouter());
         server.use("/api", bagsRouter());
@@ -132,6 +135,7 @@ app.prepare()
         );
 
         logger.info("mapping / to /dashboard in the app");
+        server.use("/", compression());
         server.get("/", (req, res) => {
             app.render(req, res, "/dashboard", undefined);
         });


### PR DESCRIPTION
From lighthouse testing, it says there's savings to be made by doing this:

URL | Transfer Size | Potential Savings
-- | -- | --
https://sonora-qa.cyverse.org | 44 KB | 33.2 KB
/api/dashboard?limit=8(sonora-qa.cyverse.org) | 34.5 KB | 26.9 KB

next.js already supports compression, but doesn't do it for places where we're circumventing it, which includes both `/` and all the `/api` endpoints. So, this imports the same module that nextjs uses, and applies it to those endpoints. At some point, we'll probably put nginx in front of sonora, at which point we can either set this to be configurable (along with the nextjs default compression) or remove it outright. But for now, this will produce a small performance benefit.
