### PR TITLE
Merge namespacesRequired into pageProps

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -268,5 +268,15 @@ MyApp.getInitialProps = async ({ Component, ctx }) => {
         pageProps = await Component.getInitialProps(ctx);
     }
 
-    return { pageProps, namespacesRequired: ["common"] };
+    // merge the two always-needed namespaces into the pageProps namespacesRequired array
+    return {
+        pageProps: {
+            ...pageProps,
+            namespacesRequired: [
+                ...pageProps?.namespacesRequired,
+                "common",
+                "bags",
+            ],
+        },
+    };
 };


### PR DESCRIPTION
I think this prevents the "prop title doesn't match" thing that's been a bit maddening for me for a little bit here. This makes sure that a.) `bags` are in the default list, since they're used in the AppBar and appear everywhere, and b.) that those are merged into the `pageProps`, not isolated out somewhere separate that I'm not sure is used.

Would appreciate someone checking my work that this is, in fact, the right thing to do. next-i18next doesn't seem to be very well-documented, but I might well be missing something.