### PR TITLE
CORE-702 Add apps create and edit pages

### DIFF
--- a/public/static/locales/en/apps.json
+++ b/public/static/locales/en/apps.json
@@ -28,6 +28,7 @@
     "comments": "Comments",
     "commentsNotSupported": "Comments not supported for external apps!",
     "copyAppUrl": "Copy App URL",
+    "create": "Create",
     "createQuickLaunchLabel": "Create Quick Launch",
     "declineAuthBtnText": "Not Now",
     "defaultLabel": "Default",

--- a/src/common/NavigationConstants.js
+++ b/src/common/NavigationConstants.js
@@ -15,6 +15,7 @@ export default {
     LOGIN: "login",
     LOGOUT: "logout",
     MORE: "more",
+    NEW_APP: "apps/create",
     NOTIFICATIONS: "notifications",
     NOTIFICATION_WS: "/websocket/notifications",
     REF_GENOMES: "refgenomes",

--- a/src/components/apps/editor/ParamGroups.js
+++ b/src/components/apps/editor/ParamGroups.js
@@ -30,6 +30,7 @@ import {
     Card,
     CardActions,
     CardContent,
+    Grid,
     Typography,
     makeStyles,
 } from "@material-ui/core";
@@ -74,23 +75,23 @@ function ParamGroupForm(props) {
                     <ExpandMore className={classes.paramsViewsExpandIcon} />
                 }
             >
-                <Typography className={classes.flex} variant="subtitle2">
-                    {group.label}
-                </Typography>
-                <ParamLayoutActions
-                    baseId={groupBaseId}
-                    ButtonProps={{
-                        color: "primary",
-                        variant: "contained",
-                        onFocus: (event) => event.stopPropagation(),
-                        onClick: (event) => event.stopPropagation(),
-                    }}
-                    DotMenuButtonProps={{ color: "inherit" }}
-                    onMoveUp={onMoveUp}
-                    onMoveDown={onMoveDown}
-                    onEdit={() => onEdit(fieldName)}
-                    onDelete={onDelete}
-                />
+                <Grid container justify="space-between">
+                    <Typography variant="subtitle2">{group.label}</Typography>
+                    <ParamLayoutActions
+                        baseId={groupBaseId}
+                        ButtonProps={{
+                            color: "primary",
+                            variant: "contained",
+                            onFocus: (event) => event.stopPropagation(),
+                            onClick: (event) => event.stopPropagation(),
+                        }}
+                        DotMenuButtonProps={{ color: "inherit" }}
+                        onMoveUp={onMoveUp}
+                        onMoveDown={onMoveDown}
+                        onEdit={() => onEdit(fieldName)}
+                        onDelete={onDelete}
+                    />
+                </Grid>
             </AccordionSummary>
             <AccordionDetails className={classes.accordionDetails}>
                 <Parameters

--- a/src/components/apps/editor/formatters.js
+++ b/src/components/apps/editor/formatters.js
@@ -37,7 +37,7 @@ import FileInfoTypes from "components/models/FileInfoTypes";
  * @returns Initial form values.
  */
 const initAppValues = (app) => {
-    const { groups } = app;
+    const groups = app?.groups;
 
     const initializedGroups = groups?.map(({ name, ...group }, groupIndex) => ({
         ...group,

--- a/src/components/apps/editor/index.js
+++ b/src/components/apps/editor/index.js
@@ -6,6 +6,7 @@
 import React from "react";
 
 import { Formik } from "formik";
+import { useRouter } from "next/router";
 import { useMutation } from "react-query";
 
 import { useTranslation } from "i18n";
@@ -23,6 +24,9 @@ import ParametersPreview from "./ParametersPreview";
 import AppStepper, { StepperSkeleton } from "../AppStepper";
 import AppStepDisplay, { BottomNavigationSkeleton } from "../AppStepDisplay";
 
+import { getAppEditPath } from "../utils";
+
+import BackButton from "components/utils/BackButton";
 import ComingSoonInfo from "components/utils/ComingSoonInfo";
 import SaveButton from "components/utils/SaveButton";
 import WrappedErrorHandler from "components/utils/error/WrappedErrorHandler";
@@ -42,9 +46,9 @@ import {
 import {
     Button,
     ButtonGroup,
+    Grid,
     makeStyles,
     Paper,
-    Toolbar,
     Typography,
     useTheme,
     useMediaQuery,
@@ -143,7 +147,7 @@ const AppEditor = (props) => {
 
     const { t } = useTranslation(["app_editor", "app_editor_help", "common"]);
     const classes = useStyles();
-
+    const router = useRouter();
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down("xs"));
 
@@ -235,6 +239,11 @@ const AppEditor = (props) => {
                 const app = formatSubmission(values);
 
                 const onSuccess = (app) => {
+                    if (!values.id) {
+                        // A new app was saved, so update address to new URL
+                        router.replace(getAppEditPath(app.system_id, app.id));
+                    }
+
                     // Note that enableReinitialize should not be used when
                     // using resetForm with new values.
                     actions.resetForm({ values: initAppValues(app) });
@@ -265,9 +274,16 @@ const AppEditor = (props) => {
                 const saveDisabled = isSubmitting || !dirty || errors.error;
 
                 return (
-                    <Paper ref={scrollOnEditEl}>
-                        <Toolbar>
-                            <Typography variant="h6" className={classes.flex}>
+                    <Paper className={classes.formContainer}>
+                        <Grid
+                            ref={scrollOnEditEl}
+                            container
+                            justify="space-between"
+                            alignItems="flex-start"
+                            wrap="nowrap"
+                        >
+                            <BackButton />
+                            <Typography variant="h6">
                                 {t(values.id ? "editApp" : "createApp", {
                                     name: values.name,
                                 })}
@@ -278,7 +294,8 @@ const AppEditor = (props) => {
                                 disabled={saveDisabled}
                                 onSave={handleSubmit}
                             />
-                        </Toolbar>
+                        </Grid>
+
                         {isSubmitting ? (
                             <StepperSkeleton baseId={baseId} ref={stepperRef} />
                         ) : (
@@ -300,6 +317,7 @@ const AppEditor = (props) => {
                                 ref={stepperRef}
                             />
                         )}
+
                         <AppStepDisplay
                             step={activeStep + 1}
                             label={activeStepInfo.contentLabel}

--- a/src/components/apps/editor/styles.js
+++ b/src/components/apps/editor/styles.js
@@ -13,7 +13,11 @@ export default (theme) => ({
         ),
     },
 
-    flex: { flex: 1 },
+    formContainer: {
+        overflow: "auto",
+        height: "100%",
+        padding: theme.spacing(1),
+    },
 
     paramCard: {
         margin: theme.spacing(1, 0),

--- a/src/components/apps/ids.js
+++ b/src/components/apps/ids.js
@@ -10,6 +10,8 @@ export default {
     APP_COMMENTS: "appComments",
     CARD: "card",
     CLOSE_BTN: "closeButton",
+    CREATE_APP_BTN: "createAppButton",
+    CREATE_MENU_ITEM: "createAppMenuItem",
     DIALOG: "dialog",
     APP_QUICK_LAUNCH: "appQuickLaunch",
     LISTING_TABLE: "listingTable",
@@ -53,6 +55,7 @@ export default {
     VIEW_ALL_APPS: "viewAllApps",
     QL_MENU_ITEM: "quickLaunch",
     DOC_MENU_ITEM: "documentation",
+    EDIT_MENU_ITEM: "edit",
     QUICK_LAUNCH: {
         NAME: "name",
         DESCRIPTION: "description",

--- a/src/components/apps/listing/Listing.js
+++ b/src/components/apps/listing/Listing.js
@@ -47,21 +47,22 @@ import { useUserProfile } from "contexts/userProfile";
 import AdminAppDetailsDialog from "../admin/details/AdminAppDetails";
 import { trackIntercomEvent, IntercomEvents } from "common/intercom";
 
-function Listing({
-    baseId,
-    onRouteToApp,
-    onRouteToListing,
-    selectedSystemId,
-    selectedAppId,
-    page,
-    rowsPerPage,
-    order,
-    orderBy,
-    filter,
-    category,
-    showErrorAnnouncer,
-    isAdminView,
-}) {
+function Listing(props) {
+    const {
+        baseId,
+        onRouteToListing,
+        selectedSystemId,
+        selectedAppId,
+        page,
+        rowsPerPage,
+        order,
+        orderBy,
+        filter,
+        category,
+        showErrorAnnouncer,
+        isAdminView,
+    } = props;
+
     const { t } = useTranslation(["apps", "common"]);
     const [isGridView, setGridView] = useState(false);
     const [userProfile] = useUserProfile();
@@ -449,7 +450,6 @@ function Listing({
                 handleCheckboxClick={handleCheckboxClick}
                 handleClick={handleClick}
                 handleRequestSort={handleRequestSort}
-                onRouteToApp={onRouteToApp}
                 canShare={shareEnabled}
                 onDetailsSelected={onDetailsSelected}
                 setSharingDlgOpen={setSharingDlgOpen}

--- a/src/components/apps/listing/RowDotMenu.js
+++ b/src/components/apps/listing/RowDotMenu.js
@@ -8,25 +8,32 @@ import React from "react";
 
 import { build, DotMenu } from "@cyverse-de/ui-lib";
 
-import QLMenuItem from "../menuItems/QLMenuItem";
-import DocMenuItem from "../menuItems/DocMenuItem";
 import ids from "../ids";
+import { isWritable } from "../utils";
 
 import DetailsMenuItem from "../menuItems/DetailsMenuItem";
+import DocMenuItem from "../menuItems/DocMenuItem";
+import EditMenuItem from "../menuItems/EditMenuItem";
+import QLMenuItem from "../menuItems/QLMenuItem";
+
 import SharingMenuItem from "components/sharing/SharingMenuItem";
 import shareIds from "components/sharing/ids";
 
 function RowDotMenu(props) {
     const {
+        app,
         baseId,
         ButtonProps,
-        onDetailsSelected,
         canShare,
         setSharingDlgOpen,
+        onDetailsSelected,
         onDocSelected,
         onQLSelected,
         isAdminView,
     } = props;
+
+    const canEdit = isWritable(app.permission);
+
     return (
         <DotMenu
             baseId={baseId}
@@ -45,6 +52,14 @@ function RowDotMenu(props) {
                             baseId={baseId}
                             onClose={onClose}
                             setSharingDlgOpen={setSharingDlgOpen}
+                        />
+                    ),
+                    canEdit && (
+                        <EditMenuItem
+                            key={build(baseId, ids.EDIT_MENU_ITEM)}
+                            baseId={baseId}
+                            onClose={onClose}
+                            app={app}
                         />
                     ),
                     <DocMenuItem

--- a/src/components/apps/menuItems/EditMenuItem.js
+++ b/src/components/apps/menuItems/EditMenuItem.js
@@ -1,0 +1,34 @@
+import React from "react";
+
+import { useRouter } from "next/router";
+
+import { useTranslation } from "i18n";
+import ids from "../ids";
+import { getAppEditPath } from "../utils";
+
+import { build } from "@cyverse-de/ui-lib";
+
+import { ListItemIcon, ListItemText, MenuItem } from "@material-ui/core";
+import { Edit } from "@material-ui/icons";
+
+export default function EditMenuItem(props) {
+    const { baseId, app, onClose } = props;
+
+    const router = useRouter();
+    const { t } = useTranslation("common");
+
+    return (
+        <MenuItem
+            id={build(baseId, ids.EDIT_MENU_ITEM)}
+            onClick={() => {
+                onClose();
+                router.push(getAppEditPath(app.system_id, app.id));
+            }}
+        >
+            <ListItemIcon>
+                <Edit fontSize="small" />
+            </ListItemIcon>
+            <ListItemText primary={t("edit")} />
+        </MenuItem>
+    );
+}

--- a/src/components/apps/toolbar/AppsDotMenu.js
+++ b/src/components/apps/toolbar/AppsDotMenu.js
@@ -24,6 +24,7 @@ import {
     useTheme,
 } from "@material-ui/core";
 import {
+    Add as CreateAppIcon,
     FilterList,
     Build,
     Info,
@@ -129,15 +130,26 @@ function AppsDotMenu(props) {
                     key={build(baseId, ids.MANAGE_TOOLS_DIVIDER)}
                     id={build(baseId, ids.MANAGE_TOOLS_DIVIDER)}
                 />,
-                <Link href={`${NavigationConstants.TOOLS}`}>
-                    <MenuItem
-                        key={build(baseId, ids.TOOLS_MENU_ITEM)}
-                        id={build(baseId, ids.TOOLS_MENU_ITEM)}
-                    >
+                <Link
+                    key={ids.TOOLS_MENU_ITEM}
+                    href={NavigationConstants.TOOLS}
+                >
+                    <MenuItem id={build(baseId, ids.TOOLS_MENU_ITEM)}>
                         <ListItemIcon>
                             <Build fontSize="small" />
                         </ListItemIcon>
                         <ListItemText primary={t("manageTools")} />
+                    </MenuItem>
+                </Link>,
+                <Link
+                    key={ids.CREATE_MENU_ITEM}
+                    href={NavigationConstants.NEW_APP}
+                >
+                    <MenuItem id={build(baseId, ids.CREATE_MENU_ITEM)}>
+                        <ListItemIcon>
+                            <CreateAppIcon fontSize="small" />
+                        </ListItemIcon>
+                        <ListItemText primary={t("create")} />
                     </MenuItem>
                 </Link>,
             ]}

--- a/src/components/apps/toolbar/Toolbar.js
+++ b/src/components/apps/toolbar/Toolbar.js
@@ -23,6 +23,7 @@ import {
 
 import { makeStyles } from "@material-ui/core/styles";
 import {
+    Add as CreateAppIcon,
     Info,
     Build,
     FilterList as FilterListIcon,
@@ -155,7 +156,7 @@ function AppsToolbar(props) {
                     )}
                 </Hidden>
                 <Hidden xsDown>
-                    <Link href={`${NavigationConstants.TOOLS}`}>
+                    <Link href={NavigationConstants.TOOLS}>
                         <Button
                             id={build(appsToolbarId, ids.TOOLS_BTN)}
                             className={classes.toolbarItems}
@@ -166,6 +167,21 @@ function AppsToolbar(props) {
                             size="small"
                         >
                             {t("manageTools")}
+                        </Button>
+                    </Link>
+                </Hidden>
+                <Hidden xsDown>
+                    <Link href={NavigationConstants.NEW_APP}>
+                        <Button
+                            id={build(appsToolbarId, ids.CREATE_APP_BTN)}
+                            className={classes.toolbarItems}
+                            variant="outlined"
+                            disableElevation
+                            color="primary"
+                            startIcon={<CreateAppIcon />}
+                            size="small"
+                        >
+                            {t("create")}
                         </Button>
                     </Link>
                 </Hidden>

--- a/src/components/apps/utils.js
+++ b/src/components/apps/utils.js
@@ -20,7 +20,9 @@ import Text from "components/apps/launch/params/Text";
 import ReferenceGenomeSelect from "components/apps/launch/ReferenceGenomeSelect";
 
 import AppParamTypes from "components/models/AppParamTypes";
-import Permissions from "components/models/Permissions";
+import Permissions, {
+    permissionHierarchy,
+} from "components/models/Permissions";
 
 /**
  * Builds a path to the App Launch Wizard for the app with the given IDs.
@@ -30,6 +32,15 @@ import Permissions from "components/models/Permissions";
  */
 export const getAppLaunchPath = (systemId, appId) =>
     `/${NavigationConstants.APPS}/${systemId}/${appId}/launch`;
+
+/**
+ * Builds a path to the App Editor for the app with the given IDs.
+ *
+ * @param {string} systemId The app's system ID.
+ * @param {string} appId The app's ID.
+ */
+export const getAppEditPath = (systemId, appId) =>
+    `/${NavigationConstants.APPS}/${systemId}/${appId}/edit`;
 
 /**
  *
@@ -98,6 +109,13 @@ export const canShare = (apps) => {
         apps &&
         apps.length > 0 &&
         !apps.find((app) => app?.permission !== Permissions.OWN)
+    );
+};
+
+export const isWritable = (permission) => {
+    return (
+        permissionHierarchy(permission) >=
+        permissionHierarchy(Permissions.WRITE)
     );
 };
 

--- a/src/components/utils/SignInDialog.js
+++ b/src/components/utils/SignInDialog.js
@@ -7,11 +7,10 @@
 import React from "react";
 
 import DEErrorDialog from "./error/DEErrorDialog";
+import { signInErrorResponse } from "./error/errorCode";
 
 const SignInDialog = (props) => {
-    return (
-        <DEErrorDialog errorObject={{ response: { status: 401 } }} {...props} />
-    );
+    return <DEErrorDialog errorObject={signInErrorResponse} {...props} />;
 };
 
 export default SignInDialog;

--- a/src/components/utils/error/errorCode.js
+++ b/src/components/utils/error/errorCode.js
@@ -13,3 +13,5 @@ export const ERROR_CODES = {
     ERR_LIMIT_REACHED: "ERR_LIMIT_REACHED",
     ERR_PERMISSION_NEEDED: "ERR_PERMISSION_NEEDED",
 };
+
+export const signInErrorResponse = { response: { status: 401 } };

--- a/src/pages/admin/apps.js
+++ b/src/pages/admin/apps.js
@@ -15,7 +15,7 @@ import { getLocalStorage } from "components/utils/localStorage";
 
 import constants from "../../constants";
 import appFields from "components/apps/appFields";
-import { getAppLaunchPath, getListingPath } from "components/apps/utils";
+import { getListingPath } from "components/apps/utils";
 import Listing from "components/apps/listing/Listing";
 import { useUserProfile } from "contexts/userProfile";
 import NotAuthorized from "components/utils/error/NotAuthorized";
@@ -69,9 +69,6 @@ export default function Apps() {
         return (
             <Listing
                 baseId="apps"
-                onRouteToApp={(systemId, appId) =>
-                    router.push(getAppLaunchPath(systemId, appId))
-                }
                 onRouteToListing={onRouteToListing}
                 page={selectedPage}
                 rowsPerPage={selectedRowsPerPage}

--- a/src/pages/apps.js
+++ b/src/pages/apps.js
@@ -15,7 +15,7 @@ import { getLocalStorage } from "components/utils/localStorage";
 
 import constants from "../constants";
 import appFields from "components/apps/appFields";
-import { getAppLaunchPath, getListingPath } from "components/apps/utils";
+import { getListingPath } from "components/apps/utils";
 import Listing from "components/apps/listing/Listing";
 
 export default function Apps() {
@@ -61,9 +61,6 @@ export default function Apps() {
     return (
         <Listing
             baseId="apps"
-            onRouteToApp={(systemId, appId) =>
-                router.push(getAppLaunchPath(systemId, appId))
-            }
             onRouteToListing={onRouteToListing}
             page={selectedPage}
             rowsPerPage={selectedRowsPerPage}

--- a/src/pages/apps/[systemId]/[appId]/edit.js
+++ b/src/pages/apps/[systemId]/[appId]/edit.js
@@ -11,6 +11,9 @@ import { useQuery } from "react-query";
 import AppEditor from "components/apps/editor";
 import ids from "components/apps/editor/ids";
 
+import { signInErrorResponse } from "components/utils/error/errorCode";
+import { useUserProfile } from "contexts/userProfile";
+
 import {
     getAppUI,
     getAppById,
@@ -23,6 +26,8 @@ export default function AppEdit() {
     const [appListingInfo, setAppListingInfo] = React.useState(null);
     const [loadingError, setLoadingError] = React.useState(null);
 
+    const [userProfile] = useUserProfile();
+
     const router = useRouter();
     const { systemId, appId } = router.query;
 
@@ -30,7 +35,7 @@ export default function AppEdit() {
         queryKey: [APP_BY_ID_QUERY_KEY, { systemId, appId }],
         queryFn: getAppById,
         config: {
-            enabled: systemId && appId,
+            enabled: userProfile?.id && systemId && appId,
             onSuccess: (result) => {
                 setAppListingInfo(result?.apps[0]);
             },
@@ -42,11 +47,19 @@ export default function AppEdit() {
         queryKey: [APP_UI_QUERY_KEY, { systemId, appId }],
         queryFn: getAppUI,
         config: {
-            enabled: systemId && appId,
+            enabled: userProfile?.id && systemId && appId,
             onSuccess: setApp,
             onError: setLoadingError,
         },
     });
+
+    React.useEffect(() => {
+        if (userProfile?.id) {
+            setLoadingError(null);
+        } else {
+            setLoadingError(signInErrorResponse);
+        }
+    }, [userProfile]);
 
     const loading = appInfoLoading || isFetching;
     const isPublic = appListingInfo?.is_public;

--- a/src/pages/apps/[systemId]/[appId]/edit.js
+++ b/src/pages/apps/[systemId]/[appId]/edit.js
@@ -1,0 +1,74 @@
+/**
+ * A page for displaying the App Editor for an app with the given IDs.
+ *
+ * @author psarando
+ */
+import React from "react";
+
+import { useRouter } from "next/router";
+import { useQuery } from "react-query";
+
+import AppEditor from "components/apps/editor";
+import ids from "components/apps/editor/ids";
+
+import {
+    getAppUI,
+    getAppById,
+    APP_UI_QUERY_KEY,
+    APP_BY_ID_QUERY_KEY,
+} from "serviceFacades/apps";
+
+export default function AppEdit() {
+    const [app, setApp] = React.useState(null);
+    const [appListingInfo, setAppListingInfo] = React.useState(null);
+    const [loadingError, setLoadingError] = React.useState(null);
+
+    const router = useRouter();
+    const { systemId, appId } = router.query;
+
+    const { isFetching: appInfoLoading } = useQuery({
+        queryKey: [APP_BY_ID_QUERY_KEY, { systemId, appId }],
+        queryFn: getAppById,
+        config: {
+            enabled: systemId && appId,
+            onSuccess: (result) => {
+                setAppListingInfo(result?.apps[0]);
+            },
+            onError: setLoadingError,
+        },
+    });
+
+    const { isFetching } = useQuery({
+        queryKey: [APP_UI_QUERY_KEY, { systemId, appId }],
+        queryFn: getAppUI,
+        config: {
+            enabled: systemId && appId,
+            onSuccess: setApp,
+            onError: setLoadingError,
+        },
+    });
+
+    const loading = appInfoLoading || isFetching;
+    const isPublic = appListingInfo?.is_public;
+
+    return (
+        <AppEditor
+            baseId={ids.APP_EDITOR_VIEW}
+            appDescription={app}
+            loading={loading}
+            loadingError={loadingError}
+            cosmeticOnly={isPublic}
+        />
+    );
+}
+
+AppEdit.getInitialProps = async () => ({
+    namespacesRequired: [
+        "app_editor",
+        "app_editor_help",
+        "app_param_types",
+        "common",
+        "data",
+        "launch",
+    ],
+});

--- a/src/pages/apps/[systemId]/[appId]/index.js
+++ b/src/pages/apps/[systemId]/[appId]/index.js
@@ -12,7 +12,7 @@ import { getLocalStorage } from "components/utils/localStorage";
 
 import constants from "../../../../constants";
 import appFields from "components/apps/appFields";
-import { getAppLaunchPath, getListingPath } from "components/apps/utils";
+import { getListingPath } from "components/apps/utils";
 import Listing from "components/apps/listing/Listing";
 
 /**
@@ -60,9 +60,6 @@ export default function App() {
             baseId="apps"
             selectedSystemId={systemId}
             selectedAppId={appId}
-            onRouteToApp={(systemId, appId) =>
-                router.push(getAppLaunchPath(systemId, appId))
-            }
             onRouteToListing={onRouteToListing}
             page={selectedPage}
             rowsPerPage={selectedRowsPerPage}

--- a/src/pages/apps/[systemId]/[appId]/launch.js
+++ b/src/pages/apps/[systemId]/[appId]/launch.js
@@ -1,7 +1,7 @@
 /**
- * @author psarando
- *
  * A page for displaying the App Launch Wizard for an app with the given IDs.
+ *
+ * @author psarando
  */
 import React from "react";
 

--- a/src/pages/apps/create.js
+++ b/src/pages/apps/create.js
@@ -9,11 +9,27 @@ import AppEditor from "components/apps/editor";
 import NewAppDefaults from "components/apps/editor/NewAppDefaults";
 import ids from "components/apps/editor/ids";
 
+import { signInErrorResponse } from "components/utils/error/errorCode";
+
+import { useUserProfile } from "contexts/userProfile";
+
 export default function AppCreate() {
+    const [userProfile] = useUserProfile();
+    const [loadingError, setLoadingError] = React.useState(null);
+
+    React.useEffect(() => {
+        if (userProfile?.id) {
+            setLoadingError(null);
+        } else {
+            setLoadingError(signInErrorResponse);
+        }
+    }, [userProfile]);
+
     return (
         <AppEditor
             baseId={ids.APP_EDITOR_VIEW}
             appDescription={NewAppDefaults}
+            loadingError={loadingError}
         />
     );
 }

--- a/src/pages/apps/create.js
+++ b/src/pages/apps/create.js
@@ -1,0 +1,30 @@
+/**
+ * A page for displaying the App Editor for creating a new app.
+ *
+ * @author psarando
+ */
+import React from "react";
+
+import AppEditor from "components/apps/editor";
+import NewAppDefaults from "components/apps/editor/NewAppDefaults";
+import ids from "components/apps/editor/ids";
+
+export default function AppCreate() {
+    return (
+        <AppEditor
+            baseId={ids.APP_EDITOR_VIEW}
+            appDescription={NewAppDefaults}
+        />
+    );
+}
+
+AppCreate.getInitialProps = async () => ({
+    namespacesRequired: [
+        "app_editor",
+        "app_editor_help",
+        "app_param_types",
+        "common",
+        "data",
+        "launch",
+    ],
+});

--- a/src/server/api/apps.js
+++ b/src/server/api/apps.js
@@ -147,6 +147,16 @@ export default function appsRouter() {
         })
     );
 
+    logger.info("adding the GET /apps/:systemId/:appId/ui handler");
+    api.get(
+        "/apps/:systemId/:appId/ui",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "GET",
+            pathname: "/apps/:systemId/:appId/ui",
+        })
+    );
+
     logger.info("adding the POST /apps/permission-lister handler");
     api.post(
         "/apps/permission-lister",

--- a/src/serviceFacades/apps.js
+++ b/src/serviceFacades/apps.js
@@ -21,6 +21,7 @@ const APP_CATEGORIES_QUERY_KEY = "fetchPrivateCategories";
 const APPS_SEARCH_QUERY_KEY = "searchApps";
 const APP_BY_ID_QUERY_KEY = "fetchAppById";
 const APP_DOC_QUERY_KEY = "fetchAppDoc";
+const APP_UI_QUERY_KEY = "fetchAppUI";
 
 //ADMIN KEYS
 const ADMIN_APPS_QUERY_KEY = "fetchAllAppsForAdmin";
@@ -235,6 +236,13 @@ function saveAppDoc({ systemId, appId, documentation }) {
     });
 }
 
+function getAppUI(_, { systemId, appId }) {
+    return callApi({
+        endpoint: `/api/apps/${systemId}/${appId}/ui`,
+        method: "GET",
+    });
+}
+
 // start of admin end-points
 function getAppsForAdmin(
     key,
@@ -383,6 +391,7 @@ export {
     getAppDescription,
     getAppDetails,
     getAppPermissions,
+    getAppUI,
     appFavorite,
     rateApp,
     updateApp,
@@ -401,6 +410,7 @@ export {
     APPS_SEARCH_QUERY_KEY,
     APP_BY_ID_QUERY_KEY,
     APP_DOC_QUERY_KEY,
+    APP_UI_QUERY_KEY,
     ADMIN_APPS_QUERY_KEY,
     ADMIN_APP_DETAILS_QUERY_KEY,
     ADMIN_APP_AVU_QUERY_KEY,

--- a/stories/apps/Listing.stories.js
+++ b/stories/apps/Listing.stories.js
@@ -37,9 +37,6 @@ function ListingTest(props) {
             <UserProfileProvider>
                 <Listing
                     baseId="tableView"
-                    onRouteToApp={(systemId, appId) =>
-                        console.log("onRouteToApp", systemId, appId)
-                    }
                     onRouteToListing={(
                         order,
                         orderBy,

--- a/stories/apps/TableView.stories.js
+++ b/stories/apps/TableView.stories.js
@@ -15,9 +15,6 @@ export const AppsTableViewTest = () => {
             baseId="tableView"
             handleSelectAllClick={(event) => logger("Select All Clicked")}
             handleClick={(event, resourceId, index) => logger("Row Clicked")}
-            onRouteToApp={(systemId, appId) =>
-                console.log("onRouteToApp", systemId, appId)
-            }
             selected={[]}
             searchTerm=""
         />


### PR DESCRIPTION
This PR will integrate the App editor view from #308 into nextjs `create` and `edit` pages. When a new app is initially saved, the browser's address bar will update to the `edit` page with the new App's ID.

Some cosmetic changes were added in this PR, since the `Back` button was added, so now the `Back` and `Save` buttons are spaced evenly around the title of the App editor form (either `Create App:` or `Edit App:` followed by the App's name).

![App Editor header buttons, title, and stepper - desktop](https://user-images.githubusercontent.com/996408/113376551-d8300c80-9326-11eb-81bf-38a7f918e31c.png)

---

App Editor header on mobile:
![App Editor header buttons, title, and stepper - desktop](https://user-images.githubusercontent.com/996408/113376598-ef6efa00-9326-11eb-9437-cdd56a8e43a5.png)

---

A `Create` button was added to the Apps listing toolbar (or dot-menu on mobile):
![App Listing toolbar with create button](https://user-images.githubusercontent.com/996408/113377290-bf285b00-9328-11eb-8166-ccfc575d8721.png)

---

The dot-menu on mobile:
![App Listing mobile dot-menu with create button](https://user-images.githubusercontent.com/996408/113376768-57254500-9327-11eb-8f2d-89d6e267d7a5.png)

---

An `Edit` menu item has been added to App listing's row dot-menus:
![App Listing row dot-menu](https://user-images.githubusercontent.com/996408/113376856-9784c300-9327-11eb-8709-215d7f500517.png)
