### PR TITLE
Add new, non-admin VICE API calls for loading page

### DIFF
--- a/src/server/api/vice.js
+++ b/src/server/api/vice.js
@@ -148,7 +148,7 @@ export default function viceRouter() {
         })
     );
 
-    logger.info("adding the GET /vice/listing handler");
+    logger.info("adding the GET /vice/resources handler");
     api.get(
         "/vice/resources",
         auth.authnTokenMiddleware,

--- a/src/server/api/vice.js
+++ b/src/server/api/vice.js
@@ -148,5 +148,35 @@ export default function viceRouter() {
         })
     );
 
+    logger.info("adding the GET /vice/listing handler");
+    api.get(
+        "/vice/resources",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "GET",
+            pathname: "/vice/resources",
+        })
+    );
+
+    logger.info("adding the GET /vice/:host/description handler");
+    api.get(
+        "/vice/:host/description",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "GET",
+            pathname: "/vice/:host/description",
+        })
+    );
+
+    logger.info("adding the GET /vice/:host/url-ready handler");
+    api.get(
+        "/vice/:host/url-ready",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "GET",
+            pathname: "/vice/:host/url-ready",
+        })
+    );
+
     return api;
 }


### PR DESCRIPTION
Requires the following PRs be merged:
* https://github.com/cyverse-de/terrain/pull/202
* https://github.com/cyverse-de/app-exposer/pull/18

Contains the following changes.

* Adds GET /vice/resources which returns a filtered VICE analysis listing for the logged in user.
* Adds GET /vice/:host/description which returns a VICE analysis listing entry for the analysis associated with :host. Access permission for the logged in user is checked.
* Adds GET /vice/:host/url-ready which returns whether or not the VICE analysis associated with :host is ready for access by browsers. Access permission for the logged in user is checked.