### PR TITLE
Disable news and events in the dashboard.

### DIFF
--- a/src/components/dashboard/index.js
+++ b/src/components/dashboard/index.js
@@ -22,8 +22,8 @@ import * as constants from "./constants";
 import useStyles from "./styles";
 import * as fns from "./functions";
 import {
-    NewsFeed,
-    EventsFeed,
+    // NewsFeed,
+    // EventsFeed,
     RecentlyUsedApps,
     PublicApps,
     RecentAnalyses,
@@ -114,8 +114,8 @@ const Dashboard = (props) => {
     const [detailsAnalysis, setDetailsAnalysis] = useState(null);
 
     let sections = [
-        new NewsFeed(),
-        new EventsFeed(),
+        // new NewsFeed(),
+        // new EventsFeed(),
         new VideosFeed(),
         new PublicApps(),
     ];
@@ -126,8 +126,8 @@ const Dashboard = (props) => {
             new RunningAnalyses(),
             new RecentlyUsedApps(),
             new PublicApps(),
-            new NewsFeed(),
-            new EventsFeed(),
+            // new NewsFeed(),
+            // new EventsFeed(),
             new VideosFeed(),
         ];
     }


### PR DESCRIPTION
The RSS feeds on the webiste haven't updated recently, so these sections are very out of date.

They're just commented out for now, since hopefully we'll be able to bring them back in the future. 