### PR TITLE
Selection drawer updates

### DIFF
--- a/src/components/data/SelectionDrawer.js
+++ b/src/components/data/SelectionDrawer.js
@@ -97,12 +97,12 @@ function SelectionToolbar(props) {
         <>
             <Toolbar id={build(baseId, ids.SELECTION_TOOLBAR)} ref={toolbarRef}>
                 {hasValidSelection ? (
-                    <Typography color="primary" variant="subtitle2">
+                    <Typography color="primary" variant="h6">
                         {t("selectedItems", { count: selectedTotal })}
                     </Typography>
                 ) : hasInvalidSelection ? (
                     <Typography
-                        variant="subtitle2"
+                        variant="h6"
                         style={{ color: theme.palette.error.main }}
                     >
                         {t("invalidSelection", {
@@ -111,7 +111,7 @@ function SelectionToolbar(props) {
                         })}
                     </Typography>
                 ) : (
-                    <Typography variant="subtitle2">
+                    <Typography variant="h6">
                         {t("selectionSuggestion", {
                             context: acceptedType,
                             count: multiSelect ? 0 : 1,
@@ -122,6 +122,8 @@ function SelectionToolbar(props) {
                 <Button
                     id={build(baseId, ids.SELECTION_TOOLBAR, ids.CANCEL_BTN)}
                     onClick={onClose}
+                    variant="outlined"
+                    style={{ margin: theme.spacing(1) }}
                 >
                     {t("cancel")}
                 </Button>
@@ -130,6 +132,8 @@ function SelectionToolbar(props) {
                         id={build(baseId, ids.SELECTION_TOOLBAR, ids.OK_BTN)}
                         color={"primary"}
                         onClick={handleConfirm}
+                        variant="contained"
+                        style={{ margin: theme.spacing(1) }}
                     >
                         {t("ok")}
                     </Button>
@@ -244,6 +248,8 @@ function SelectionDrawer(props) {
                             setToolbarRef={setToolbarRef}
                         />
                     )}
+                    toolbarVisibility={false}
+                    rowDotMenuVisibility={false}
                 />
             </PageWrapper>
         </Drawer>

--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -73,6 +73,8 @@ function Listing(props) {
         order,
         orderBy,
         onRouteToListing,
+        toolbarVisibility = true,
+        rowDotMenuVisibility = true,
     } = props;
     const { t } = useTranslation("data");
 
@@ -473,6 +475,7 @@ function Listing(props) {
                     }
                     setSharingDlgOpen={setSharingDlgOpen}
                     onPublicLinksSelected={() => setPublicLinksDlgOpen(true)}
+                    toolbarVisibility={toolbarVisibility}
                 />
                 {!isGridView && (
                     <TableView
@@ -497,6 +500,7 @@ function Listing(props) {
                         onPublicLinksSelected={() =>
                             setPublicLinksDlgOpen(true)
                         }
+                        rowDotMenuVisibility={rowDotMenuVisibility}
                     />
                 )}
                 {isGridView && <span>Coming Soon!</span>}

--- a/src/components/data/listing/TableView.js
+++ b/src/components/data/listing/TableView.js
@@ -109,7 +109,7 @@ function getDefaultCols(rowDotMenuVisibility, dataRecordFields) {
 function getLocalStorageCols(rowDotMenuVisibility, dataRecordFields) {
     let localCols = getLocalStorage(constants.LOCAL_STORAGE.DATA.COLUMNS);
     if (!rowDotMenuVisibility && localCols) {
-        return localCols.filter((key) => key !== dataRecordFields.DOT_MENU.ke);
+        return localCols.filter((key) => key !== dataRecordFields.DOT_MENU.key);
     }
     return localCols;
 }

--- a/src/components/data/listing/TableView.js
+++ b/src/components/data/listing/TableView.js
@@ -98,8 +98,20 @@ const invalidRowStyles = makeStyles((theme) => ({
     hover: {},
 }));
 
-function getLocalStorageCols() {
-    return getLocalStorage(constants.LOCAL_STORAGE.DATA.COLUMNS);
+function getDefaultCols(rowDotMenuVisibility, dataRecordFields) {
+    const defCols = [dataRecordFields.CHECKBOX.key, dataRecordFields.NAME.key];
+    if (rowDotMenuVisibility) {
+        defCols.push(dataRecordFields.DOT_MENU.key);
+    }
+    return defCols;
+}
+
+function getLocalStorageCols(rowDotMenuVisibility, dataRecordFields) {
+    let localCols = getLocalStorage(constants.LOCAL_STORAGE.DATA.COLUMNS);
+    if (!rowDotMenuVisibility && localCols) {
+        return localCols.filter((key) => key !== dataRecordFields.DOT_MENU.ke);
+    }
+    return localCols;
 }
 
 function setLocalStorageCols(columns) {
@@ -127,17 +139,15 @@ function TableView(props) {
         setSharingDlgOpen,
         onMetadataSelected,
         onPublicLinksSelected,
+        rowDotMenuVisibility,
     } = props;
     const invalidRowClass = invalidRowStyles();
     const { t } = useTranslation("data");
     const dataRecordFields = dataFields(t);
     const tableId = build(baseId, ids.LISTING_TABLE);
     const [displayColumns, setDisplayColumns] = useState(
-        getLocalStorageCols() || [
-            dataRecordFields.CHECKBOX.key,
-            dataRecordFields.NAME.key,
-            dataRecordFields.DOT_MENU.key,
-        ]
+        getLocalStorageCols(rowDotMenuVisibility, dataRecordFields) ||
+            getDefaultCols(rowDotMenuVisibility, dataRecordFields)
     );
 
     const onSetDisplayColumns = (columns) => {
@@ -193,7 +203,7 @@ function TableView(props) {
     };
 
     const getTableColumns = () => {
-        return [
+        const cols = [
             {
                 name: "",
                 align: "center",
@@ -209,7 +219,9 @@ function TableView(props) {
                 id: dataRecordFields.NAME.key,
             },
             ...optionalColumns(),
-            {
+        ];
+        if (rowDotMenuVisibility) {
+            cols.push({
                 name: (
                     <CustomizeColumns
                         baseId={tableId}
@@ -222,13 +234,14 @@ function TableView(props) {
                 enableSorting: false,
                 key: dataRecordFields.DOT_MENU.key,
                 id: dataRecordFields.DOT_MENU.key,
-            },
-        ];
+            });
+        }
+        return cols;
     };
 
     const getColumnDetails = (keys) => {
         return keys.map((key) =>
-            getTableColumns(dataRecordFields).find((col) => col.key === key)
+            getTableColumns().find((col) => col.key === key)
         );
     };
 
@@ -372,30 +385,34 @@ function TableView(props) {
                                                 </Fragment>
                                             )
                                         )}
-                                        <TableCell align="right">
-                                            <RowDotMenu
-                                                baseId={build(
-                                                    tableId,
-                                                    resourceName
-                                                )}
-                                                onDetailsSelected={
-                                                    onDetailsSelected
-                                                }
-                                                onDeleteSelected={() =>
-                                                    onDeleteSelected(resourceId)
-                                                }
-                                                resource={resource}
-                                                setSharingDlgOpen={
-                                                    setSharingDlgOpen
-                                                }
-                                                onMetadataSelected={
-                                                    onMetadataSelected
-                                                }
-                                                onPublicLinksSelected={
-                                                    onPublicLinksSelected
-                                                }
-                                            />
-                                        </TableCell>
+                                        {rowDotMenuVisibility && (
+                                            <TableCell align="right">
+                                                <RowDotMenu
+                                                    baseId={build(
+                                                        tableId,
+                                                        resourceName
+                                                    )}
+                                                    onDetailsSelected={
+                                                        onDetailsSelected
+                                                    }
+                                                    onDeleteSelected={() =>
+                                                        onDeleteSelected(
+                                                            resourceId
+                                                        )
+                                                    }
+                                                    resource={resource}
+                                                    setSharingDlgOpen={
+                                                        setSharingDlgOpen
+                                                    }
+                                                    onMetadataSelected={
+                                                        onMetadataSelected
+                                                    }
+                                                    onPublicLinksSelected={
+                                                        onPublicLinksSelected
+                                                    }
+                                                />
+                                            </TableCell>
+                                        )}
                                     </DERow>
                                 );
                             })}

--- a/src/components/data/toolbar/Toolbar.js
+++ b/src/components/data/toolbar/Toolbar.js
@@ -63,6 +63,7 @@ function DataToolbar(props) {
         setSharingDlgOpen,
         onMetadataSelected,
         onPublicLinksSelected,
+        toolbarVisibility,
     } = props;
 
     const { t } = useTranslation("data");
@@ -87,104 +88,108 @@ function DataToolbar(props) {
                 baseId={toolbarId}
             />
             <div className={classes.divider} />
-            <Hidden smDown>
-                {detailsEnabled && (
-                    <Button
-                        id={build(toolbarId, ids.DETAILS_BTN)}
-                        variant="outlined"
-                        size="small"
-                        disableElevation
-                        color="primary"
-                        onClick={onDetailsSelected}
-                        className={classes.button}
-                        startIcon={<Info />}
-                    >
-                        <Hidden xsDown>{t("details")}</Hidden>
-                    </Button>
-                )}
-                {isWritable(permission) && (
-                    <>
-                        <Button
-                            id={build(toolbarId, ids.CREATE_BTN)}
-                            variant="outlined"
-                            size="small"
-                            disableElevation
-                            color="primary"
-                            onClick={onCreateFolderClicked}
-                            className={classes.button}
-                            startIcon={<CreateNewFolder />}
-                        >
-                            <Hidden xsDown>{t("folder")}</Hidden>
-                        </Button>
-                        <UploadMenuBtn
+            {toolbarVisibility && (
+                <>
+                    <Hidden smDown>
+                        {detailsEnabled && (
+                            <Button
+                                id={build(toolbarId, ids.DETAILS_BTN)}
+                                variant="outlined"
+                                size="small"
+                                disableElevation
+                                color="primary"
+                                onClick={onDetailsSelected}
+                                className={classes.button}
+                                startIcon={<Info />}
+                            >
+                                <Hidden xsDown>{t("details")}</Hidden>
+                            </Button>
+                        )}
+                        {isWritable(permission) && (
+                            <>
+                                <Button
+                                    id={build(toolbarId, ids.CREATE_BTN)}
+                                    variant="outlined"
+                                    size="small"
+                                    disableElevation
+                                    color="primary"
+                                    onClick={onCreateFolderClicked}
+                                    className={classes.button}
+                                    startIcon={<CreateNewFolder />}
+                                >
+                                    <Hidden xsDown>{t("folder")}</Hidden>
+                                </Button>
+                                <UploadMenuBtn
+                                    uploadMenuId={uploadMenuId}
+                                    localUploadId={localUploadId}
+                                    path={path}
+                                    setUploadDialogOpen={setUploadDialogOpen}
+                                    setImportDialogOpen={setImportDialogOpen}
+                                />
+                            </>
+                        )}
+                        {selected && selected.length > 0 && (
+                            <Button
+                                id={build(toolbarId, ids.ADD_TO_BAG_BTN)}
+                                variant="outlined"
+                                size="small"
+                                disableElevation
+                                color="primary"
+                                onClick={onAddToBagSelected}
+                                startIcon={<AddToBagIcon />}
+                            >
+                                <Hidden xsDown>{t("addToBag")}</Hidden>
+                            </Button>
+                        )}
+                        {canShare && (
+                            <SharingButton
+                                size="small"
+                                baseId={toolbarId}
+                                setSharingDlgOpen={setSharingDlgOpen}
+                            />
+                        )}
+                    </Hidden>
+
+                    {hasDotMenu && (
+                        <DataDotMenu
+                            baseId={toolbarId}
+                            path={path}
+                            onDeleteSelected={onDeleteSelected}
+                            onCreateFolderSelected={onCreateFolderClicked}
+                            onDetailsSelected={onDetailsSelected}
+                            onAddToBagSelected={onAddToBagSelected}
+                            permission={permission}
+                            refreshListing={refreshListing}
+                            detailsEnabled={detailsEnabled}
                             uploadMenuId={uploadMenuId}
                             localUploadId={localUploadId}
-                            path={path}
                             setUploadDialogOpen={setUploadDialogOpen}
                             setImportDialogOpen={setImportDialogOpen}
+                            getSelectedResources={getSelectedResources}
+                            selected={selected}
+                            onCreateHTFileSelected={onCreateHTFileSelected}
+                            onCreateMultiInputFileSelected={
+                                onCreateMultiInputFileSelected
+                            }
+                            canShare={canShare}
+                            setSharingDlgOpen={setSharingDlgOpen}
+                            isSmall={isSmall}
+                            onMetadataSelected={onMetadataSelected}
+                            onPublicLinksSelected={onPublicLinksSelected}
                         />
-                    </>
-                )}
-                {selected && selected.length > 0 && (
-                    <Button
-                        id={build(toolbarId, ids.ADD_TO_BAG_BTN)}
-                        variant="outlined"
-                        size="small"
-                        disableElevation
-                        color="primary"
-                        onClick={onAddToBagSelected}
-                        startIcon={<AddToBagIcon />}
-                    >
-                        <Hidden xsDown>{t("addToBag")}</Hidden>
-                    </Button>
-                )}
-                {canShare && (
-                    <SharingButton
-                        size="small"
-                        baseId={toolbarId}
-                        setSharingDlgOpen={setSharingDlgOpen}
+                    )}
+
+                    <CreateFolderDialog
+                        path={path}
+                        open={createFolderDlgOpen}
+                        onClose={onCreateFolderDlgClose}
+                        onFolderCreated={() => {
+                            onCreateFolderDlgClose();
+                            refreshListing();
+                        }}
                     />
-                )}
-            </Hidden>
-
-            {hasDotMenu && (
-                <DataDotMenu
-                    baseId={toolbarId}
-                    path={path}
-                    onDeleteSelected={onDeleteSelected}
-                    onCreateFolderSelected={onCreateFolderClicked}
-                    onDetailsSelected={onDetailsSelected}
-                    onAddToBagSelected={onAddToBagSelected}
-                    permission={permission}
-                    refreshListing={refreshListing}
-                    detailsEnabled={detailsEnabled}
-                    uploadMenuId={uploadMenuId}
-                    localUploadId={localUploadId}
-                    setUploadDialogOpen={setUploadDialogOpen}
-                    setImportDialogOpen={setImportDialogOpen}
-                    getSelectedResources={getSelectedResources}
-                    selected={selected}
-                    onCreateHTFileSelected={onCreateHTFileSelected}
-                    onCreateMultiInputFileSelected={
-                        onCreateMultiInputFileSelected
-                    }
-                    canShare={canShare}
-                    setSharingDlgOpen={setSharingDlgOpen}
-                    isSmall={isSmall}
-                    onMetadataSelected={onMetadataSelected}
-                    onPublicLinksSelected={onPublicLinksSelected}
-                />
+                </>
             )}
-
-            <CreateFolderDialog
-                path={path}
-                open={createFolderDlgOpen}
-                onClose={onCreateFolderDlgClose}
-                onFolderCreated={() => {
-                    onCreateFolderDlgClose();
-                    refreshListing();
-                }}
-            />
         </Toolbar>
     );
 }


### PR DESCRIPTION
- Remove toolbar actions and row level dot menu from Selection Drawer.
- Styling improvement
- Valid Selection
  Prod:
![image](https://user-images.githubusercontent.com/1250790/103017718-06ed5880-456a-11eb-9cf6-4b8fd278b094.png)

This PR:
Now the drawer is clutter and distraction free. Also  found that selecting `Metadata` or `New HT analysis path list file (or Multi-Input)` from the selection drawer throws errors in prod. So I think getting rid of these actions from here is step in the right direction. We can look into adding upload option based on user feedback. 
![image](https://user-images.githubusercontent.com/1250790/103017550-c988cb00-4569-11eb-8ae7-1f7c1abcd032.png)

- invalid Selection
Prod:
![image](https://user-images.githubusercontent.com/1250790/103017806-21bfcd00-456a-11eb-8dd2-7a0bcec71ee3.png)

This PR:
![image](https://user-images.githubusercontent.com/1250790/103017593-d6a5ba00-4569-11eb-9f26-4f56579c4bc7.png)

