### PR TITLE
Add mathematica syntax highlighting

### DIFF
--- a/src/components/models/MimeTypes.js
+++ b/src/components/models/MimeTypes.js
@@ -16,6 +16,7 @@ const mimeTypes = {
     X_RSRC: "x-rsrc",
     X_PYTHON: "x-python",
     X_WEB_MARKDOWN: "x-web-markdown",
+    MATHEMATICA: "mathematica",
 };
 const getViewerMode = (mimeType) => {
     let mode = null;
@@ -34,6 +35,9 @@ const getViewerMode = (mimeType) => {
             break;
         case mimeTypes.X_WEB_MARKDOWN:
             mode = "markdown";
+            break;
+        case mimeTypes.MATHEMATICA:
+            mode = "mathematica";
             break;
         default:
             break;


### PR DESCRIPTION
Silly and small. Was looking at a bundle analysis and mathematica is the second-largest language in the highlight.js code, so on a whim I decided to see if Tika detects it, and it does. So I added it here. Now mathematica files have syntax highlighting. Woo.