### PR TITLE
CORE-1165 Integrate Metadata listing in data/ds/item page

### DIFF
--- a/src/common/NavigationConstants.js
+++ b/src/common/NavigationConstants.js
@@ -1,4 +1,7 @@
-// constants that define navigation routes
+/**
+ * Constants that define navigation routes.
+ * Warning: server/index.js expects each value to be a string.
+ */
 export default {
     ADMIN: "admin",
     ANALYSES: "analyses",
@@ -16,7 +19,13 @@ export default {
     RELAUNCH: "relaunch",
     SEARCH: "search",
     SETTINGS: "settings",
-    VICE: "vice",
     TOOLS: "tools",
+    VICE: "vice",
     YOUTUBE_EMBED_BASE: "https://youtu.be",
+};
+
+export const NavigationParams = {
+    // This could be updated with more options in the future,
+    // such as CONTENTS, DETAILS, or LISTING.
+    VIEW: { METADATA: "metadata" },
 };

--- a/src/components/apps/launch/AppInfo.js
+++ b/src/components/apps/launch/AppInfo.js
@@ -6,7 +6,6 @@
 import React from "react";
 import { useTranslation } from "i18n";
 import { Trans } from "react-i18next";
-import { useRouter } from "next/router";
 
 import styles from "./styles";
 
@@ -14,6 +13,8 @@ import { intercomShow } from "common/intercom";
 
 import AppDoc from "components/apps/details/AppDoc";
 import DetailsDrawer from "components/apps/details/Drawer";
+
+import BackButton from "components/utils/BackButton";
 import DEErrorDialog from "components/utils/error/DEErrorDialog";
 import ErrorTypography from "components/utils/error/ErrorTypography";
 
@@ -32,7 +33,7 @@ import {
     useTheme,
 } from "@material-ui/core";
 
-import { ArrowBack, Info, MenuBook } from "@material-ui/icons";
+import { Info, MenuBook } from "@material-ui/icons";
 
 import { Skeleton } from "@material-ui/lab";
 
@@ -58,6 +59,7 @@ const LoadingErrorDisplay = ({ baseId, loadingError }) => {
         </>
     );
 };
+
 const UnavailableMsg = ({ app, hasDeprecatedParams, baseId }) => {
     let message = "";
     const { t } = useTranslation("launch");
@@ -109,30 +111,23 @@ const UnavailableMsg = ({ app, hasDeprecatedParams, baseId }) => {
         </Typography>
     );
 };
