### PR TITLE
CORE-1321 Markdown support for App Info text

### DIFF
--- a/src/components/apps/details/AppDoc.js
+++ b/src/components/apps/details/AppDoc.js
@@ -5,7 +5,7 @@
 
 import React, { useEffect, useState } from "react";
 import { useQuery, useMutation } from "react-query";
-import sanitizeHtml from "sanitize-html";
+
 import { useTranslation } from "i18n";
 
 import { build as buildDebugId } from "@cyverse-de/ui-lib";
@@ -24,6 +24,8 @@ import {
 import ErrorTypographyWithDialog from "components/utils/error/ErrorTypographyWithDialog";
 import GridLoading from "components/utils/GridLoading";
 import ConfirmationDialog from "components/utils/ConfirmationDialog";
+import markdownToHtml from "components/utils/markdownToHtml";
+
 import {
     CircularProgress,
     Dialog,
@@ -81,16 +83,9 @@ function Documentation(props) {
     const { t } = useTranslation("apps");
 
     useEffect(() => {
-        const regenerateMarkdown = async (documentation) => {
-            const showdown = (await import("showdown")).default;
-            const converter = new showdown.Converter();
-            converter.setFlavor("github");
-            setHtmlDocumentation(
-                sanitizeHtml(converter.makeHtml(documentation))
-            );
-        };
-
-        regenerateMarkdown(documentation);
+        markdownToHtml(documentation).then((html) => {
+            setHtmlDocumentation(html);
+        });
     }, [documentation]);
 
     if (loading) {

--- a/src/components/apps/launch/params/Info.js
+++ b/src/components/apps/launch/params/Info.js
@@ -5,18 +5,26 @@
  */
 import React from "react";
 
-import sanitizeHtml from "sanitize-html";
+import markdownToHtml from "components/utils/markdownToHtml";
 
 import { Typography } from "@material-ui/core";
 
 export default function Info({ param, ...props }) {
+    const [infoHtml, setInfoHtml] = React.useState("");
+
+    React.useEffect(() => {
+        if (param?.label) {
+            markdownToHtml(param.label).then((html) => setInfoHtml(html));
+        } else {
+            setInfoHtml("");
+        }
+    }, [param]);
+
     return (
         <Typography
             gutterBottom
             variant="body1"
-            dangerouslySetInnerHTML={{
-                __html: sanitizeHtml(param?.label),
-            }}
+            dangerouslySetInnerHTML={{ __html: infoHtml }}
             {...props}
         />
     );

--- a/src/components/utils/markdownToHtml.js
+++ b/src/components/utils/markdownToHtml.js
@@ -1,0 +1,24 @@
+/**
+ * @author ianmcorvidae, psarando
+ */
+import sanitizeHtml from "sanitize-html";
+
+/**
+ * This promise will take raw markdown as a string,
+ * sanitize any HTML tags already included in the raw string,
+ * then resolve the final HTML rendered from the sanitized markdown.
+ *
+ * @param {string} rawMarkdown The raw markdown to sanitize and render as HTML.
+ * @returns {Promise} A Promise whose fulfillment value is the sanitized,
+ *                    raw HTML string.
+ */
+const markdownToHtml = async (rawMarkdown) => {
+    const showdown = (await import("showdown")).default;
+
+    const converter = new showdown.Converter();
+    converter.setFlavor("github");
+
+    return converter.makeHtml(sanitizeHtml(rawMarkdown));
+};
+
+export default markdownToHtml;

--- a/stories/apps/AppDescriptionMocks.js
+++ b/stories/apps/AppDescriptionMocks.js
@@ -109,7 +109,8 @@ export const AppDescriptionMock = {
                     type: "Info",
                     omit_if_blank: false,
                     validators: [],
-                    label: "<h4>Info Text!</h4>\nDoes <b>HTML</b> display?",
+                    label:
+                        "<h4>Info Text!</h4>\nDoes <b>HTML</b> display?\n:sparkles: `Markdown` **now** _supported_ :tada:",
                     id: "177d78f6-5a83-11ea-9e38-008cfa5ae621",
                     order: 0,
                     isVisible: true,

--- a/stories/apps/launch/data/KitchenSinkApp.js
+++ b/stories/apps/launch/data/KitchenSinkApp.js
@@ -96,7 +96,8 @@ export default {
                     name: "",
                     type: "Info",
                     validators: [],
-                    label: "<h4>Info Text!</h4>\nDoes <b>HTML</b> display?",
+                    label:
+                        "<h4>Info Text!</h4>\nDoes <b>HTML</b> display?\n:sparkles: `Markdown` **now** _supported_ :tada:",
                     id:
                         "17794ff6-5a83-11ea-9e38-008cfa5ae621_177d78f6-5a83-11ea-9e38-008cfa5ae621",
                     isVisible: true,


### PR DESCRIPTION
This PR refactors the `AppDoc` Markdown support into a common util function that can also be used by App Info text parameters, so that App integrators can write in Markdown and the App Launch form will display it as sanitized HTML.

![Info param editor with Markdown support](https://user-images.githubusercontent.com/996408/113373789-79679480-9320-11eb-8b92-8549bfcc9b11.png)