### PR TITLE
Low-hanging-fruit syntax highlighting

### DIFF
--- a/src/components/models/MimeTypes.js
+++ b/src/components/models/MimeTypes.js
@@ -2,14 +2,17 @@ const mimeTypes = {
     PNG: "png",
     GIF: "gif",
     JPEG: "jpeg",
+
     MP4: "mp4",
     OGG: "ogg",
     WEBM: "webm",
+
     PDF: "pdf",
     PLAIN: "plain",
     HTML: "html",
     XHTML_XML: "xhtml+xml",
     PREVIEW: "preview",
+
     X_SH: "x-sh",
     VIZ: "viz",
     X_PERL: "x-perl",

--- a/src/components/models/MimeTypes.js
+++ b/src/components/models/MimeTypes.js
@@ -1,49 +1,161 @@
 const mimeTypes = {
+    // Images
     PNG: "png",
     GIF: "gif",
     JPEG: "jpeg",
 
+    // Video
     MP4: "mp4",
     OGG: "ogg",
     WEBM: "webm",
 
+    // DocumentViewer types
     PDF: "pdf",
     PLAIN: "plain",
     HTML: "html",
     XHTML_XML: "xhtml+xml",
     PREVIEW: "preview",
 
+    // More common scientific languages
+    X_AWK: "x-awk",
     X_SH: "x-sh",
-    VIZ: "viz",
     X_PERL: "x-perl",
-    X_RSRC: "x-rsrc",
+    X_RSRC: "x-rsrc", // R
     X_PYTHON: "x-python",
-    X_WEB_MARKDOWN: "x-web-markdown",
+    X_CSRC: "x-csrc", // C
+    X_CPPSRC: "x-c++src", // C++
+    X_FORTRAN: "x-fortran",
     MATHEMATICA: "mathematica",
+    X_MATLAB: "x-matlab",
+    X_RUBY: "x-ruby",
+    X_SAS: "x-sas",
+    VIZ: "viz", // not sure what this is
+
+    // Markup & web languages
+    X_WEB_MARKDOWN: "x-web-markdown",
+    X_ASCIIDOC: "x-asciidoc",
+    CSS: "css",
+    X_HAML: "x-haml",
+    JAVASCRIPT: "javascript",
+    JSON: "json",
+    X_LATEX: "x-latex",
+    X_TEX: "x-tex",
+    XML: "xml",
+    X_YAML: "x-yaml",
+
+    // long-tail languages
+    X_ACTIONSCRIPT: "x-actionscript",
+    X_ADA: "x-ada",
+    X_APPLESCRIPT: "x-applescript",
+    X_ASPECTJ: "x-aspectj",
+    X_BASIC: "x-basic",
+    X_CLOJURE: "x-clojure",
+    X_COFFEESCRIPT: "x-coffeescript",
+    X_CSHARP: "x-csharp",
+    X_D: "x-d",
+    DIFF: "x-diff",
+    BATCH: "x-bat", // windows/dos batch file
+    X_ERLANG: "x-erlang",
+    X_GO: "x-go",
+    X_GROOVY: "x-groovy",
+    X_HASKELL: "x-haskell",
+    X_HAXE: "x-haxe",
+    X_INI: "x-ini", // also TOML, but we can't detect that right now
+    X_JAVA_SOURCE: "x-java-source",
+    X_JAVA_PROPERTIES: "x-java-properties",
+    X_COMMON_LISP: "x-common-lisp",
+    X_LUA: "x-lua",
+    X_MAKEFILE: "x-makefile",
+    X_OBJCSRC: "x-objcsrc", // Objective-C
+    X_OCAML: "x-ocaml",
+    X_PHP: "x-php",
+    X_PROLOG: "x-prolog",
+    X_SCALA: "x-scala",
+    X_SCHEME: "x-scheme",
+    X_STSRC: "x-stsrc", // Smalltalk
+    X_SQL: "x-sql",
+    X_TCL: "x-tcl",
+    X_VBDOTNET: "x-vbdotnet",
+    X_VERILOG: "x-verilog",
+    X_VHDL: "x-vhdl",
+    XQUERY: "xquery",
 };
 const getViewerMode = (mimeType) => {
+    // modes whose mime types are the same string
+    const identicalModes = [
+        "css",
+        "javascript",
+        "json",
+        "mathematica",
+        "xml",
+        "xquery",
+    ];
+    // modes whose mime types are the mode name with an x- prefix
+    const xModes = [
+        "actionscript",
+        "ada",
+        "applescript",
+        "asciidoc",
+        "aspectj",
+        "awk",
+        "basic",
+        "clojure",
+        "coffeescript",
+        "csharp",
+        "d",
+        "diff",
+        "erlang",
+        "fortran",
+        "go",
+        "groovy",
+        "haml",
+        "haskell",
+        "haxe",
+        "ini",
+        "latex",
+        "lua",
+        "makefile",
+        "matlab",
+        "ocaml",
+        "perl",
+        "php",
+        "prolog",
+        "python",
+        "ruby",
+        "sas",
+        "scala",
+        "scheme",
+        "sql",
+        "tcl",
+        "vbscript",
+        "verilog",
+        "vhdl",
+        "yaml",
+    ];
+    // modes that don't fit into nice mappings like above
+    const modeMap = {
+        "x-csrc": "c",
+        "x-c++src": "cpp",
+        "x-bat": "dos",
+        "x-java-source": "java",
+        "x-java-properties": "properties",
+        "x-tex": "latex",
+        "x-common-lisp": "lisp",
+        "x-objcsrc": "objectivec",
+        "x-sh": "shell",
+        "x-stsrc": "smalltalk",
+        "x-vbdotnet": "vbnet",
+    };
     let mode = null;
-    switch (mimeType) {
-        case mimeTypes.X_SH:
-            mode = "shell";
-            break;
-        case mimeTypes.X_PYTHON:
-            mode = "python";
-            break;
-        case mimeTypes.X_PERL:
-            mode = "perl";
-            break;
-        case mimeTypes.X_RSRC:
-            mode = "r";
-            break;
-        case mimeTypes.X_WEB_MARKDOWN:
-            mode = "markdown";
-            break;
-        case mimeTypes.MATHEMATICA:
-            mode = "mathematica";
-            break;
-        default:
-            break;
+    if (identicalModes.includes(mimeType)) {
+        mode = mimeType;
+    } else if (
+        mimeType.startsWith("x-") &&
+        xModes.includes(mimeType.slice(2))
+    ) {
+        mode = mimeType.slice(2);
+    } else if (modeMap[mimeType]) {
+        mode = modeMap[mimeType];
     }
     return mode;
 };


### PR DESCRIPTION
This adds a whole bunch of syntax highlighting languages. My other PR, needing UX work, isn't going out super immediately, but these are the easy ones to add (and we'll want both things anyway). I changed how the mode detection code works since now there's a lot more in the list and the switch seemed like it would be quite unwieldy. I haven't tested all of these, but I've tested at least one in each category (exact mimetype -> mode, exact except for the x- prefix, and completely custom mapping).