### PR TITLE
CORE-702 Hide App Editor navigation buttons when editing groups/params

### DIFF
--- a/src/components/apps/editor/ParamGroups.js
+++ b/src/components/apps/editor/ParamGroups.js
@@ -13,10 +13,8 @@ import { useTranslation } from "i18n";
 import ids from "./ids";
 import styles from "./styles";
 
-import GroupPropertyForm from "./GroupPropertyForm";
 import Parameters from "./Parameters";
 import ParamLayoutActions from "./ParamLayoutActions";
-import ParamPropertyForm from "./ParamPropertyForm";
 
 import ConfirmationDialog from "components/utils/ConfirmationDialog";
 
@@ -110,39 +108,26 @@ function ParamGroupForm(props) {
 }
 
 function ParamGroups(props) {
-    const { baseId, values, keyCount, setKeyCount, scrollOnEdit } = props;
+    const {
+        baseId,
+        values,
+        keyCount,
+        setKeyCount,
+        scrollOnEdit,
+        scrollToField,
+        setScrollToField,
+        setEditGroupField,
+        setEditParamField,
+    } = props;
 
     const [confirmDeleteIndex, setConfirmDeleteIndex] = React.useState(-1);
     const onCloseDeleteConfirm = () => setConfirmDeleteIndex(-1);
-
-    const [editGroupField, setEditGroupField] = React.useState();
-    const [editParamField, setEditParamField] = React.useState();
-    const [scrollToField, setScrollToField] = React.useState();
 
     const { t } = useTranslation(["app_editor", "app_editor_help", "common"]);
 
     const groups = getIn(values, "groups");
 
-    return editGroupField ? (
-        <GroupPropertyForm
-            baseId={baseId}
-            fieldName={editGroupField}
-            onDone={() => {
-                setScrollToField(editGroupField);
-                setEditGroupField(null);
-            }}
-        />
-    ) : editParamField ? (
-        <ParamPropertyForm
-            baseId={buildID(baseId, ids.PROPERTY_EDITOR)}
-            onClose={() => {
-                setScrollToField(editParamField);
-                setEditParamField(null);
-            }}
-            fieldName={editParamField}
-            values={values}
-        />
-    ) : (
+    return (
         <FieldArray
             name="groups"
             render={(arrayHelpers) => (

--- a/src/components/apps/editor/index.js
+++ b/src/components/apps/editor/index.js
@@ -18,8 +18,10 @@ import styles from "./styles";
 import AppInfo from "./AppInfo";
 import AppStepperFormSkeleton from "../AppStepperFormSkeleton";
 import CmdLineOrderForm from "./CmdLineOrderForm";
+import GroupPropertyForm from "./GroupPropertyForm";
 import ParamGroups from "./ParamGroups";
 import ParametersPreview from "./ParametersPreview";
+import ParamPropertyForm from "./ParamPropertyForm";
 
 import AppStepper, { StepperSkeleton } from "../AppStepper";
 import AppStepDisplay, { BottomNavigationSkeleton } from "../AppStepDisplay";
@@ -113,6 +115,9 @@ const AppEditor = (props) => {
     } = props;
 
     const [activeStep, setActiveStep] = React.useState(0);
+    const [editGroupField, setEditGroupField] = React.useState();
+    const [editParamField, setEditParamField] = React.useState();
+    const [scrollToField, setScrollToField] = React.useState();
 
     // Keeps track of the next available globally unique
     // `key` count for groups and parameters.
@@ -323,7 +328,9 @@ const AppEditor = (props) => {
                             label={activeStepInfo.contentLabel}
                             bottomOffset={isMobile && stepperHeight}
                             actions={
-                                !isMobile && (
+                                !isMobile &&
+                                !editGroupField &&
+                                !editParamField && (
                                     <StepperNavigation
                                         baseId={buildID(
                                             baseId,
@@ -340,7 +347,9 @@ const AppEditor = (props) => {
                                 isSubmitting ? (
                                     <BottomNavigationSkeleton />
                                 ) : (
-                                    !isMobile && (
+                                    !isMobile &&
+                                    !editGroupField &&
+                                    !editParamField && (
                                         <StepperNavigation
                                             baseId={buildID(
                                                 baseId,
@@ -355,7 +364,29 @@ const AppEditor = (props) => {
                                 )
                             }
                         >
-                            {activeStepInfo === stepAppInfo ? (
+                            {editGroupField ? (
+                                <GroupPropertyForm
+                                    baseId={baseId}
+                                    fieldName={editGroupField}
+                                    onDone={() => {
+                                        setScrollToField(editGroupField);
+                                        setEditGroupField(null);
+                                    }}
+                                />
+                            ) : editParamField ? (
+                                <ParamPropertyForm
+                                    baseId={buildID(
+                                        baseId,
+                                        ids.PROPERTY_EDITOR
+                                    )}
+                                    onClose={() => {
+                                        setScrollToField(editParamField);
+                                        setEditParamField(null);
+                                    }}
+                                    fieldName={editParamField}
+                                    values={values}
+                                />
+                            ) : activeStepInfo === stepAppInfo ? (
                                 <AppInfo baseId={baseId} />
                             ) : activeStepInfo === stepParameters ? (
                                 <ParamGroups
@@ -364,6 +395,10 @@ const AppEditor = (props) => {
                                     keyCount={keyCount}
                                     setKeyCount={setKeyCount}
                                     scrollOnEdit={scrollOnEdit}
+                                    scrollToField={scrollToField}
+                                    setScrollToField={setScrollToField}
+                                    setEditGroupField={setEditGroupField}
+                                    setEditParamField={setEditParamField}
                                 />
                             ) : activeStepInfo === stepPreview ? (
                                 <ParametersPreview


### PR DESCRIPTION
This PR will update the App Editor so that the step navigation buttons are hidden when editing app groups and params.

The simplest way to do this was to refactor the state management of displaying the group and param property editors, out of the groups form, up into the main editor form. That way the navigation buttons can simply be hidden while one of those editors is open.

Here is the App Editor Step 2 when not editing a group or param:
![App Editor - Step 2](https://user-images.githubusercontent.com/996408/114114261-619a8e00-9895-11eb-97ef-3e5781502089.png)

---

Now when editing param properties:
![App Editor - Step 2 - edit param](https://user-images.githubusercontent.com/996408/114114324-83941080-9895-11eb-8d92-89eca93af794.png)

---

And the group label editor:
![App Editor - Step 2 - edit section](https://user-images.githubusercontent.com/996408/114114568-f4d3c380-9895-11eb-84c4-f58148dc9696.png)

---

These changes do no affect the mobile stepper, which is always displayed at the bottom of the screen, on top of everything else.