+
 const AppInfo = React.forwardRef((props, ref) => {
     const { app, baseId, hasDeprecatedParams, loading, loadingError } = props;
-    const { t } = useTranslation("common");
-    const { t: i18nApps } = useTranslation("apps");
-    const router = useRouter();
+    const { t } = useTranslation("apps");
     const classes = useStyles();
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down("xs"));
     const [detailsDrawerOpen, setDetailsDrawerOpen] = React.useState(false);
     const [docDialogOpen, setDocDialogOpen] = React.useState(false);
+
     return (
         <div ref={ref}>
-            <Button
-                color="primary"
-                variant={isMobile ? "text" : "contained"}
-                size="small"
+            <BackButton
                 style={{
                     margin: isMobile ? theme.spacing(0) : theme.spacing(0.5),
                 }}
-                startIcon={<ArrowBack fontSize="small" />}
-                onClick={() => router.back()}
-            >
-                <Hidden xsDown>{t("back")}</Hidden>
-            </Button>
+            />
             <Button
                 id={buildDebugId(baseId, ids.BUTTONS.DETAILS)}
                 className={classes.detailsButton}
@@ -141,7 +136,7 @@ const AppInfo = React.forwardRef((props, ref) => {
                 size="small"
                 startIcon={<Info color="primary" fontSize="small" />}
             >
-                <Hidden xsDown>{i18nApps("details")}</Hidden>
+                <Hidden xsDown>{t("details")}</Hidden>
             </Button>
             <Button
                 id={buildDebugId(baseId, ids.BUTTONS.DOCUMENTATION)}
@@ -151,7 +146,7 @@ const AppInfo = React.forwardRef((props, ref) => {
                 size="small"
                 startIcon={<MenuBook color="primary" fontSize="small" />}
             >
-                <Hidden xsDown>{i18nApps("documentation")}</Hidden>
+                <Hidden xsDown>{t("documentation")}</Hidden>
             </Button>
             <Typography
                 variant={isMobile ? "subtitle2" : "h6"}

--- a/src/components/data/ids.js
+++ b/src/components/data/ids.js
@@ -24,6 +24,7 @@ export default {
     DELETE: "delete",
     DELETE_BTN: "deleteButton",
     DELETE_MENU_ITEM: "delete",
+    DELETE_MENU_ITEM_DIVIDER: "deleteMenuItemDivider",
     DETAILS_MENU_ITEM: "details",
     DETAILS_MENU_ITEM_DIVIDER: "detailsDivider",
     DETAILS_BTN: "detailsBtn",

--- a/src/components/data/ids.js
+++ b/src/components/data/ids.js
@@ -41,7 +41,7 @@ export default {
     LISTING_TABLE: "listingTable",
     LOADING_SKELETON: "loadingSkeleton",
     MANUAL_UPLOAD_MI: "manualUploadMenuItem",
-    metadataMI: "metadata",
+    METADATA_MI: "metadata",
     navLink: "navigationLink",
     OK_BTN: "okBtn",
     OWN: "own",

--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -420,9 +420,23 @@ function Listing(props) {
     );
 
     const onPathChange = (path, resourceType, id, view) => {
-        //set page to 0 for the new path
-        const queryParams = getPageQueryParams(order, orderBy, 0, rowsPerPage);
-        handlePathChange(path, queryParams, resourceType, id, view);
+        if (view === NavigationParams.VIEW.METADATA) {
+            handlePathChange(path, { view });
+        } else if (!resourceType || resourceType === ResourceTypes.FOLDER) {
+            //set page to 0 for the new path
+            const queryParams = getPageQueryParams(
+                order,
+                orderBy,
+                0,
+                rowsPerPage
+            );
+            handlePathChange(path, queryParams);
+        } else {
+            handlePathChange(path, {
+                type: resourceType,
+                resourceId: id,
+            });
+        }
     };
 
     const isLoading = isQueryLoading([isFetching, removeResourceStatus]);

--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -15,6 +15,9 @@ import Drawer from "../details/Drawer";
 import FileBrowser from "../toolbar/FileBrowser";
 import DataToolbar from "../toolbar/Toolbar";
 
+import { camelcaseit } from "common/functions";
+import { NavigationParams } from "common/NavigationConstants";
+
 import DEPagination from "components/utils/DEPagination";
 import ResourceTypes from "components/models/ResourceTypes";
 import isQueryLoading from "components/utils/isQueryLoading";
@@ -25,7 +28,6 @@ import {
     trackUpload,
 } from "components/uploads/UploadDrop";
 import UploadDropTarget from "components/uploads/UploadDropTarget";
-import { camelcaseit } from "common/functions";
 import withErrorAnnouncer from "components/utils/error/withErrorAnnouncer";
 import Sharing from "components/sharing";
 import { formatSharedData } from "components/sharing/util";
@@ -333,7 +335,16 @@ function Listing(props) {
     };
 
     const onMetadataSelected = (resourceId) => {
-        console.log("Metadata", resourceId);
+        const resources = getSelectedResources([resourceId]);
+        if (resources) {
+            const resource = resources[0];
+            onPathChange(
+                resource.path,
+                resource.type,
+                resourceId,
+                NavigationParams.VIEW.METADATA
+            );
+        }
     };
 
     const onDeleteSelected = (resourceId) => {
@@ -408,10 +419,10 @@ function Listing(props) {
         [setNavError]
     );
 
-    const onPathChange = (path, resourceType, id) => {
+    const onPathChange = (path, resourceType, id, view) => {
         //set page to 0 for the new path
         const queryParams = getPageQueryParams(order, orderBy, 0, rowsPerPage);
-        handlePathChange(path, queryParams, resourceType, id);
+        handlePathChange(path, queryParams, resourceType, id, view);
     };
 
     const isLoading = isQueryLoading([isFetching, removeResourceStatus]);

--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -468,6 +468,7 @@ function Listing(props) {
                         orderBy={orderBy}
                         selected={selected}
                         setSharingDlgOpen={setSharingDlgOpen}
+                        onMetadataSelected={onMetadataSelected}
                         onPublicLinksSelected={() =>
                             setPublicLinksDlgOpen(true)
                         }

--- a/src/components/data/listing/RowDotMenu.js
+++ b/src/components/data/listing/RowDotMenu.js
@@ -9,6 +9,7 @@ import React from "react";
 import { DotMenu } from "@cyverse-de/ui-lib";
 import DetailsMenuItem from "../menuItems/DetailsMenuItem";
 import DeleteMenuItem from "../menuItems/DeleteMenuItem";
+import MetadataMenuItem from "../menuItems/MetadataMenuItem";
 import SharingMenuItem from "../../sharing/SharingMenuItem";
 import { hasOwn, containsFolders } from "../utils";
 import ids from "../ids";
@@ -24,6 +25,7 @@ function RowDotMenu(props) {
         onDetailsSelected,
         resource,
         setSharingDlgOpen,
+        onMetadataSelected,
         onPublicLinksSelected,
     } = props;
 
@@ -39,6 +41,13 @@ function RowDotMenu(props) {
                     baseId={baseId}
                     onClose={onClose}
                     onDetailsSelected={onDetailsSelected}
+                />,
+                <MetadataMenuItem
+                    key={ids.METADATA_MI}
+                    baseId={baseId}
+                    resourceId={resource.id}
+                    onClose={onClose}
+                    onMetadataSelected={onMetadataSelected}
                 />,
                 isOwner && (
                     <DeleteMenuItem

--- a/src/components/data/listing/RowDotMenu.js
+++ b/src/components/data/listing/RowDotMenu.js
@@ -50,14 +50,6 @@ function RowDotMenu(props) {
                     onMetadataSelected={onMetadataSelected}
                 />,
                 isOwner && (
-                    <DeleteMenuItem
-                        key={build(baseId, ids.DELETE_MENU_ITEM)}
-                        baseId={baseId}
-                        onClose={onClose}
-                        onDeleteSelected={onDeleteSelected}
-                    />
-                ),
-                isOwner && (
                     <SharingMenuItem
                         key={build(baseId, shareIds.SHARING_MENU_ITEM)}
                         baseId={baseId}
@@ -71,6 +63,14 @@ function RowDotMenu(props) {
                         baseId={baseId}
                         onClose={onClose}
                         onPublicLinksSelected={onPublicLinksSelected}
+                    />
+                ),
+                isOwner && (
+                    <DeleteMenuItem
+                        key={build(baseId, ids.DELETE_MENU_ITEM)}
+                        baseId={baseId}
+                        onClose={onClose}
+                        onDeleteSelected={onDeleteSelected}
                     />
                 ),
             ]}

--- a/src/components/data/listing/TableView.js
+++ b/src/components/data/listing/TableView.js
@@ -125,6 +125,7 @@ function TableView(props) {
         orderBy,
         selected,
         setSharingDlgOpen,
+        onMetadataSelected,
         onPublicLinksSelected,
     } = props;
     const invalidRowClass = invalidRowStyles();
@@ -386,6 +387,9 @@ function TableView(props) {
                                                 resource={resource}
                                                 setSharingDlgOpen={
                                                     setSharingDlgOpen
+                                                }
+                                                onMetadataSelected={
+                                                    onMetadataSelected
                                                 }
                                                 onPublicLinksSelected={
                                                     onPublicLinksSelected

--- a/src/components/data/menuItems/MetadataMenuItem.js
+++ b/src/components/data/menuItems/MetadataMenuItem.js
@@ -1,0 +1,35 @@
+/**
+ * @author psarando
+ */
+import React from "react";
+
+import { useTranslation } from "i18n";
+
+import ids from "../ids";
+
+import { build } from "@cyverse-de/ui-lib";
+
+import { ListItemIcon, ListItemText, MenuItem } from "@material-ui/core";
+import { List as MetadataIcon } from "@material-ui/icons";
+
+function MetadataMenuItem(props) {
+    const { baseId, resourceId, onClose, onMetadataSelected } = props;
+    const { t } = useTranslation("data");
+
+    return (
+        <MenuItem
+            id={build(baseId, ids.METADATA_MI)}
+            onClick={() => {
+                onClose();
+                onMetadataSelected(resourceId);
+            }}
+        >
+            <ListItemIcon>
+                <MetadataIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText primary={t("metadata")} />
+        </MenuItem>
+    );
+}
+
+export default MetadataMenuItem;

--- a/src/components/data/toolbar/DataDotMenu.js
+++ b/src/components/data/toolbar/DataDotMenu.js
@@ -17,6 +17,7 @@ import UploadMenuItems from "./UploadMenuItems";
 import { useTranslation } from "i18n";
 import DetailsMenuItem from "../menuItems/DetailsMenuItem";
 import DeleteMenuItem from "../menuItems/DeleteMenuItem";
+import MetadataMenuItem from "../menuItems/MetadataMenuItem";
 import SharingMenuItem from "components/sharing/SharingMenuItem";
 import PublicLinksMenuItem from "../menuItems/PublicLinksMenuItem";
 import PathListAutomation from "../PathListAutomation";
@@ -66,6 +67,7 @@ function DataDotMenu(props) {
         canShare,
         setSharingDlgOpen,
         isSmall,
+        onMetadataSelected,
         onPublicLinksSelected,
     } = props;
 
@@ -83,6 +85,8 @@ function DataDotMenu(props) {
         ? getSelectedResources()
         : null;
     const deleteMiEnabled = !isSelectionEmpty && isOwner(selectedResources);
+    const metadataMiEnabled = selected?.length === 1;
+
     const router = useRouter();
     const routeToFile = (id, path) => {
         router.push(
@@ -186,6 +190,15 @@ function DataDotMenu(props) {
                                   onDeleteSelected={onDeleteSelected}
                               />
                           ),
+                    metadataMiEnabled && (
+                        <MetadataMenuItem
+                            key={ids.METADATA_MI}
+                            baseId={baseId}
+                            resourceId={selected[0]}
+                            onClose={onClose}
+                            onMetadataSelected={onMetadataSelected}
+                        />
+                    ),
                     isWritable(permission) && [
                         <MenuItem
                             key={build(baseId, ids.CREATE_HT_FILE_MI)}

--- a/src/components/data/toolbar/DataDotMenu.js
+++ b/src/components/data/toolbar/DataDotMenu.js
@@ -151,20 +151,16 @@ function DataDotMenu(props) {
                                       setSharingDlgOpen={setSharingDlgOpen}
                                   />
                               ),
-                              deleteMiEnabled && (
-                                  <DeleteMenuItem
-                                      key={build(baseId, ids.DELETE_MENU_ITEM)}
+                              metadataMiEnabled && (
+                                  <MetadataMenuItem
+                                      key={ids.METADATA_MI}
                                       baseId={baseId}
+                                      resourceId={selected[0]}
                                       onClose={onClose}
-                                      onDeleteSelected={onDeleteSelected}
+                                      onMetadataSelected={onMetadataSelected}
                                   />
                               ),
-                              <Divider
-                                  key={build(
-                                      baseId,
-                                      ids.UPLOAD_MENU_ITEM_DIVIDER
-                                  )}
-                              />,
+                              <Divider key={ids.UPLOAD_MENU_ITEM_DIVIDER} />,
                               isWritable(permission) && (
                                   <UploadMenuItems
                                       key={build(baseId, ids.UPLOAD_MENU_ITEM)}
@@ -182,23 +178,15 @@ function DataDotMenu(props) {
                                   />
                               ),
                           ]
-                        : deleteMiEnabled && (
-                              <DeleteMenuItem
-                                  key={build(baseId, ids.DELETE_MENU_ITEM)}
+                        : metadataMiEnabled && (
+                              <MetadataMenuItem
+                                  key={ids.METADATA_MI}
                                   baseId={baseId}
+                                  resourceId={selected[0]}
                                   onClose={onClose}
-                                  onDeleteSelected={onDeleteSelected}
+                                  onMetadataSelected={onMetadataSelected}
                               />
                           ),
-                    metadataMiEnabled && (
-                        <MetadataMenuItem
-                            key={ids.METADATA_MI}
-                            baseId={baseId}
-                            resourceId={selected[0]}
-                            onClose={onClose}
-                            onMetadataSelected={onMetadataSelected}
-                        />
-                    ),
                     isWritable(permission) && [
                         <MenuItem
                             key={build(baseId, ids.CREATE_HT_FILE_MI)}
@@ -272,6 +260,15 @@ function DataDotMenu(props) {
                                 onClose={onClose}
                             />
                         ),
+                    <Divider key={ids.DELETE_MENU_ITEM_DIVIDER} />,
+                    deleteMiEnabled && (
+                        <DeleteMenuItem
+                            key={ids.DELETE_MENU_ITEM}
+                            baseId={baseId}
+                            onClose={onClose}
+                            onDeleteSelected={onDeleteSelected}
+                        />
+                    ),
                 ]}
             />
             <CreateFolderDialog

--- a/src/components/data/toolbar/Toolbar.js
+++ b/src/components/data/toolbar/Toolbar.js
@@ -74,7 +74,7 @@ function DataToolbar(props) {
     const theme = useTheme();
     const isSmall = useMediaQuery(theme.breakpoints.down("sm"));
     const hasDotMenu =
-        (isSmall && selectedResources && selectedResources.length > 0) ||
+        (selectedResources && selectedResources.length > 0) ||
         isWritable(permission);
 
     let toolbarId = build(baseId, ids.TOOLBAR);

--- a/src/components/data/toolbar/Toolbar.js
+++ b/src/components/data/toolbar/Toolbar.js
@@ -61,6 +61,7 @@ function DataToolbar(props) {
         onCreateHTFileSelected,
         onCreateMultiInputFileSelected,
         setSharingDlgOpen,
+        onMetadataSelected,
         onPublicLinksSelected,
     } = props;
 
@@ -170,6 +171,7 @@ function DataToolbar(props) {
                     canShare={canShare}
                     setSharingDlgOpen={setSharingDlgOpen}
                     isSmall={isSmall}
+                    onMetadataSelected={onMetadataSelected}
                     onPublicLinksSelected={onPublicLinksSelected}
                 />
             )}

--- a/src/components/data/utils.js
+++ b/src/components/data/utils.js
@@ -128,7 +128,13 @@ const getPageQueryParams = (order, orderBy, page, rowsPerPage) => {
     const selectedPage = page || DEFAULT_PAGE_SETTINGS.page;
     const selectedRowsPerPage =
         rowsPerPage || DEFAULT_PAGE_SETTINGS.rowsPerPage;
-    return `selectedOrder=${selectedOrder}&selectedOrderBy=${selectedOrderBy}&selectedPage=${selectedPage}&selectedRowsPerPage=${selectedRowsPerPage}`;
+
+    return {
+        selectedOrder,
+        selectedOrderBy,
+        selectedPage,
+        selectedRowsPerPage,
+    };
 };
 
 const containsFolders = (resources) => {

--- a/src/components/data/viewers/DocumentViewer.js
+++ b/src/components/data/viewers/DocumentViewer.js
@@ -16,7 +16,14 @@ import { build } from "@cyverse-de/ui-lib";
 import { Typography } from "@material-ui/core";
 
 export default function DocumentViewer(props) {
-    const { baseId, path, resourceId, onRefresh, fileName } = props;
+    const {
+        baseId,
+        path,
+        resourceId,
+        handlePathChange,
+        onRefresh,
+        fileName,
+    } = props;
     const { t } = useTranslation("data");
     useEffect(() => {
         window.open(
@@ -32,6 +39,7 @@ export default function DocumentViewer(props) {
                 path={path}
                 resourceId={resourceId}
                 allowLineNumbers={false}
+                handlePathChange={handlePathChange}
                 onRefresh={onRefresh}
                 fileName={fileName}
             />

--- a/src/components/data/viewers/FileViewer.js
+++ b/src/components/data/viewers/FileViewer.js
@@ -58,7 +58,14 @@ const VIEWER_TYPE = {
 };
 
 export default function FileViewer(props) {
-    const { path, resourceId, createFile, onNewFileSaved, baseId } = props;
+    const {
+        path,
+        resourceId,
+        createFile,
+        handlePathChange,
+        onNewFileSaved,
+        baseId,
+    } = props;
 
     const { t } = useTranslation("data");
     const router = useRouter();
@@ -290,6 +297,7 @@ export default function FileViewer(props) {
                     data={flatData}
                     mode={mode}
                     loading={isFetchingMore}
+                    handlePathChange={handlePathChange}
                     onRefresh={() => refreshViewer(manifestKey)}
                 />
                 <LoadMoreButton />
@@ -305,6 +313,7 @@ export default function FileViewer(props) {
                     resourceId={resourceId}
                     data={flattenStructureData(memoizedData)}
                     loading={isFetchingMore}
+                    handlePathChange={handlePathChange}
                     onRefresh={() => refreshViewer(manifestKey)}
                 />
                 <LoadMoreButton />
@@ -316,6 +325,7 @@ export default function FileViewer(props) {
                 baseId={baseId}
                 path={path}
                 fileName={fileName}
+                handlePathChange={handlePathChange}
                 onRefresh={() => refreshViewer(manifestKey)}
             />
         );
@@ -325,6 +335,7 @@ export default function FileViewer(props) {
                 baseId={baseId}
                 path={path}
                 fileName={fileName}
+                handlePathChange={handlePathChange}
                 onRefresh={() => refreshViewer(manifestKey)}
             />
         );
@@ -334,6 +345,7 @@ export default function FileViewer(props) {
                 baseId={baseId}
                 path={path}
                 fileName={fileName}
+                handlePathChange={handlePathChange}
                 onRefresh={() => refreshViewer(manifestKey)}
             />
         );
@@ -359,6 +371,7 @@ export default function FileViewer(props) {
                     data={dataToView}
                     loading={isFetchingMore}
                     separator={separator}
+                    handlePathChange={handlePathChange}
                     onRefresh={() => refreshViewer(manifestKey)}
                     onNewFileSaved={onNewFileSaved}
                 />

--- a/src/components/data/viewers/ImageViewer.js
+++ b/src/components/data/viewers/ImageViewer.js
@@ -18,7 +18,14 @@ import { build } from "@cyverse-de/ui-lib";
 import { Typography } from "@material-ui/core";
 
 export default function ImageViewer(props) {
-    const { baseId, path, resourceId, onRefresh, fileName } = props;
+    const {
+        baseId,
+        path,
+        resourceId,
+        handlePathChange,
+        onRefresh,
+        fileName,
+    } = props;
     const { t } = useTranslation("data");
     const [url, setUrl] = useState("");
 
@@ -34,6 +41,7 @@ export default function ImageViewer(props) {
                     path={path}
                     resourceId={resourceId}
                     allowLineNumbers={false}
+                    handlePathChange={handlePathChange}
                     onRefresh={onRefresh}
                     fileName={fileName}
                 />

--- a/src/components/data/viewers/PathListViewer.js
+++ b/src/components/data/viewers/PathListViewer.js
@@ -70,6 +70,7 @@ function PathListViewer(props) {
         loading,
         showErrorAnnouncer,
         createFile,
+        handlePathChange,
         onRefresh,
         onNewFileSaved,
         fileName,
@@ -263,6 +264,7 @@ function PathListViewer(props) {
                 }}
                 dirty={dirty}
                 selectionCount={Object.keys(selectedRowIds).length}
+                handlePathChange={handlePathChange}
                 onRefresh={onRefresh}
                 fileName={fileName}
                 createFile={createFile}

--- a/src/components/data/viewers/StructuredTextViewer.js
+++ b/src/components/data/viewers/StructuredTextViewer.js
@@ -33,6 +33,7 @@ export default function StructuredTextViewer(props) {
         resourceId,
         data,
         loading,
+        handlePathChange,
         onRefresh,
         fileName,
     } = props;
@@ -87,6 +88,7 @@ export default function StructuredTextViewer(props) {
                 }}
                 firstRowHeader={firstRowHeader}
                 onFirstRowHeader={(header) => setFirstRowHeader(header)}
+                handlePathChange={handlePathChange}
                 onRefresh={onRefresh}
                 fileName={fileName}
             />

--- a/src/components/data/viewers/TextViewer.js
+++ b/src/components/data/viewers/TextViewer.js
@@ -25,6 +25,7 @@ export default function TextViewer(props) {
         data,
         loading,
         mode,
+        handlePathChange,
         onRefresh,
         fileName,
     } = props;
@@ -42,6 +43,7 @@ export default function TextViewer(props) {
                 allowLineNumbers={true}
                 showLineNumbers={showLineNumbers}
                 onShowLineNumbers={(show) => setShowLineNumbers(show)}
+                handlePathChange={handlePathChange}
                 onRefresh={onRefresh}
                 fileName={fileName}
             />

--- a/src/components/data/viewers/Toolbar.js
+++ b/src/components/data/viewers/Toolbar.js
@@ -136,13 +136,7 @@ function ViewerToolbar(props) {
         });
 
     const onViewMetadata = () =>
-        handlePathChange(
-            path,
-            null,
-            ResourceTypes.FILE,
-            resourceId,
-            NavigationParams.VIEW.METADATA
-        );
+        handlePathChange(path, { view: NavigationParams.VIEW.METADATA });
 
     return (
         <>

--- a/src/components/data/viewers/Toolbar.js
+++ b/src/components/data/viewers/Toolbar.js
@@ -7,17 +7,18 @@
  */
 import React, { useEffect, useState } from "react";
 
-import { useRouter } from "next/router";
-
 import { queryCache, useQuery } from "react-query";
 import { useTranslation } from "i18n";
+import { NavigationParams } from "common/NavigationConstants";
 
-import { getHost } from "../../utils/getHost";
 import ids from "./ids";
 
 import { getInfoTypes, INFO_TYPES_QUERY_KEY } from "serviceFacades/filesystem";
 import DetailsDrawer from "components/data/details/Drawer";
 import ResourceTypes from "components/models/ResourceTypes";
+
+import BackButton from "components/utils/BackButton";
+import { getHost } from "components/utils/getHost";
 import withErrorAnnouncer from "components/utils/error/withErrorAnnouncer";
 
 import { build, DotMenu } from "@cyverse-de/ui-lib";
@@ -33,16 +34,14 @@ import {
     ListItemIcon,
     ListItemText,
     MenuItem,
-    useTheme,
-    useMediaQuery,
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import {
     Add,
-    ArrowBack,
     CloudDownload,
     Delete,
     Info,
+    List as MetadataIcon,
     Refresh,
     Save,
 } from "@material-ui/icons";
@@ -81,16 +80,13 @@ function ViewerToolbar(props) {
         selectionCount,
         dirty,
         onRefresh,
+        handlePathChange,
         fileName,
         createFile,
     } = props;
 
     const { t } = useTranslation("data");
     const { t: i18nCommon } = useTranslation("common");
-    const router = useRouter();
-
-    const theme = useTheme();
-    const isMobile = useMediaQuery(theme.breakpoints.down("xs"));
 
     const [detailsResource, setDetailsResource] = useState(null);
     const [infoTypes, setInfoTypes] = useState([]);
@@ -131,18 +127,27 @@ function ViewerToolbar(props) {
         },
     });
 
+    const onViewDetails = () =>
+        setDetailsResource({
+            id: resourceId,
+            path,
+            label: fileName,
+            type: ResourceTypes.FILE,
+        });
+
+    const onViewMetadata = () =>
+        handlePathChange(
+            path,
+            null,
+            ResourceTypes.FILE,
+            resourceId,
+            NavigationParams.VIEW.METADATA
+        );
+
     return (
         <>
             <Toolbar variant="dense" id={baseId}>
-                <Button
-                    color="primary"
-                    variant={isMobile ? "text" : "contained"}
-                    size="small"
-                    startIcon={<ArrowBack fontSize="small" />}
-                    onClick={() => router.back()}
-                >
-                    <Hidden xsDown>{t("back")}</Hidden>
-                </Button>
+                <BackButton />
                 <Divider
                     orientation="vertical"
                     flexItem
@@ -270,17 +275,22 @@ function ViewerToolbar(props) {
                                 variant="outlined"
                                 disableElevation
                                 color="primary"
-                                onClick={() =>
-                                    setDetailsResource({
-                                        id: resourceId,
-                                        path,
-                                        label: fileName,
-                                        type: ResourceTypes.FILE,
-                                    })
-                                }
+                                onClick={onViewDetails}
                                 startIcon={<Info />}
                             >
                                 <Hidden xsDown>{t("details")}</Hidden>
+                            </Button>
+                            <Button
+                                id={build(baseId, ids.METADATA_BTN)}
+                                size="small"
+                                className={classes.toolbarItems}
+                                variant="outlined"
+                                disableElevation
+                                color="primary"
+                                onClick={onViewMetadata}
+                                startIcon={<MetadataIcon />}
+                            >
+                                <Hidden xsDown>{t("metadata")}</Hidden>
                             </Button>
                             <Button
                                 id={build(baseId, ids.DOWNLOAD_BTN)}
@@ -294,20 +304,20 @@ function ViewerToolbar(props) {
                             >
                                 <Hidden xsDown>{t("download")}</Hidden>
                             </Button>
+                            <Button
+                                id={build(baseId, ids.REFRESH_BTN)}
+                                size="small"
+                                className={classes.toolbarItems}
+                                variant="outlined"
+                                disableElevation
+                                color="primary"
+                                onClick={onRefresh}
+                                startIcon={<Refresh fontSize="small" />}
+                            >
+                                <Hidden xsDown>{i18nCommon("refresh")}</Hidden>
+                            </Button>
                         </>
                     )}
-                    <Button
-                        id={build(baseId, ids.REFRESH_BTN)}
-                        size="small"
-                        className={classes.toolbarItems}
-                        variant="outlined"
-                        disableElevation
-                        color="primary"
-                        onClick={onRefresh}
-                        startIcon={<Refresh fontSize="small" />}
-                    >
-                        <Hidden xsDown>{i18nCommon("refresh")}</Hidden>
-                    </Button>
                 </Hidden>
                 <Hidden mdUp>
                     <>
@@ -440,49 +450,71 @@ function ViewerToolbar(props) {
                                         <ListItemText primary={t("delete")} />
                                     </MenuItem>,
                                 ],
-                                <MenuItem
-                                    key={build(baseId, ids.DETAILS_MENU_ITEM)}
-                                    id={build(baseId, ids.DETAILS_MENU_ITEM)}
-                                    onClick={() => {
-                                        onClose();
-                                        setDetailsResource({
-                                            id: resourceId,
-                                            path,
-                                            label: fileName,
-                                            type: ResourceTypes.FILE,
-                                        });
-                                    }}
-                                >
-                                    <ListItemIcon>
-                                        <Info fontSize="small" />
-                                    </ListItemIcon>
-                                    <ListItemText primary={t("details")} />
-                                </MenuItem>,
-                                <MenuItem
-                                    key={build(baseId, ids.DOWNLOAD_MENU_ITEM)}
-                                    id={build(baseId, ids.DOWNLOAD_MENU_ITEM)}
-                                    onClick={() => {
-                                        onClose();
-                                        setDownload(true);
-                                    }}
-                                >
-                                    <ListItemIcon>
-                                        <CloudDownload fontSize="small" />
-                                    </ListItemIcon>
-                                    <ListItemText primary={t("download")} />
-                                </MenuItem>,
-                                <MenuItem
-                                    key={build(baseId, ids.REFRESH_MENU_ITEM)}
-                                    id={build(baseId, ids.REFRESH_MENU_ITEM)}
-                                    onClick={onRefresh}
-                                >
-                                    <ListItemIcon>
-                                        <Refresh fontSize="small" />
-                                    </ListItemIcon>
-                                    <ListItemText
-                                        primary={i18nCommon("refresh")}
-                                    />
-                                </MenuItem>,
+                                !createFile && [
+                                    <MenuItem
+                                        key={ids.DETAILS_MENU_ITEM}
+                                        id={build(
+                                            baseId,
+                                            ids.DETAILS_MENU_ITEM
+                                        )}
+                                        onClick={() => {
+                                            onClose();
+                                            onViewDetails();
+                                        }}
+                                    >
+                                        <ListItemIcon>
+                                            <Info fontSize="small" />
+                                        </ListItemIcon>
+                                        <ListItemText primary={t("details")} />
+                                    </MenuItem>,
+                                    <MenuItem
+                                        key={ids.METADATA_MENU_ITEM}
+                                        id={build(
+                                            baseId,
+                                            ids.METADATA_MENU_ITEM
+                                        )}
+                                        onClick={() => {
+                                            onClose();
+                                            onViewMetadata();
+                                        }}
+                                    >
+                                        <ListItemIcon>
+                                            <MetadataIcon fontSize="small" />
+                                        </ListItemIcon>
+                                        <ListItemText primary={t("metadata")} />
+                                    </MenuItem>,
+                                    <MenuItem
+                                        key={ids.DOWNLOAD_MENU_ITEM}
+                                        id={build(
+                                            baseId,
+                                            ids.DOWNLOAD_MENU_ITEM
+                                        )}
+                                        onClick={() => {
+                                            onClose();
+                                            setDownload(true);
+                                        }}
+                                    >
+                                        <ListItemIcon>
+                                            <CloudDownload fontSize="small" />
+                                        </ListItemIcon>
+                                        <ListItemText primary={t("download")} />
+                                    </MenuItem>,
+                                    <MenuItem
+                                        key={ids.REFRESH_MENU_ITEM}
+                                        id={build(
+                                            baseId,
+                                            ids.REFRESH_MENU_ITEM
+                                        )}
+                                        onClick={onRefresh}
+                                    >
+                                        <ListItemIcon>
+                                            <Refresh fontSize="small" />
+                                        </ListItemIcon>
+                                        <ListItemText
+                                            primary={i18nCommon("refresh")}
+                                        />
+                                    </MenuItem>,
+                                ],
                             ]}
                         />
                     </>

--- a/src/components/data/viewers/VideoViewer.js
+++ b/src/components/data/viewers/VideoViewer.js
@@ -19,7 +19,14 @@ import { build } from "@cyverse-de/ui-lib";
 import { Typography } from "@material-ui/core";
 
 export default function VideoViewer(props) {
-    const { baseId, path, resourceId, onRefresh, fileName } = props;
+    const {
+        baseId,
+        path,
+        resourceId,
+        handlePathChange,
+        onRefresh,
+        fileName,
+    } = props;
     const { t } = useTranslation("data");
     const [url, setUrl] = useState("");
 
@@ -35,6 +42,7 @@ export default function VideoViewer(props) {
                     path={path}
                     resourceId={resourceId}
                     allowLineNumbers={false}
+                    handlePathChange={handlePathChange}
                     onRefresh={onRefresh}
                     fileName={fileName}
                 />

--- a/src/components/data/viewers/ids.js
+++ b/src/components/data/viewers/ids.js
@@ -13,6 +13,8 @@ export default {
     LOAD_MORE_BTN: "loadMoreButton",
     LINE_NUMBERS_SWITCH: "lineNumberSwitch",
     LINE_NUMBER_MENU_ITEM: "lineNumberSwitchMenuItem",
+    METADATA_BTN: "metadataButton",
+    METADATA_MENU_ITEM: "metadataMenuItem",
     REFRESH_BTN: "refreshButton",
     REFRESH_MENU_ITEM: "refreshMenuItem",
     SAVE_BTN: "saveButton",

--- a/src/components/metadata/form/MetadataFormToolbar.js
+++ b/src/components/metadata/form/MetadataFormToolbar.js
@@ -6,6 +6,7 @@ import React from "react";
 import { Trans } from "react-i18next";
 
 import { useTranslation } from "i18n";
+import BackButton from "components/utils/BackButton";
 import DEDialog from "components/utils/DEDialog";
 
 import ids from "../ids";
@@ -54,12 +55,13 @@ const MetadataFormToolbar = (props) => {
     const classes = useStyles();
 
     return (
-        <Toolbar variant="dense">
+        <Toolbar variant="dense" className={classes.metadataFormToolbar}>
+            <BackButton />
             <Typography
                 id={build(baseId, ids.TITLE)}
                 variant="h6"
                 color="inherit"
-                className={classes.flex}
+                className={classes.metadataFormTitle}
             >
                 {title}
             </Typography>

--- a/src/components/metadata/form/index.js
+++ b/src/components/metadata/form/index.js
@@ -27,6 +27,7 @@ import ExternalLink from "components/utils/ExternalLink";
 
 import { ERROR_CODES, getErrorCode } from "components/utils/error/errorCode";
 import withErrorAnnouncer from "components/utils/error/withErrorAnnouncer";
+import WrappedErrorHandler from "components/utils/error/WrappedErrorHandler";
 
 import { useBootstrapInfo } from "contexts/bootstrap";
 import { useUserProfile } from "contexts/userProfile";
@@ -284,7 +285,12 @@ const MetadataFormListing = (props) => {
     );
 };
 
-const MetadataForm = ({ loading, showErrorAnnouncer, ...props }) => {
+const MetadataForm = ({
+    loading,
+    loadingError,
+    showErrorAnnouncer,
+    ...props
+}) => {
     // targetResource should be spread down into the dialog form below.
     const { targetResource } = props;
 
@@ -406,7 +412,7 @@ const MetadataForm = ({ loading, showErrorAnnouncer, ...props }) => {
         const { avus, "irods-avus": irodsAVUs } = values;
         const { setSubmitting, setStatus } = actions;
 
-        const updatedMetadata = { ...metadata, avus, "irods-avus": irodsAVUs };
+        const updatedMetadata = { avus, "irods-avus": irodsAVUs };
 
         const onSuccess = () => {
             setSubmitting(false);
@@ -440,11 +446,19 @@ const MetadataForm = ({ loading, showErrorAnnouncer, ...props }) => {
 
     const baseId = ids.EDIT_METADATA_FORM;
 
+    if (loadingError) {
+        return (
+            <WrappedErrorHandler baseId={baseId} errorObject={loadingError} />
+        );
+    }
+
+    const { avus, "irods-avus": irodsAVUs } = metadata;
+
     return (
         <>
             <Formik
                 enableReinitialize
-                initialValues={{ ...metadata }}
+                initialValues={{ avus, "irods-avus": irodsAVUs }}
                 validate={validate}
                 onSubmit={handleSubmit}
             >

--- a/src/components/metadata/listing/index.js
+++ b/src/components/metadata/listing/index.js
@@ -25,7 +25,8 @@ import {
 } from "@cyverse-de/ui-lib";
 
 import {
-    Grid,
+    ButtonGroup,
+    Button,
     IconButton,
     Paper,
     Table,
@@ -36,6 +37,8 @@ import {
     Toolbar,
     Typography,
     makeStyles,
+    useMediaQuery,
+    useTheme,
 } from "@material-ui/core";
 
 import {
@@ -52,24 +55,39 @@ const MetadataGridToolbar = (props) => {
 
     const { t } = useTranslation("metadata");
     const classes = useStyles();
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down("xs"));
 
     return (
         <Toolbar>
-            {editable && (
-                <IconButton
-                    id={build(parentID, ids.BUTTONS.ADD)}
-                    color="primary"
-                    aria-label={t("addMetadata")}
-                    onClick={onAddAVU}
-                >
-                    <ContentAdd />
-                </IconButton>
-            )}
-            <div className={classes.title}>
-                <Typography id={build(parentID, ids.TITLE)} variant="h6">
-                    {t("avus")}
-                </Typography>
-            </div>
+            <Typography
+                id={build(parentID, ids.TITLE)}
+                variant="h6"
+                className={classes.avuListingTitle}
+            >
+                {t("avus")}
+            </Typography>
+            {editable &&
+                (isMobile ? (
+                    <IconButton
+                        id={build(parentID, ids.BUTTONS.ADD)}
+                        color="primary"
+                        aria-label={t("addMetadata")}
+                        onClick={onAddAVU}
+                    >
+                        <ContentAdd />
+                    </IconButton>
+                ) : (
+                    <Button
+                        id={build(parentID, ids.BUTTONS.ADD)}
+                        color="primary"
+                        variant="outlined"
+                        startIcon={<ContentAdd />}
+                        onClick={onAddAVU}
+                    >
+                        {t("addMetadata")}
+                    </Button>
+                ))}
         </Toolbar>
     );
 };
@@ -145,47 +163,34 @@ const AVURow = ({
             </TableCell>
             <TableCell>{value}</TableCell>
             <TableCell>{unit}</TableCell>
-            <TableCell padding="none" align="right">
-                {avuChildCount}
-            </TableCell>
-            <TableCell padding="none">
-                <Grid
-                    container
-                    spacing={0}
-                    wrap="nowrap"
-                    direction="row"
-                    justify="center"
-                    alignItems="center"
-                >
-                    <Grid item>
-                        <IconButton
-                            id={build(rowID, ids.BUTTONS.EDIT)}
-                            aria-label={editable ? t("edit") : t("view")}
-                            className={classes.button}
+            <TableCell align="right">{avuChildCount}</TableCell>
+            <TableCell>
+                <ButtonGroup variant="text">
+                    <Button
+                        id={build(rowID, ids.BUTTONS.EDIT)}
+                        aria-label={editable ? t("edit") : t("view")}
+                        className={classes.button}
+                        onClick={(event) => {
+                            event.stopPropagation();
+                            onRowEdit();
+                        }}
+                    >
+                        {editable ? <ContentEdit /> : <ContentView />}
+                    </Button>
+                    {editable && (
+                        <Button
+                            id={build(rowID, ids.BUTTONS.DELETE)}
+                            aria-label={t("delete")}
+                            className={classes.deleteIcon}
                             onClick={(event) => {
                                 event.stopPropagation();
-                                onRowEdit();
+                                onRowDelete();
                             }}
                         >
-                            {editable ? <ContentEdit /> : <ContentView />}
-                        </IconButton>
-                    </Grid>
-                    {editable && (
-                        <Grid item>
-                            <IconButton
-                                id={build(rowID, ids.BUTTONS.DELETE)}
-                                aria-label={t("delete")}
-                                classes={{ root: classes.deleteIcon }}
-                                onClick={(event) => {
-                                    event.stopPropagation();
-                                    onRowDelete();
-                                }}
-                            >
-                                <ContentRemove />
-                            </IconButton>
-                        </Grid>
+                            <ContentRemove />
+                        </Button>
                     )}
-                </Grid>
+                </ButtonGroup>
             </TableCell>
         </TableRow>
     );

--- a/src/components/metadata/styles.js
+++ b/src/components/metadata/styles.js
@@ -6,9 +6,11 @@ const styles = (theme) => ({
         width: "100%",
         height: "100%",
     },
-    flex: {
+    metadataFormTitle: {
+        paddingLeft: theme.spacing(1),
         flex: 1,
     },
+    metadataFormToolbar: { alignItems: "flex-start" },
     tableHead: {
         backgroundColor: theme.palette.lightGray,
         position: "sticky",

--- a/src/components/metadata/styles.js
+++ b/src/components/metadata/styles.js
@@ -9,6 +9,7 @@ const styles = (theme) => ({
     metadataFormTitle: {
         paddingLeft: theme.spacing(1),
         flex: 1,
+        overflow: "auto",
     },
     metadataFormToolbar: { alignItems: "flex-start" },
     tableHead: {
@@ -17,10 +18,7 @@ const styles = (theme) => ({
         top: 0,
     },
     deleteIcon: {
-        margin: 5,
-        "&:hover": {
-            backgroundColor: theme.palette.error.main,
-        },
+        color: theme.palette.error.main,
     },
     toolbar: {
         paddingLeft: theme.spacing(1),
@@ -32,10 +30,8 @@ const styles = (theme) => ({
     actions: {
         color: theme.palette.text.secondary,
     },
-    title: {
-        paddingLeft: theme.spacing(1),
-        flex: "0 0 auto",
-        maxWidth: "25rem",
+    avuListingTitle: {
+        flex: 1,
     },
     errorSubTitle: {
         color: theme.palette.error.dark,

--- a/src/components/utils/BackButton.js
+++ b/src/components/utils/BackButton.js
@@ -9,7 +9,7 @@ import React from "react";
 import { useRouter } from "next/router";
 import { useTranslation } from "i18n";
 
-import { Button, Hidden, useMediaQuery, useTheme } from "@material-ui/core";
+import { Button, IconButton, useMediaQuery, useTheme } from "@material-ui/core";
 
 import { ArrowBack } from "@material-ui/icons";
 
@@ -19,16 +19,28 @@ export default function BackButton(props) {
     const isMobile = useMediaQuery(theme.breakpoints.down("xs"));
     const { t } = useTranslation("common");
 
-    return (
-        <Button
+    const onClick = () => router && router.back();
+
+    return isMobile ? (
+        <IconButton
             color="primary"
-            variant={isMobile ? "text" : "contained"}
-            size="small"
-            startIcon={<ArrowBack fontSize="small" />}
-            onClick={() => router && router.back()}
+            edge="start"
+            aria-label={t("back")}
+            onClick={onClick}
             {...props}
         >
-            <Hidden xsDown>{t("back")}</Hidden>
+            <ArrowBack />
+        </IconButton>
+    ) : (
+        <Button
+            color="primary"
+            variant={"contained"}
+            size="small"
+            startIcon={<ArrowBack fontSize="small" />}
+            onClick={onClick}
+            {...props}
+        >
+            {t("back")}
         </Button>
     );
 }

--- a/src/components/utils/BackButton.js
+++ b/src/components/utils/BackButton.js
@@ -1,0 +1,34 @@
+/**
+ * @author psarando, sriram
+ *
+ * A button that uses the next/router to navigate back to the previous page in
+ * the browser's history.
+ */
+import React from "react";
+
+import { useRouter } from "next/router";
+import { useTranslation } from "i18n";
+
+import { Button, Hidden, useMediaQuery, useTheme } from "@material-ui/core";
+
+import { ArrowBack } from "@material-ui/icons";
+
+export default function BackButton(props) {
+    const router = useRouter();
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down("xs"));
+    const { t } = useTranslation("common");
+
+    return (
+        <Button
+            color="primary"
+            variant={isMobile ? "text" : "contained"}
+            size="small"
+            startIcon={<ArrowBack fontSize="small" />}
+            onClick={() => router && router.back()}
+            {...props}
+        >
+            <Hidden xsDown>{t("back")}</Hidden>
+        </Button>
+    );
+}

--- a/src/pages/data/ds/[...pathItems].js
+++ b/src/pages/data/ds/[...pathItems].js
@@ -67,47 +67,47 @@ export default function DataStore() {
     const resourcePath = decodeURIComponent(path);
 
     const handlePathChange = useCallback(
-        (path, params, resourceType, id, view) => {
-            const url = `${baseRoutingPath}${dynamicPathName}`;
-            const as = `${baseRoutingPath}${getEncodedPath(path)}`;
+        (path, query) => {
+            const pathname = `${baseRoutingPath}${getEncodedPath(path)}`;
 
-            if (view === NavigationParams.VIEW.METADATA) {
-                const viewParams = `view=${view}`;
-                router.push(`${url}?${viewParams}`, `${as}?${viewParams}`);
-            } else if (!resourceType || resourceType === ResourceTypes.FOLDER) {
-                router.push(`${url}?${params}`, `${as}?${params}`);
-            } else {
-                const viewerParams = `type=${ResourceTypes.FILE}&resourceId=${id}`;
-                router.push(`${url}?${viewerParams}`, `${as}?${viewerParams}`);
-            }
+            router.push({
+                pathname,
+                query,
+            });
         },
         [baseRoutingPath, router]
     );
 
     const onCreateHTFileSelected = useCallback(
         (path) => {
-            const createFile = infoTypes.HT_ANALYSIS_PATH_LIST;
             const encodedPath = getEncodedPath(
                 path.concat(`/${viewerConstants.NEW_FILE_NAME}`)
             );
-            router.push(
-                `${baseRoutingPath}${dynamicPathName}?type=${ResourceTypes.FILE}&createFile=${createFile}`,
-                `${baseRoutingPath}${encodedPath}?type=${ResourceTypes.FILE}&createFile=${createFile}`
-            );
+
+            router.push({
+                pathname: `${baseRoutingPath}${encodedPath}`,
+                query: {
+                    type: ResourceTypes.FILE,
+                    createFile: infoTypes.HT_ANALYSIS_PATH_LIST,
+                },
+            });
         },
         [baseRoutingPath, router]
     );
 
     const onCreateMultiInputFileSelected = useCallback(
         (path) => {
-            const createFile = infoTypes.MULTI_INPUT_PATH_LIST;
             const encodedPath = getEncodedPath(
                 path.concat(`/${viewerConstants.NEW_FILE_NAME}`)
             );
-            router.push(
-                `${baseRoutingPath}${dynamicPathName}?type=${ResourceTypes.FILE}&createFile=${createFile}`,
-                `${baseRoutingPath}${encodedPath}?type=${ResourceTypes.FILE}&createFile=${createFile}`
-            );
+
+            router.push({
+                pathname: `${baseRoutingPath}${encodedPath}`,
+                query: {
+                    type: ResourceTypes.FILE,
+                    createFile: infoTypes.MULTI_INPUT_PATH_LIST,
+                },
+            });
         },
         [baseRoutingPath, router]
     );
@@ -115,10 +115,16 @@ export default function DataStore() {
     const onNewFileSaved = useCallback(
         (path, resourceId) => {
             const encodedPath = getEncodedPath(path);
-            router.push(
-                `${baseRoutingPath}${dynamicPathName}?type=${ResourceTypes.FILE}&resourceId=${resourceId}`,
-                `${baseRoutingPath}${encodedPath}?type=${ResourceTypes.FILE}&resourceId=${resourceId}`
-            );
+
+            // Using router.replace instead of push to prevent the user
+            // from navigating back to a create-file page.
+            router.replace({
+                pathname: `${baseRoutingPath}${encodedPath}`,
+                query: {
+                    type: ResourceTypes.FILE,
+                    resourceId,
+                },
+            });
         },
         [baseRoutingPath, router]
     );
@@ -127,10 +133,16 @@ export default function DataStore() {
         (path, order, orderBy, page, rowsPerPage) => {
             if (path) {
                 const encodedPath = getEncodedPath(path);
-                router.push(
-                    `${baseRoutingPath}${dynamicPathName}?selectedOrder=${order}&selectedOrderBy=${orderBy}&selectedPage=${page}&selectedRowsPerPage=${rowsPerPage}`,
-                    `${baseRoutingPath}${encodedPath}?selectedOrder=${order}&selectedOrderBy=${orderBy}&selectedPage=${page}&selectedRowsPerPage=${rowsPerPage}`
-                );
+
+                router.push({
+                    pathname: `${baseRoutingPath}${encodedPath}`,
+                    query: {
+                        selectedOrder: order,
+                        selectedOrderBy: orderBy,
+                        selectedPage: page,
+                        selectedRowsPerPage: rowsPerPage,
+                    },
+                });
             }
         },
         [baseRoutingPath, router]

--- a/src/pages/data/ds/[...pathItems].js
+++ b/src/pages/data/ds/[...pathItems].js
@@ -168,6 +168,7 @@ export default function DataStore() {
                 path={resourcePath}
                 createFile={createFile}
                 baseId="data.viewer"
+                handlePathChange={handlePathChange}
                 onNewFileSaved={onNewFileSaved}
             />
         );

--- a/src/pages/data/ds/index.js
+++ b/src/pages/data/ds/index.js
@@ -30,7 +30,11 @@ export default function Data() {
                     ? `${irodsHomePath}/${username}`
                     : `${irodsHomePath}/shared`
             );
-            router.push(`${router.pathname}${defaultPath}?${defaultParams}`);
+
+            router.push({
+                pathname: `${router.pathname}${defaultPath}`,
+                query: defaultParams,
+            });
         }
     }, [router, config, userProfile]);
 

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -35,9 +35,11 @@ export default function Data() {
                     ? `${irodsHomePath}/${username}`
                     : `${irodsHomePath}/shared`
             );
-            router.push(
-                `${router.pathname}${constants.PATH_SEPARATOR}${constants.DATA_STORE_STORAGE_ID}${defaultPath}?${defaultParams}`
-            );
+
+            router.push({
+                pathname: `${router.pathname}${constants.PATH_SEPARATOR}${constants.DATA_STORE_STORAGE_ID}${defaultPath}`,
+                query: defaultParams,
+            });
         }
     }, [router, config, userProfile]);
 

--- a/stories/metadata/MetadataForm.stories.js
+++ b/stories/metadata/MetadataForm.stories.js
@@ -57,7 +57,9 @@ mockAxios.onPost(/\/api\/filesystem\/.*\/metadata/).reply((config) => {
     return [200, { path: testResourcePath, user: "ipcdev" }];
 });
 
-const MetadataViewStory = ({ loading, loggedOut }) => {
+const MetadataViewStory = (props) => {
+    const { loading, loadingError, loggedOut } = props;
+
     const [userProfile, setUserProfile] = useUserProfile();
 
     React.useEffect(() => {
@@ -67,6 +69,11 @@ const MetadataViewStory = ({ loading, loggedOut }) => {
     return (
         <MetadataForm
             loading={loading}
+            loadingError={
+                loadingError && {
+                    response: { status: 500, data: errorResponse },
+                }
+            }
             targetResource={
                 loading
                     ? null
@@ -81,16 +88,31 @@ const MetadataViewStory = ({ loading, loggedOut }) => {
     );
 };
 
-export const MetadataView = ({ loading, "Logged-Out View": loggedOut }) => {
+export const MetadataView = (props) => {
+    const {
+        loading,
+        "Loading Error": loadingError,
+        "Logged-Out View": loggedOut,
+    } = props;
+
     return (
         <UserProfileProvider>
-            <MetadataViewStory loading={loading} loggedOut={loggedOut} />
+            <MetadataViewStory
+                loading={loading}
+                loadingError={loadingError}
+                loggedOut={loggedOut}
+            />
         </UserProfileProvider>
     );
 };
 
 MetadataView.argTypes = {
     loading: {
+        control: {
+            type: "boolean",
+        },
+    },
+    "Loading Error": {
         control: {
             type: "boolean",
         },


### PR DESCRIPTION
This PR will integrate the Metadata listing with `/data/ds/[...pathItem]` pages.

A new `?view=metadata` navigation query param constant was added that this page can use to determine whether to display metadata on a file or folder, rather than that item's contents.

For example, `/data/ds/iplant/home/ipcdev/bilbo-funny-1.jpg?view=metadata`.
![bilbo-funny-1.jpg Metadata Listing](https://user-images.githubusercontent.com/996408/102160611-fee33980-3e42-11eb-9d51-9927c2842f9d.png)

I also reorganized the data listing dot menus a bit, especially since it was far too easy for me to accidentally click `Delete` right after opening the dot menu when it was the first item in the list. So now `Delete` is at the bottom under a separating divider:
![Data Listing Toolbar Dot-menu](https://user-images.githubusercontent.com/996408/102160819-64cfc100-3e43-11eb-91ab-7bcf53606d54.png)

---

On mobile:
![Data Listing Toolbar Dot-menu - mobile](https://user-images.githubusercontent.com/996408/102161099-ecb5cb00-3e43-11eb-92a2-54e7ec43a970.png)

---

Similarly the listing row dot-menus were rearranged:
![Data Listing Row Dot-menu - mobile](https://user-images.githubusercontent.com/996408/102161217-22f34a80-3e44-11eb-9980-1d00c9bba97b.png)
