### PR TITLE
CORE-1378 and CORE-1379 Completed analysis notifications take you to the output folder

### DIFF
--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -1,5 +1,6 @@
 {
     "about": "About",
+    "accessAnalysisOutput": "{{message}}. Access your output files here.",
     "add": "Add",
     "admin": "Admin",
     "all": "All",

--- a/src/components/analyses/utils.js
+++ b/src/components/analyses/utils.js
@@ -223,7 +223,8 @@ const ANALYSIS_TERMINAL_STATES = [
  * @returns {boolean}
  */
 const isTerminated = (analysis) => {
-    return ANALYSIS_TERMINAL_STATES.includes(analysis?.status);
+    const status = analysis?.status || analysis?.analysisstatus;
+    return ANALYSIS_TERMINAL_STATES.includes(status);
 };
 
 export {

--- a/src/components/notifications/Message.js
+++ b/src/components/notifications/Message.js
@@ -70,7 +70,12 @@ function AnalysisLink(props) {
             const resultFolder = payload?.analysisresultsfolder;
             const href = getFolderPage(resultFolder);
 
-            return <MessageLink href={href} message={message} />;
+            return (
+                <MessageLink
+                    href={href}
+                    message={t("accessAnalysisOutput", { message })}
+                />
+            );
         }
 
         const analysisId =

--- a/src/components/notifications/Message.js
+++ b/src/components/notifications/Message.js
@@ -49,12 +49,12 @@ function AnalysisLink(props) {
     const { notification } = props;
     const { t } = useTranslation("common");
     const message = getDisplayMessage(notification);
-    const payload = notification.payload;
-    const action = payload?.action;
+    const analysis = notification.payload;
+    const action = analysis?.action;
 
     const isJobStatusChange = action === "job_status_change";
     const isShare = action === "share";
-    const isComplete = isTerminated(payload);
+    const isComplete = isTerminated(analysis);
 
     if (isShare || isJobStatusChange) {
         const accessUrl = notification.payload.access_url;
@@ -67,7 +67,7 @@ function AnalysisLink(props) {
         }
 
         if (isComplete) {
-            const resultFolder = payload?.analysisresultsfolder;
+            const resultFolder = analysis?.analysisresultsfolder;
             const href = getFolderPage(resultFolder);
 
             return (
@@ -79,19 +79,19 @@ function AnalysisLink(props) {
         }
 
         const analysisId =
-            isShare && payload?.analyses?.length > 0
-                ? payload.analyses[0].analysis_id
-                : isJobStatusChange && payload?.id;
+            isShare && analysis?.analyses?.length > 0
+                ? analysis.analyses[0].analysis_id
+                : isJobStatusChange && analysis?.id;
 
         if (analysisId) {
             const [href, as] = getAnalysisDetailsLinkRefs(analysisId);
 
             const allowRating =
                 isJobStatusChange &&
-                payload?.system_id === systemIds.de &&
-                (payload?.status === analysisStatus.COMPLETED ||
-                    payload?.status === analysisStatus.FAILED ||
-                    payload?.status === analysisStatus.CANCELED);
+                analysis?.system_id === systemIds.de &&
+                (analysis?.status === analysisStatus.COMPLETED ||
+                    analysis?.status === analysisStatus.FAILED ||
+                    analysis?.status === analysisStatus.CANCELED);
 
             return (
                 <>
@@ -99,9 +99,9 @@ function AnalysisLink(props) {
                     <br />
                     {allowRating && (
                         <RatingWidget
-                            appId={payload?.app_id}
-                            appName={payload?.app_name}
-                            systemId={payload?.system_id}
+                            appId={analysis?.app_id}
+                            appName={analysis?.app_name}
+                            systemId={analysis?.system_id}
                         />
                     )}
                 </>


### PR DESCRIPTION
... and the notification message has been updated to say "Access your output files here." similar to the VICE running notification.

NOTE: This is on top of #334, so the first commit can be ignored

Screenshot (I'm hovering over the completed notification and you can see the preview URL in the bottom left is going to the data page)
![image](https://user-images.githubusercontent.com/8909156/116165849-97bb7880-a6b1-11eb-8fda-fff418b25ea4.png)
