### PR TITLE
Switch to a mutation for the instant launch API call.

### DIFF
--- a/src/serviceFacades/instantlaunches.js
+++ b/src/serviceFacades/instantlaunches.js
@@ -215,7 +215,7 @@ export const deleteInstantLaunchHandler = async (id) => {
  * @param {Object} instantLaunch - The instant launch object returned by defaultInstantLaunch().
  * @param {Object} resource - An array of resources to use as inputs to the instantly launched app.
  */
-export const instantlyLaunch = async (instantLaunch, resource) => {
+export const instantlyLaunch = async ({ instantLaunch, resource }) => {
     let qID; // The quick launch ID, used to get app information.
     let qlp; // The promise used to get quick launch information.
 


### PR DESCRIPTION
SSIA.

Very similar to the suggestion @ash3rz made in the PR that added instant launches.

I attempted to simplify the `setOpen(false)` so they were in the `onSettled` handler or in a `try...finally`, but in both cases there was an unacceptable delay between the dialog closing at the `router.push()` call taking effect, leaving the user an opportunity to click around and screw up the flow. Ultimately I ended up leaving things as they are.