### PR TITLE
Fix browser navigation for data view.

### DIFF
--- a/src/components/data/SelectionDrawer.js
+++ b/src/components/data/SelectionDrawer.js
@@ -28,9 +28,12 @@ import Listing from "components/data/listing/Listing";
 import ResourceTypes from "../models/ResourceTypes";
 
 import styles from "./styles";
+import constants from "../../constants";
 
 import PageWrapper from "../../components/layout/PageWrapper";
 import useComponentHeight from "../utils/useComponentHeight";
+import { DEFAULT_PAGE_SETTINGS } from "components/data/utils";
+import { getLocalStorage } from "components/utils/localStorage";
 
 const useStyles = makeStyles(styles);
 
@@ -217,6 +220,16 @@ function SelectionDrawer(props) {
                     baseId={build(id, ids.DATA_VIEW)}
                     multiSelect={multiSelect}
                     isInvalidSelection={isInvalidSelection}
+                    page={DEFAULT_PAGE_SETTINGS.page}
+                    rowsPerPage={
+                        parseInt(
+                            getLocalStorage(
+                                constants.LOCAL_STORAGE.DATA.PAGE_SIZE
+                            )
+                        ) || DEFAULT_PAGE_SETTINGS.rowsPerPage
+                    }
+                    order={DEFAULT_PAGE_SETTINGS.order}
+                    orderBy={DEFAULT_PAGE_SETTINGS.orderBy}
                     render={(selectedTotal, getSelectedResources) => (
                         <SelectionToolbar
                             baseId={id}

--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -86,12 +86,7 @@ function Listing(props) {
     const [detailsResource, setDetailsResource] = useState(null);
     const [infoTypes, setInfoTypes] = useState([]);
     const [infoTypesQueryEnabled, setInfoTypesQueryEnabled] = useState(false);
-    const [pagedListingKey, setPagedListingKey] = useState(
-        DATA_LISTING_QUERY_KEY
-    );
-    const [pagedListingQueryEnabled, setPagedListingQueryEnabled] = useState(
-        false
-    );
+
     const [navError, setNavError] = useState(null);
 
     // Used to force the data listing to refresh when uploads are completed.
@@ -122,10 +117,18 @@ function Listing(props) {
     };
 
     const { error, isFetching } = useQuery({
-        queryKey: pagedListingKey,
+        queryKey: [
+            DATA_LISTING_QUERY_KEY,
+            path,
+            rowsPerPage,
+            orderBy,
+            order,
+            page,
+            uploadsCompleted,
+        ],
         queryFn: getPagedListing,
         config: {
-            enabled: pagedListingQueryEnabled,
+            enabled: !!path,
             onSuccess: (respData) => {
                 setData({
                     total: respData?.total,
@@ -165,18 +168,6 @@ function Listing(props) {
 
     useEffect(() => {
         setSelected([]);
-        if (path) {
-            setPagedListingKey([
-                DATA_LISTING_QUERY_KEY,
-                path,
-                rowsPerPage,
-                orderBy,
-                order,
-                page,
-                uploadsCompleted,
-            ]);
-            setPagedListingQueryEnabled(true);
-        }
     }, [path, rowsPerPage, orderBy, order, page, uploadsCompleted]);
 
     const viewUploadQueue = useCallback(() => {

--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -149,7 +149,18 @@ function Listing(props) {
     });
 
     const refreshListing = () =>
-        queryCache.invalidateQueries(pagedListingKey, { force: true });
+        queryCache.invalidateQueries(
+            [
+                DATA_LISTING_QUERY_KEY,
+                path,
+                rowsPerPage,
+                orderBy,
+                order,
+                page,
+                uploadsCompleted,
+            ],
+            { force: true }
+        );
 
     const [removeResources, { status: removeResourceStatus }] = useMutation(
         deleteResources,

--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -10,6 +10,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import TableView from "./TableView";
 
 import ids from "../ids";
+import globalConstants from "../../../constants";
 import Drawer from "../details/Drawer";
 import FileBrowser from "../toolbar/FileBrowser";
 import DataToolbar from "../toolbar/Toolbar";
@@ -28,7 +29,7 @@ import { camelcaseit } from "common/functions";
 import withErrorAnnouncer from "components/utils/error/withErrorAnnouncer";
 import Sharing from "components/sharing";
 import { formatSharedData } from "components/sharing/util";
-import { DEFAULT_PAGE_SETTINGS, getPageQueryParams } from "../utils";
+import { getPageQueryParams } from "../utils";
 
 import {
     useUploadTrackingState,
@@ -65,10 +66,10 @@ function Listing(props) {
         showErrorAnnouncer,
         onCreateHTFileSelected,
         onCreateMultiInputFileSelected,
-        selectedPage,
-        selectedRowsPerPage,
-        selectedOrder,
-        selectedOrderBy,
+        page,
+        rowsPerPage,
+        order,
+        orderBy,
         onRouteToListing,
     } = props;
     const { t } = useTranslation("data");
@@ -76,20 +77,9 @@ function Listing(props) {
     const uploadTracker = useUploadTrackingState();
     const theme = useTheme();
     const [isGridView, setGridView] = useState(false);
-    const [order, setOrder] = useState(
-        selectedOrder || DEFAULT_PAGE_SETTINGS.order
-    );
-    const [orderBy, setOrderBy] = useState(
-        selectedOrderBy || DEFAULT_PAGE_SETTINGS.orderBy
-    );
+
     const [selected, setSelected] = useState([]);
     const [lastSelectIndex, setLastSelectIndex] = useState(-1);
-    const [page, setPage] = useState(
-        selectedPage || DEFAULT_PAGE_SETTINGS.page
-    );
-    const [rowsPerPage, setRowsPerPage] = useState(
-        selectedRowsPerPage || DEFAULT_PAGE_SETTINGS.rowsPerPage
-    );
     const [data, setData] = useState({ total: 0, listing: [] });
     const [detailsEnabled, setDetailsEnabled] = useState(false);
     const [detailsOpen, setDetailsOpen] = useState(false);
@@ -246,33 +236,19 @@ function Listing(props) {
         setDetailsEnabled(selected && selected.length === 1);
     }, [selected]);
 
-    useEffect(() => {
-        if (
-            selectedOrder !== order ||
-            selectedOrderBy !== orderBy ||
-            selectedPage !== page ||
-            selectedRowsPerPage !== rowsPerPage
-        ) {
-            onRouteToListing &&
-                onRouteToListing(path, order, orderBy, page, rowsPerPage);
-        }
-    }, [
-        onRouteToListing,
-        order,
-        orderBy,
-        page,
-        path,
-        rowsPerPage,
-        selectedOrder,
-        selectedOrderBy,
-        selectedPage,
-        selectedRowsPerPage,
-    ]);
-
     const handleRequestSort = (event, property) => {
-        const isAsc = orderBy === property && order === "asc";
-        setOrder(isAsc ? "desc" : "asc");
-        setOrderBy(property);
+        const isAsc =
+            orderBy === property && order === globalConstants.SORT_ASCENDING;
+        onRouteToListing &&
+            onRouteToListing(
+                path,
+                isAsc
+                    ? globalConstants.SORT_DESCENDING
+                    : globalConstants.SORT_ASCENDING,
+                property,
+                page,
+                rowsPerPage
+            );
     };
 
     const handleSelectAllClick = (event) => {
@@ -367,12 +343,19 @@ function Listing(props) {
     };
 
     const handleChangePage = (event, newPage) => {
-        setPage(newPage - 1);
+        onRouteToListing &&
+            onRouteToListing(path, order, orderBy, newPage - 1, rowsPerPage);
     };
 
     const handleChangeRowsPerPage = (newPageSize) => {
-        setRowsPerPage(parseInt(newPageSize, 10));
-        setPage(0);
+        onRouteToListing &&
+            onRouteToListing(
+                path,
+                order,
+                orderBy,
+                0,
+                parseInt(newPageSize, 10)
+            );
     };
 
     const onDetailsSelected = () => {
@@ -424,12 +407,8 @@ function Listing(props) {
     );
 
     const onPathChange = (path, resourceType, id) => {
-        const queryParams = getPageQueryParams(
-            order,
-            orderBy,
-            page,
-            rowsPerPage
-        );
+        //set page to 0 for the new path
+        const queryParams = getPageQueryParams(order, orderBy, 0, rowsPerPage);
         handlePathChange(path, queryParams, resourceType, id);
     };
 

--- a/src/pages/data/ds/[...pathItems].js
+++ b/src/pages/data/ds/[...pathItems].js
@@ -10,7 +10,7 @@ import constants from "../../../constants";
 import { getLocalStorage } from "components/utils/localStorage";
 import viewerConstants from "components/data/viewers/constants";
 import Listing from "components/data/listing/Listing";
-import { getEncodedPath } from "components/data/utils";
+import { getEncodedPath, DEFAULT_PAGE_SETTINGS } from "components/data/utils";
 import FileViewer from "components/data/viewers/FileViewer";
 import infoTypes from "components/models/InfoTypes";
 import ResourceTypes from "components/models/ResourceTypes";
@@ -34,12 +34,14 @@ export default function DataStore() {
     const router = useRouter();
     const query = router.query;
 
-    const selectedPage = parseInt(query.selectedPage);
-    const selectedRowsPerPage = parseInt(
-        getLocalStorage(constants.LOCAL_STORAGE.DATA.PAGE_SIZE)
-    );
-    const selectedOrder = query.selectedOrder;
-    const selectedOrderBy = query.selectedOrderBy;
+    const selectedPage =
+        parseInt(query.selectedPage) || DEFAULT_PAGE_SETTINGS.page;
+    const selectedRowsPerPage =
+        parseInt(getLocalStorage(constants.LOCAL_STORAGE.DATA.PAGE_SIZE)) ||
+        DEFAULT_PAGE_SETTINGS.rowsPerPage;
+    const selectedOrder = query.selectedOrder || DEFAULT_PAGE_SETTINGS.order;
+    const selectedOrderBy =
+        query.selectedOrderBy || DEFAULT_PAGE_SETTINGS.orderBy;
 
     const isFile = query.type === ResourceTypes.FILE;
     const resourceId = query.resourceId;
@@ -130,10 +132,10 @@ export default function DataStore() {
                 baseId="data"
                 onCreateHTFileSelected={onCreateHTFileSelected}
                 onCreateMultiInputFileSelected={onCreateMultiInputFileSelected}
-                selectedPage={selectedPage}
-                selectedRowsPerPage={selectedRowsPerPage}
-                selectedOrder={selectedOrder}
-                selectedOrderBy={selectedOrderBy}
+                page={selectedPage}
+                rowsPerPage={selectedRowsPerPage}
+                order={selectedOrder}
+                orderBy={selectedOrderBy}
                 onRouteToListing={onRouteToListing}
             />
         );

--- a/src/pages/data/ds/[...pathItems].js
+++ b/src/pages/data/ds/[...pathItems].js
@@ -37,6 +37,7 @@ export default function DataStore() {
     const selectedPage =
         parseInt(query.selectedPage) || DEFAULT_PAGE_SETTINGS.page;
     const selectedRowsPerPage =
+        parseInt(query.selectedRowsPerPage) ||
         parseInt(getLocalStorage(constants.LOCAL_STORAGE.DATA.PAGE_SIZE)) ||
         DEFAULT_PAGE_SETTINGS.rowsPerPage;
     const selectedOrder = query.selectedOrder || DEFAULT_PAGE_SETTINGS.order;

--- a/stories/data/Listing.stories.js
+++ b/stories/data/Listing.stories.js
@@ -21,10 +21,10 @@ function ListingTest(props) {
                 baseId="tableView"
                 path="/iplant/home/ipcdev"
                 handlePathChange={(path) => logger("Change to path " + path)}
-                selectedPage={0}
-                selectedRowsPerPage={100}
-                selectedOrder={constants.SORT_DESCENDING}
-                selectedOrderBy="name"
+                page={0}
+                rowsPerPage={100}
+                order={constants.SORT_DESCENDING}
+                orderBy="name"
             />
         </UploadTrackingProvider>
     );


### PR DESCRIPTION
- I eliminated props to state copy of `order`, `orderBy`, `page` and `rowsPerPage`. That seems have fixed most of the issues that we have seen so far with respect to browser `Back` and `Forward` buttons based navigation in Data View. We might want to do the same for other views as well.
- Request reviewers to test these changes locally to make sure edge cases aren't missed.