### PR TITLE
CORE-1369 Fix App Launch form cutoff at page bottom

### DIFF
--- a/src/components/apps/editor/styles.js
+++ b/src/components/apps/editor/styles.js
@@ -14,8 +14,6 @@ export default (theme) => ({
     },
 
     formContainer: {
-        overflow: "auto",
-        height: "100%",
         padding: theme.spacing(1),
     },
 

--- a/src/components/apps/launch/styles.js
+++ b/src/components/apps/launch/styles.js
@@ -14,7 +14,6 @@ export default (theme) => ({
     },
     appInfoTypography: {
         color: theme.palette.info.main,
-        width: "100%",
         margin: theme.spacing(0.5),
         [theme.breakpoints.down("xs")]: {
             margin: theme.spacing(0.3),

--- a/src/components/layout/PageWrapper.js
+++ b/src/components/layout/PageWrapper.js
@@ -24,6 +24,7 @@ function PageWrapper(props) {
             className={classes.wrapper}
             style={{
                 maxHeight: `calc(100vh - ${appBarHeight + theme.spacing(1)}px)`,
+                overflow: "auto",
             }}
         >
             {props.children}


### PR DESCRIPTION
This PR will add an `overflow` style to the `PageWrapper` component that wraps all Sonora page content.

This fixes the App Launch form getting cutoff at the bottom of the page, and doesn't appear to affect appearance of other components using it.

The 100% width style of the `AppInfo` title and description were causing horizontal scrolling with the new `overflow` style, but it appears that style is not needed anyway.

Before:
![Long App Launch form - before CORE-1369](https://user-images.githubusercontent.com/996408/114478974-58226600-9bb4-11eb-9588-5e9006f76fba.png)

---

After (notice the scroll bar now in the bottom right):
![Long App Launch form - after CORE-1369](https://user-images.githubusercontent.com/996408/114479025-6e302680-9bb4-11eb-8c08-d079ef9fea3c.png)
