### PR TITLE
CORE-1225 Fix analysis submissions with empty file/folder inputs

### DIFF
--- a/src/components/apps/launch/AppLaunchForm.js
+++ b/src/components/apps/launch/AppLaunchForm.js
@@ -481,6 +481,9 @@ const paramConfigsReducer = (configs, group) => {
                 case constants.PARAM_TYPE.TEXT_SELECTION:
                 case constants.PARAM_TYPE.INTEGER_SELECTION:
                 case constants.PARAM_TYPE.DOUBLE_SELECTION:
+                case constants.PARAM_TYPE.FILE_INPUT:
+                case constants.PARAM_TYPE.FOLDER_INPUT:
+                case constants.PARAM_TYPE.FILE_FOLDER_INPUT:
                 case constants.PARAM_TYPE.REFERENCE_GENOME:
                 case constants.PARAM_TYPE.REFERENCE_SEQUENCE:
                 case constants.PARAM_TYPE.REFERENCE_ANNOTATION:


### PR DESCRIPTION
Currently the relaunch endpoint will return an error for submissions with empty strings for optional file/folder inputs.

This will fix the app launch form to no longer submit empty strings for file and folder inputs.