### PR TITLE
Update team icons

### DIFF
--- a/src/components/teams/Icons.js
+++ b/src/components/teams/Icons.js
@@ -5,12 +5,12 @@
  */
 
 import React from "react";
-import { Group, GroupAdd } from "@material-ui/icons";
+import { GroupAddOutlined, PeopleAltOutlined } from "@material-ui/icons";
 
 export function TeamIcon(props) {
-    return <Group {...props} />;
+    return <PeopleAltOutlined {...props} />;
 }
 
 export function AddTeamIcon(props) {
-    return <GroupAdd {...props} />;
+    return <GroupAddOutlined {...props} />;
 }


### PR DESCRIPTION
Almost forgot about this change. Switching to outlined versions to look less like the Admin icon

<img width="953" alt="image" src="https://user-images.githubusercontent.com/8909156/107826261-dc39a800-6d41-11eb-8a54-780b2ecfa243.png">
