### PR TITLE
Prevent errors when pageProps.namespacesRequired isn't present

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -273,7 +273,7 @@ MyApp.getInitialProps = async ({ Component, ctx }) => {
         pageProps: {
             ...pageProps,
             namespacesRequired: [
-                ...pageProps?.namespacesRequired,
+                ...(pageProps?.namespacesRequired ?? []),
                 "common",
                 "bags",
             ],


### PR DESCRIPTION
This fixes the `TypeError: undefined is not iterable` caused by my #294 fix. I can't get apps pages to load (so I can't create an analysis to relaunch), but I tested this with the settings page, which is another that doesn't have any required namespaces defined.