### PR TITLE
CORE-1352 Allow App editing for public apps

### DIFF
--- a/public/static/locales/en/app_editor.json
+++ b/public/static/locales/en/app_editor.json
@@ -27,6 +27,8 @@
     "defaultValue": "Default value",
     "doNotPass": "Do not pass this argument to command line.",
     "editApp": "Edit App: {{name}}",
+    "editingPublicApp": "You are editing a public app",
+    "editPublicAppHelp": "Only labels, help text, info text, and other items that are not passed to the command line may be changed. This limitation is to maintain the reproducibility of results from your app. Only the author may edit their own public app.",
     "editParameter": "Edit Parameter",
     "envVarNameLabel": "Environment Variable name",
     "errorLoadingInfoTypes": "Error loading File Info Types",

--- a/src/components/apps/editor/AppInfo.js
+++ b/src/components/apps/editor/AppInfo.js
@@ -28,7 +28,7 @@ import Search from "@material-ui/icons/Search";
  */
 const ToolSelector = (props) => {
     // These props need to be spread down into the FormTextField
-    const { id, field, form } = props;
+    const { id, disabled, field, form } = props;
     const { setFieldValue } = form;
 
     const [open, setOpen] = React.useState(false);
@@ -40,7 +40,7 @@ const ToolSelector = (props) => {
             InputProps={{
                 readOnly: true,
                 value: field.value?.name || "",
-                endAdornment: (
+                endAdornment: !disabled && (
                     <InputAdornment position="end">
                         <IconButton
                             id={buildID(id, ids.BUTTONS.SELECT_TOOL)}
@@ -70,7 +70,7 @@ const ToolSelector = (props) => {
 };
 
 export default function AppInfo(props) {
-    const { baseId } = props;
+    const { baseId, cosmeticOnly } = props;
 
     const { t } = useTranslation(["app_editor", "app_editor_help"]);
 
@@ -82,6 +82,7 @@ export default function AppInfo(props) {
                 label={t("appName")}
                 required
                 component={FormTextField}
+                disabled={cosmeticOnly}
             />
             <FastField
                 id={buildID(baseId, ids.APP_DESCRIPTION)}
@@ -106,6 +107,7 @@ export default function AppInfo(props) {
                     />
                 }
                 component={ToolSelector}
+                disabled={cosmeticOnly}
             />
         </>
     );

--- a/src/components/apps/editor/ParamGroups.js
+++ b/src/components/apps/editor/ParamGroups.js
@@ -40,6 +40,7 @@ const useStyles = makeStyles(styles);
 function ParamGroupForm(props) {
     const {
         baseId,
+        cosmeticOnly,
         fieldName,
         group,
         onDelete,
@@ -77,6 +78,7 @@ function ParamGroupForm(props) {
                     <Typography variant="subtitle2">{group.label}</Typography>
                     <ParamLayoutActions
                         baseId={groupBaseId}
+                        cosmeticOnly={cosmeticOnly}
                         ButtonProps={{
                             color: "primary",
                             variant: "contained",
@@ -94,6 +96,7 @@ function ParamGroupForm(props) {
             <AccordionDetails className={classes.accordionDetails}>
                 <Parameters
                     baseId={baseId}
+                    cosmeticOnly={cosmeticOnly}
                     groupFieldName={fieldName}
                     parameters={group.parameters}
                     onEditParam={onEditParam}
@@ -110,6 +113,7 @@ function ParamGroupForm(props) {
 function ParamGroups(props) {
     const {
         baseId,
+        cosmeticOnly,
         values,
         keyCount,
         setKeyCount,
@@ -145,30 +149,33 @@ function ParamGroups(props) {
                                 />
                             </Typography>
                         </CardContent>
-                        <CardActions>
-                            <Button
-                                id={buildID(baseId, ids.BUTTONS.ADD_GROUP)}
-                                color="primary"
-                                variant="outlined"
-                                startIcon={<Add />}
-                                onClick={() => {
-                                    arrayHelpers.unshift({
-                                        key: keyCount,
-                                        label: t("newSectionLabel"),
-                                        isVisible: true,
-                                        parameters: [],
-                                    });
-                                    setKeyCount(keyCount + 1);
-                                }}
-                            >
-                                {t("addSection")}
-                            </Button>
-                        </CardActions>
+                        {!cosmeticOnly && (
+                            <CardActions>
+                                <Button
+                                    id={buildID(baseId, ids.BUTTONS.ADD_GROUP)}
+                                    color="primary"
+                                    variant="outlined"
+                                    startIcon={<Add />}
+                                    onClick={() => {
+                                        arrayHelpers.unshift({
+                                            key: keyCount,
+                                            label: t("newSectionLabel"),
+                                            isVisible: true,
+                                            parameters: [],
+                                        });
+                                        setKeyCount(keyCount + 1);
+                                    }}
+                                >
+                                    {t("addSection")}
+                                </Button>
+                            </CardActions>
+                        )}
                     </Card>
                     {groups?.map((group, index) => (
                         <ParamGroupForm
                             key={group.key}
                             baseId={baseId}
+                            cosmeticOnly={cosmeticOnly}
                             fieldName={`groups.${index}`}
                             group={group}
                             keyCount={keyCount}

--- a/src/components/apps/editor/ParamLayoutActions.js
+++ b/src/components/apps/editor/ParamLayoutActions.js
@@ -31,6 +31,7 @@ const useStyles = makeStyles(styles);
 export default function ParamLayoutActions(props) {
     const {
         baseId,
+        cosmeticOnly,
         ButtonProps = {},
         DotMenuButtonProps = {},
         onDelete,
@@ -46,7 +47,7 @@ export default function ParamLayoutActions(props) {
 
     return (
         <ButtonGroup {...ButtonProps}>
-            {isMobile ? (
+            {isMobile && !cosmeticOnly ? (
                 <DotMenu
                     baseId={baseId}
                     ButtonProps={DotMenuButtonProps}
@@ -107,22 +108,26 @@ export default function ParamLayoutActions(props) {
                 />
             ) : (
                 [
-                    <Button
-                        key={buildID(baseId, ids.BUTTONS.MOVE_UP_BTN)}
-                        id={buildID(baseId, ids.BUTTONS.MOVE_UP_BTN)}
-                        aria-label={t("moveUp")}
-                        onClick={onMoveUp}
-                    >
-                        <ArrowUpward />
-                    </Button>,
-                    <Button
-                        key={buildID(baseId, ids.BUTTONS.MOVE_DOWN_BTN)}
-                        id={buildID(baseId, ids.BUTTONS.MOVE_DOWN_BTN)}
-                        aria-label={t("moveDown")}
-                        onClick={onMoveDown}
-                    >
-                        <ArrowDownward />
-                    </Button>,
+                    !cosmeticOnly && (
+                        <Button
+                            key={buildID(baseId, ids.BUTTONS.MOVE_UP_BTN)}
+                            id={buildID(baseId, ids.BUTTONS.MOVE_UP_BTN)}
+                            aria-label={t("moveUp")}
+                            onClick={onMoveUp}
+                        >
+                            <ArrowUpward />
+                        </Button>
+                    ),
+                    !cosmeticOnly && (
+                        <Button
+                            key={buildID(baseId, ids.BUTTONS.MOVE_DOWN_BTN)}
+                            id={buildID(baseId, ids.BUTTONS.MOVE_DOWN_BTN)}
+                            aria-label={t("moveDown")}
+                            onClick={onMoveDown}
+                        >
+                            <ArrowDownward />
+                        </Button>
+                    ),
                     <Button
                         key={buildID(baseId, ids.BUTTONS.EDIT_BTN)}
                         id={buildID(baseId, ids.BUTTONS.EDIT_BTN)}
@@ -131,15 +136,17 @@ export default function ParamLayoutActions(props) {
                     >
                         <Edit />
                     </Button>,
-                    <Button
-                        key={buildID(baseId, ids.BUTTONS.DELETE_BTN)}
-                        id={buildID(baseId, ids.BUTTONS.DELETE_BTN)}
-                        aria-label={t("delete")}
-                        className={classes.deleteIcon}
-                        onClick={onDelete}
-                    >
-                        <Delete />
-                    </Button>,
+                    !cosmeticOnly && (
+                        <Button
+                            key={buildID(baseId, ids.BUTTONS.DELETE_BTN)}
+                            id={buildID(baseId, ids.BUTTONS.DELETE_BTN)}
+                            aria-label={t("delete")}
+                            className={classes.deleteIcon}
+                            onClick={onDelete}
+                        >
+                            <Delete />
+                        </Button>
+                    ),
                 ]
             )}
         </ButtonGroup>

--- a/src/components/apps/editor/ParamPropertyForm.js
+++ b/src/components/apps/editor/ParamPropertyForm.js
@@ -29,6 +29,7 @@ import TextPropertyFields from "./params/TextPropertyFields";
 
 import { getAppParameterLaunchComponent } from "../utils";
 
+import Info from "components/apps/launch/params/Info";
 import MultiFileSelector from "components/apps/launch/params/MultiFileSelector";
 
 import AppParamTypes from "components/models/AppParamTypes";
@@ -44,12 +45,16 @@ import {
 } from "@material-ui/core";
 
 function ParamPreview(props) {
-    const { baseId, fieldName, param } = props;
+    const { baseId, cosmeticOnly, fieldName, param } = props;
 
     const defaultValueFieldName = `${fieldName}.defaultValue`;
 
     const FieldComponent = getAppParameterLaunchComponent(param.type);
-    const fieldProps = { disabled: FieldComponent === MultiFileSelector };
+    const fieldProps = {
+        disabled:
+            FieldComponent === MultiFileSelector ||
+            (cosmeticOnly && FieldComponent !== Info),
+    };
 
     return (
         <Field
@@ -63,7 +68,7 @@ function ParamPreview(props) {
 }
 
 function PropertyFormFields(props) {
-    const { baseId, fieldName, param } = props;
+    const { baseId, cosmeticOnly, fieldName, param } = props;
 
     const baseParamId = buildID(baseId, fieldName);
 
@@ -75,6 +80,7 @@ function PropertyFormFields(props) {
             return (
                 <MultiLineTextPropertyFields
                     baseId={baseParamId}
+                    cosmeticOnly={cosmeticOnly}
                     fieldName={fieldName}
                 />
             );
@@ -83,6 +89,7 @@ function PropertyFormFields(props) {
             return (
                 <IntegerPropertyFields
                     baseId={baseParamId}
+                    cosmeticOnly={cosmeticOnly}
                     fieldName={fieldName}
                     param={param}
                 />
@@ -92,6 +99,7 @@ function PropertyFormFields(props) {
             return (
                 <DoublePropertyFields
                     baseId={baseParamId}
+                    cosmeticOnly={cosmeticOnly}
                     fieldName={fieldName}
                     param={param}
                 />
@@ -101,6 +109,7 @@ function PropertyFormFields(props) {
             return (
                 <CheckboxPropertyFields
                     baseId={baseParamId}
+                    cosmeticOnly={cosmeticOnly}
                     fieldName={fieldName}
                 />
             );
@@ -109,6 +118,7 @@ function PropertyFormFields(props) {
             return (
                 <EnvironmentVariablePropertyFields
                     baseId={baseParamId}
+                    cosmeticOnly={cosmeticOnly}
                     fieldName={fieldName}
                 />
             );
@@ -119,6 +129,7 @@ function PropertyFormFields(props) {
             return (
                 <SelectionPropertyFields
                     baseId={baseId}
+                    cosmeticOnly={cosmeticOnly}
                     fieldName={fieldName}
                     paramArguments={param.arguments}
                 />
@@ -128,6 +139,7 @@ function PropertyFormFields(props) {
             return (
                 <FileInputPropertyFields
                     baseId={baseParamId}
+                    cosmeticOnly={cosmeticOnly}
                     fieldName={fieldName}
                 />
             );
@@ -136,6 +148,7 @@ function PropertyFormFields(props) {
             return (
                 <FolderInputPropertyFields
                     baseId={baseParamId}
+                    cosmeticOnly={cosmeticOnly}
                     fieldName={fieldName}
                 />
             );
@@ -144,6 +157,7 @@ function PropertyFormFields(props) {
             return (
                 <MultiFileSelectorPropertyFields
                     baseId={baseParamId}
+                    cosmeticOnly={cosmeticOnly}
                     fieldName={fieldName}
                 />
             );
@@ -152,6 +166,7 @@ function PropertyFormFields(props) {
             return (
                 <FileOutputPropertyFields
                     baseId={baseParamId}
+                    cosmeticOnly={cosmeticOnly}
                     fieldName={fieldName}
                 />
             );
@@ -160,6 +175,7 @@ function PropertyFormFields(props) {
             return (
                 <FolderOutputPropertyFields
                     baseId={baseParamId}
+                    cosmeticOnly={cosmeticOnly}
                     fieldName={fieldName}
                 />
             );
@@ -168,6 +184,7 @@ function PropertyFormFields(props) {
             return (
                 <MultiFileOutputPropertyFields
                     baseId={baseParamId}
+                    cosmeticOnly={cosmeticOnly}
                     fieldName={fieldName}
                 />
             );
@@ -178,6 +195,7 @@ function PropertyFormFields(props) {
             return (
                 <ReferenceGenomePropertyFields
                     baseId={baseParamId}
+                    cosmeticOnly={cosmeticOnly}
                     fieldName={fieldName}
                     param={param}
                 />
@@ -188,6 +206,7 @@ function PropertyFormFields(props) {
                 <TextPropertyFields
                     baseId={baseParamId}
                     fieldName={fieldName}
+                    cosmeticOnly={cosmeticOnly}
                     param={param}
                 />
             );
@@ -195,7 +214,7 @@ function PropertyFormFields(props) {
 }
 
 function ParamPropertyForm(props) {
-    const { baseId, values, fieldName, onClose } = props;
+    const { baseId, cosmeticOnly, values, fieldName, onClose } = props;
 
     const { t } = useTranslation(["app_editor", "app_param_types", "common"]);
 
@@ -227,6 +246,7 @@ function ParamPropertyForm(props) {
             <CardContent>
                 <ParamPreview
                     baseId={baseId}
+                    cosmeticOnly={cosmeticOnly}
                     fieldName={fieldName}
                     param={param}
                 />
@@ -241,6 +261,7 @@ function ParamPropertyForm(props) {
             <CardContent>
                 <PropertyFormFields
                     baseId={baseId}
+                    cosmeticOnly={cosmeticOnly}
                     fieldName={fieldName}
                     param={param}
                 />

--- a/src/components/apps/editor/Parameters.js
+++ b/src/components/apps/editor/Parameters.js
@@ -18,6 +18,7 @@ import ParamSelectionPalette from "./ParamSelectionPalette";
 
 import { getAppParameterLaunchComponent } from "../utils";
 
+import Info from "components/apps/launch/params/Info";
 import MultiFileSelector from "components/apps/launch/params/MultiFileSelector";
 import ConfirmationDialog from "components/utils/ConfirmationDialog";
 
@@ -32,6 +33,7 @@ const useStyles = makeStyles(styles);
 function ParamCardForm(props) {
     const {
         baseId,
+        cosmeticOnly,
         field: { name: fieldName },
         param,
         scrollToField,
@@ -57,7 +59,10 @@ function ParamCardForm(props) {
 
     const FieldComponent = getAppParameterLaunchComponent(param.type);
     const fieldProps = {
-        disabled: !param.isVisible || FieldComponent === MultiFileSelector,
+        disabled:
+            !param.isVisible ||
+            FieldComponent === MultiFileSelector ||
+            (cosmeticOnly && FieldComponent !== Info),
     };
 
     return (
@@ -75,6 +80,7 @@ function ParamCardForm(props) {
                 action={
                     <ParamLayoutActions
                         baseId={paramBaseId}
+                        cosmeticOnly={cosmeticOnly}
                         ButtonProps={{
                             color: "primary",
                             variant: "text",
@@ -93,6 +99,7 @@ function ParamCardForm(props) {
 function Parameters(props) {
     const {
         baseId,
+        cosmeticOnly,
         groupFieldName,
         parameters,
         onEditParam,
@@ -137,17 +144,17 @@ function Parameters(props) {
                             onClose={handleAddParamMenuClose}
                             handleAddParam={handleAddParam}
                         />
-                        <Button
-                            id={buildID(baseId, ids.BUTTONS.ADD_PARAM)}
-                            color="primary"
-                            variant="contained"
-                            startIcon={<Add />}
-                            onClick={() => {
-                                setParamSelectOpen(true);
-                            }}
-                        >
-                            {t("addParameter")}
-                        </Button>
+                        {!cosmeticOnly && (
+                            <Button
+                                id={buildID(baseId, ids.BUTTONS.ADD_PARAM)}
+                                color="primary"
+                                variant="contained"
+                                startIcon={<Add />}
+                                onClick={() => setParamSelectOpen(true)}
+                            >
+                                {t("addParameter")}
+                            </Button>
+                        )}
                         {parameters?.map((param, index) => {
                             const fieldName = `${parametersFieldName}.${index}`;
                             return (
@@ -156,6 +163,7 @@ function Parameters(props) {
                                     name={fieldName}
                                     component={ParamCardForm}
                                     baseId={baseId}
+                                    cosmeticOnly={cosmeticOnly}
                                     param={param}
                                     scrollToField={scrollToField}
                                     setScrollToField={setScrollToField}

--- a/src/components/apps/editor/index.js
+++ b/src/components/apps/editor/index.js
@@ -29,7 +29,6 @@ import AppStepDisplay, { BottomNavigationSkeleton } from "../AppStepDisplay";
 import { getAppEditPath } from "../utils";
 
 import BackButton from "components/utils/BackButton";
-import ComingSoonInfo from "components/utils/ComingSoonInfo";
 import SaveButton from "components/utils/SaveButton";
 import WrappedErrorHandler from "components/utils/error/WrappedErrorHandler";
 
@@ -191,7 +190,11 @@ const AppEditor = (props) => {
         contentLabel: t("commandLineOrder"),
     };
 
-    const steps = [stepAppInfo, stepParameters, stepPreview, stepCmdLineOrder];
+    const steps = [stepAppInfo, stepParameters, stepPreview];
+
+    if (!cosmeticOnly) {
+        steps.push(stepCmdLineOrder);
+    }
 
     const isLastStep = () => {
         return activeStep === steps.length - 1;
@@ -219,8 +222,6 @@ const AppEditor = (props) => {
         <AppStepperFormSkeleton baseId={baseId} header />
     ) : loadingError ? (
         <WrappedErrorHandler baseId={baseId} errorObject={loadingError} />
-    ) : cosmeticOnly ? (
-        <ComingSoonInfo>{t("publicAppEditingNotSupported")}</ComingSoonInfo>
     ) : (
         <Formik
             initialValues={initAppValues(appDescription)}
@@ -384,13 +385,18 @@ const AppEditor = (props) => {
                                         setEditParamField(null);
                                     }}
                                     fieldName={editParamField}
+                                    cosmeticOnly={cosmeticOnly}
                                     values={values}
                                 />
                             ) : activeStepInfo === stepAppInfo ? (
-                                <AppInfo baseId={baseId} />
+                                <AppInfo
+                                    baseId={baseId}
+                                    cosmeticOnly={cosmeticOnly}
+                                />
                             ) : activeStepInfo === stepParameters ? (
                                 <ParamGroups
                                     baseId={baseId}
+                                    cosmeticOnly={cosmeticOnly}
                                     values={values}
                                     keyCount={keyCount}
                                     setKeyCount={setKeyCount}

--- a/src/components/apps/editor/index.js
+++ b/src/components/apps/editor/index.js
@@ -35,7 +35,7 @@ import WrappedErrorHandler from "components/utils/error/WrappedErrorHandler";
 import useComponentHeight from "components/utils/useComponentHeight";
 import withErrorAnnouncer from "components/utils/error/withErrorAnnouncer";
 
-import { addApp, updateApp } from "serviceFacades/apps";
+import { addApp, updateApp, updateAppLabels } from "serviceFacades/apps";
 
 import {
     AnnouncerConstants,
@@ -159,9 +159,13 @@ const AppEditor = (props) => {
         ({ app }) => {
             const { system_id: systemId, id: appId } = app;
 
+            const request = { systemId, appId, app };
+
             return appId
-                ? updateApp({ systemId, appId, app })
-                : addApp({ systemId, app });
+                ? cosmeticOnly
+                    ? updateAppLabels(request)
+                    : updateApp(request)
+                : addApp(request);
         },
         {
             onSuccess: (resp, { onSuccess }) => {
@@ -301,6 +305,17 @@ const AppEditor = (props) => {
                                 onSave={handleSubmit}
                             />
                         </Grid>
+
+                        {cosmeticOnly && (
+                            <>
+                                <Typography variant="h6" color="error">
+                                    {t("editingPublicApp")}
+                                </Typography>
+                                <Typography variant="body2">
+                                    {t("editPublicAppHelp")}
+                                </Typography>
+                            </>
+                        )}
 
                         {isSubmitting ? (
                             <StepperSkeleton baseId={baseId} ref={stepperRef} />

--- a/src/components/apps/editor/params/CheckboxPropertyFields.js
+++ b/src/components/apps/editor/params/CheckboxPropertyFields.js
@@ -24,7 +24,7 @@ import {
 import { Grid } from "@material-ui/core";
 
 export default function CheckboxPropertyFields(props) {
-    const { baseId, fieldName } = props;
+    const { baseId, cosmeticOnly, fieldName } = props;
 
     const { t } = useTranslation("app_editor");
 
@@ -49,6 +49,7 @@ export default function CheckboxPropertyFields(props) {
                         margin="normal"
                         required
                         component={FormTextField}
+                        disabled={cosmeticOnly}
                     />
                 </Grid>
                 <Grid item xs={6}>
@@ -58,6 +59,7 @@ export default function CheckboxPropertyFields(props) {
                         label={t("checkboxArgValueCheckedLabel")}
                         margin="normal"
                         component={FormTextField}
+                        disabled={cosmeticOnly}
                     />
                 </Grid>
             </Grid>
@@ -77,6 +79,7 @@ export default function CheckboxPropertyFields(props) {
                         required
                         margin="normal"
                         component={FormTextField}
+                        disabled={cosmeticOnly}
                     />
                 </Grid>
                 <Grid item xs={6}>
@@ -86,6 +89,7 @@ export default function CheckboxPropertyFields(props) {
                         label={t("checkboxArgValueUncheckedLabel")}
                         margin="normal"
                         component={FormTextField}
+                        disabled={cosmeticOnly}
                     />
                 </Grid>
             </Grid>
@@ -95,9 +99,16 @@ export default function CheckboxPropertyFields(props) {
                     name={`${fieldName}.defaultValue`}
                     label={t("checkboxDefaultLabel")}
                     component={FormCheckbox}
+                    disabled={cosmeticOnly}
                 />
+
                 <DescriptionField baseId={baseId} fieldName={fieldName} />
-                <VisibleField baseId={baseId} fieldName={fieldName} />
+
+                <VisibleField
+                    baseId={baseId}
+                    fieldName={fieldName}
+                    disabled={cosmeticOnly}
+                />
             </Grid>
         </Grid>
     );

--- a/src/components/apps/editor/params/DoublePropertyFields.js
+++ b/src/components/apps/editor/params/DoublePropertyFields.js
@@ -24,23 +24,41 @@ import { build as buildID, FormNumberField } from "@cyverse-de/ui-lib";
 import { Grid } from "@material-ui/core";
 
 export default function DoublePropertyFields(props) {
-    const { baseId, fieldName, param } = props;
+    const { baseId, cosmeticOnly, fieldName, param } = props;
 
     const validatorsFieldName = `${fieldName}.validators`;
 
     return (
         <Grid container direction="column">
             <LabelField baseId={baseId} fieldName={fieldName} />
-            <ArgumentOptionField baseId={baseId} fieldName={fieldName} />
+            <ArgumentOptionField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
             <DefaultValueField
                 baseId={baseId}
                 fieldName={fieldName}
                 component={FormNumberField}
+                disabled={cosmeticOnly}
             />
             <DescriptionField baseId={baseId} fieldName={fieldName} />
-            <RequiredField baseId={baseId} fieldName={fieldName} />
-            <VisibleField baseId={baseId} fieldName={fieldName} />
-            <ExcludeArgumentField baseId={baseId} fieldName={fieldName} />
+
+            <RequiredField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <VisibleField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <ExcludeArgumentField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
 
             <FieldArray
                 name={validatorsFieldName}
@@ -62,6 +80,7 @@ export default function DoublePropertyFields(props) {
                     return (
                         <ValidationRulesEditor
                             baseId={buildID(baseId, "validators")}
+                            cosmeticOnly={cosmeticOnly}
                             fieldName={validatorsFieldName}
                             validators={param.validators}
                             ruleOptions={[

--- a/src/components/apps/editor/params/EnvironmentVariablePropertyFields.js
+++ b/src/components/apps/editor/params/EnvironmentVariablePropertyFields.js
@@ -21,19 +21,21 @@ import { build as buildID, FormTextField } from "@cyverse-de/ui-lib";
 import { Grid } from "@material-ui/core";
 
 export default function EnvironmentVariablePropertyFields(props) {
-    const { baseId, fieldName } = props;
+    const { baseId, cosmeticOnly, fieldName } = props;
 
     const { t } = useTranslation(["app_editor", "app_editor_help"]);
 
     return (
         <Grid container direction="column">
             <LabelField baseId={baseId} fieldName={fieldName} />
+
             <FastField
                 id={buildID(baseId, ids.PARAM_FIELDS.ARGUMENT_OPTION)}
                 name={`${fieldName}.name`}
                 label={t("envVarNameLabel")}
                 helperText={t("app_editor_help:EnvironmentVariableDefaultName")}
                 component={FormTextField}
+                disabled={cosmeticOnly}
             />
             <FastField
                 id={buildID(baseId, ids.PARAM_FIELDS.DEFAULT_VALUE)}
@@ -43,10 +45,21 @@ export default function EnvironmentVariablePropertyFields(props) {
                     "app_editor_help:EnvironmentVariableDefaultValue"
                 )}
                 component={FormTextField}
+                disabled={cosmeticOnly}
             />
+
             <DescriptionField baseId={baseId} fieldName={fieldName} />
-            <RequiredField baseId={baseId} fieldName={fieldName} />
-            <VisibleField baseId={baseId} fieldName={fieldName} />
+
+            <RequiredField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <VisibleField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
         </Grid>
     );
 }

--- a/src/components/apps/editor/params/FileInfoTypesSelector.js
+++ b/src/components/apps/editor/params/FileInfoTypesSelector.js
@@ -21,7 +21,7 @@ import {
 import { MenuItem } from "@material-ui/core";
 
 export default function FileInfoTypesSelector(props) {
-    const { baseId, fieldName, label } = props;
+    const { baseId, disabled, fieldName, label } = props;
 
     const [infoTypes, setInfoTypes] = React.useState([]);
 
@@ -33,6 +33,7 @@ export default function FileInfoTypesSelector(props) {
         id: buildID(baseId, ids.PARAM_FIELDS.FILE_INFO_TYPE),
         name: `${fieldName}.file_info_type`,
         label,
+        disabled,
     };
 
     if (isFetching) {

--- a/src/components/apps/editor/params/FileInputPropertyFields.js
+++ b/src/components/apps/editor/params/FileInputPropertyFields.js
@@ -23,7 +23,7 @@ import FileInput from "components/apps/launch/params/FileInput";
 import { Grid } from "@material-ui/core";
 
 export default function FileInputPropertyFields(props) {
-    const { baseId, fieldName } = props;
+    const { baseId, cosmeticOnly, fieldName } = props;
 
     const { t } = useTranslation(["app_editor", "app_editor_help"]);
 
@@ -32,19 +32,39 @@ export default function FileInputPropertyFields(props) {
     return (
         <Grid container direction="column">
             <LabelField baseId={baseId} fieldName={fieldName} />
-            <ArgumentOptionField baseId={baseId} fieldName={fieldName} />
+
+            <ArgumentOptionField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
             <DefaultValueField
                 baseId={baseId}
                 fieldName={fieldName}
                 component={FileInput}
+                disabled={cosmeticOnly}
             />
             <DescriptionField baseId={baseId} fieldName={fieldName} />
-            <RequiredField baseId={baseId} fieldName={fieldName} />
-            <VisibleField baseId={baseId} fieldName={fieldName} />
-            <ExcludeArgumentField baseId={baseId} fieldName={fieldName} />
+
+            <RequiredField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <VisibleField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <ExcludeArgumentField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
 
             <FileInfoTypesSelector
                 baseId={baseId}
+                disabled={cosmeticOnly}
                 fieldName={fileParamsFieldName}
                 label={t("fileInfoTypeLabel")}
             />
@@ -53,6 +73,7 @@ export default function FileInputPropertyFields(props) {
                 baseId={baseId}
                 fieldName={fileParamsFieldName}
                 helperText={t("app_editor_help:IsImplicitFileInput")}
+                disabled={cosmeticOnly}
             />
         </Grid>
     );

--- a/src/components/apps/editor/params/FileOutputPropertyFields.js
+++ b/src/components/apps/editor/params/FileOutputPropertyFields.js
@@ -33,7 +33,7 @@ export const DataSources = {
 };
 
 export default function FileOutputPropertyFields(props) {
-    const { baseId, fieldName } = props;
+    const { baseId, cosmeticOnly, fieldName } = props;
 
     const { t } = useTranslation([
         "app_editor",
@@ -46,17 +46,35 @@ export default function FileOutputPropertyFields(props) {
     return (
         <Grid container direction="column">
             <LabelField baseId={baseId} fieldName={fieldName} />
-            <ArgumentOptionField baseId={baseId} fieldName={fieldName} />
+            <ArgumentOptionField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
             <DefaultValueField
                 baseId={baseId}
                 fieldName={fieldName}
                 label={t("fileOutputDefaultLabel")}
                 component={FormTextField}
+                disabled={cosmeticOnly}
             />
             <DescriptionField baseId={baseId} fieldName={fieldName} />
-            <RequiredField baseId={baseId} fieldName={fieldName} />
-            <VisibleField baseId={baseId} fieldName={fieldName} />
-            <ExcludeArgumentField baseId={baseId} fieldName={fieldName} />
+
+            <RequiredField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <VisibleField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <ExcludeArgumentField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
 
             <FastField
                 id={buildID(baseId, ids.PARAM_FIELDS.DATA_SOURCE)}
@@ -67,6 +85,7 @@ export default function FileOutputPropertyFields(props) {
                 variant="outlined"
                 margin="normal"
                 size="small"
+                disabled={cosmeticOnly}
             >
                 <MenuItem value={DataSources.FILE}>
                     {t("app_param_types:DataSrcFile")}
@@ -81,6 +100,7 @@ export default function FileOutputPropertyFields(props) {
 
             <FileInfoTypesSelector
                 baseId={baseId}
+                disabled={cosmeticOnly}
                 fieldName={fileParamsFieldName}
                 label={t("fileInfoTypeLabel")}
             />
@@ -89,6 +109,7 @@ export default function FileOutputPropertyFields(props) {
                 baseId={baseId}
                 fieldName={fileParamsFieldName}
                 helperText={t("app_editor_help:IsImplicitOutput")}
+                disabled={cosmeticOnly}
             />
         </Grid>
     );

--- a/src/components/apps/editor/params/FolderInputPropertyFields.js
+++ b/src/components/apps/editor/params/FolderInputPropertyFields.js
@@ -23,7 +23,7 @@ import FolderInput from "components/apps/launch/params/FolderInput";
 import { Grid } from "@material-ui/core";
 
 export default function FolderInputPropertyFields(props) {
-    const { baseId, fieldName } = props;
+    const { baseId, cosmeticOnly, fieldName } = props;
 
     const { t } = useTranslation(["app_editor", "app_editor_help"]);
 
@@ -32,19 +32,38 @@ export default function FolderInputPropertyFields(props) {
     return (
         <Grid container direction="column">
             <LabelField baseId={baseId} fieldName={fieldName} />
-            <ArgumentOptionField baseId={baseId} fieldName={fieldName} />
+            <ArgumentOptionField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
             <DefaultValueField
                 baseId={baseId}
                 fieldName={fieldName}
                 component={FolderInput}
+                disabled={cosmeticOnly}
             />
             <DescriptionField baseId={baseId} fieldName={fieldName} />
-            <RequiredField baseId={baseId} fieldName={fieldName} />
-            <VisibleField baseId={baseId} fieldName={fieldName} />
-            <ExcludeArgumentField baseId={baseId} fieldName={fieldName} />
+
+            <RequiredField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <VisibleField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <ExcludeArgumentField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
 
             <FileInfoTypesSelector
                 baseId={baseId}
+                disabled={cosmeticOnly}
                 fieldName={fileParamsFieldName}
                 label={t("folderInfoTypeLabel")}
             />
@@ -53,6 +72,7 @@ export default function FolderInputPropertyFields(props) {
                 baseId={baseId}
                 fieldName={fileParamsFieldName}
                 helperText={t("app_editor_help:IsImplicitFolderInput")}
+                disabled={cosmeticOnly}
             />
         </Grid>
     );

--- a/src/components/apps/editor/params/FolderOutputPropertyFields.js
+++ b/src/components/apps/editor/params/FolderOutputPropertyFields.js
@@ -23,7 +23,7 @@ import { FormTextField } from "@cyverse-de/ui-lib";
 import { Grid } from "@material-ui/core";
 
 export default function FolderOutputPropertyFields(props) {
-    const { baseId, fieldName } = props;
+    const { baseId, cosmeticOnly, fieldName } = props;
 
     const { t } = useTranslation([
         "app_editor",
@@ -36,20 +36,39 @@ export default function FolderOutputPropertyFields(props) {
     return (
         <Grid container direction="column">
             <LabelField baseId={baseId} fieldName={fieldName} />
-            <ArgumentOptionField baseId={baseId} fieldName={fieldName} />
+            <ArgumentOptionField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
             <DefaultValueField
                 baseId={baseId}
                 fieldName={fieldName}
                 label={t("folderOutputDefaultLabel")}
                 component={FormTextField}
+                disabled={cosmeticOnly}
             />
             <DescriptionField baseId={baseId} fieldName={fieldName} />
-            <RequiredField baseId={baseId} fieldName={fieldName} />
-            <VisibleField baseId={baseId} fieldName={fieldName} />
-            <ExcludeArgumentField baseId={baseId} fieldName={fieldName} />
+
+            <RequiredField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <VisibleField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <ExcludeArgumentField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
 
             <FileInfoTypesSelector
                 baseId={baseId}
+                disabled={cosmeticOnly}
                 fieldName={fileParamsFieldName}
                 label={t("folderInfoTypeLabel")}
             />
@@ -58,6 +77,7 @@ export default function FolderOutputPropertyFields(props) {
                 baseId={baseId}
                 fieldName={fileParamsFieldName}
                 helperText={t("app_editor_help:IsImplicitOutput")}
+                disabled={cosmeticOnly}
             />
         </Grid>
     );

--- a/src/components/apps/editor/params/IntegerPropertyFields.js
+++ b/src/components/apps/editor/params/IntegerPropertyFields.js
@@ -24,23 +24,41 @@ import { build as buildID, FormIntegerField } from "@cyverse-de/ui-lib";
 import { Grid } from "@material-ui/core";
 
 export default function IntegerPropertyFields(props) {
-    const { baseId, fieldName, param } = props;
+    const { baseId, cosmeticOnly, fieldName, param } = props;
 
     const validatorsFieldName = `${fieldName}.validators`;
 
     return (
         <Grid container direction="column">
             <LabelField baseId={baseId} fieldName={fieldName} />
-            <ArgumentOptionField baseId={baseId} fieldName={fieldName} />
+            <ArgumentOptionField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
             <DefaultValueField
                 baseId={baseId}
                 fieldName={fieldName}
                 component={FormIntegerField}
+                disabled={cosmeticOnly}
             />
             <DescriptionField baseId={baseId} fieldName={fieldName} />
-            <RequiredField baseId={baseId} fieldName={fieldName} />
-            <VisibleField baseId={baseId} fieldName={fieldName} />
-            <ExcludeArgumentField baseId={baseId} fieldName={fieldName} />
+
+            <RequiredField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <VisibleField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <ExcludeArgumentField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
 
             <FieldArray
                 name={validatorsFieldName}
@@ -62,6 +80,7 @@ export default function IntegerPropertyFields(props) {
                     return (
                         <ValidationRulesEditor
                             baseId={buildID(baseId, "validators")}
+                            cosmeticOnly={cosmeticOnly}
                             fieldName={validatorsFieldName}
                             validators={param.validators}
                             ruleOptions={[

--- a/src/components/apps/editor/params/MultiFileOutputPropertyFields.js
+++ b/src/components/apps/editor/params/MultiFileOutputPropertyFields.js
@@ -23,7 +23,7 @@ import { FormTextField } from "@cyverse-de/ui-lib";
 import { Grid } from "@material-ui/core";
 
 export default function MultiFileOutputPropertyFields(props) {
-    const { baseId, fieldName } = props;
+    const { baseId, cosmeticOnly, fieldName } = props;
 
     const { t } = useTranslation([
         "app_editor",
@@ -36,20 +36,39 @@ export default function MultiFileOutputPropertyFields(props) {
     return (
         <Grid container direction="column">
             <LabelField baseId={baseId} fieldName={fieldName} />
-            <ArgumentOptionField baseId={baseId} fieldName={fieldName} />
+            <ArgumentOptionField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
             <DefaultValueField
                 baseId={baseId}
                 fieldName={fieldName}
                 label={t("multiFileOutputDefaultLabel")}
                 component={FormTextField}
+                disabled={cosmeticOnly}
             />
             <DescriptionField baseId={baseId} fieldName={fieldName} />
-            <RequiredField baseId={baseId} fieldName={fieldName} />
-            <VisibleField baseId={baseId} fieldName={fieldName} />
-            <ExcludeArgumentField baseId={baseId} fieldName={fieldName} />
+
+            <RequiredField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <VisibleField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <ExcludeArgumentField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
 
             <FileInfoTypesSelector
                 baseId={baseId}
+                disabled={cosmeticOnly}
                 fieldName={fileParamsFieldName}
                 label={t("multiFileInfoTypeLabel")}
             />
@@ -58,6 +77,7 @@ export default function MultiFileOutputPropertyFields(props) {
                 baseId={baseId}
                 fieldName={fileParamsFieldName}
                 helperText={t("app_editor_help:IsImplicitOutput")}
+                disabled={cosmeticOnly}
             />
         </Grid>
     );

--- a/src/components/apps/editor/params/MultiFileSelectorPropertyFields.js
+++ b/src/components/apps/editor/params/MultiFileSelectorPropertyFields.js
@@ -25,7 +25,7 @@ import { build as buildID, FormCheckbox } from "@cyverse-de/ui-lib";
 import { Grid } from "@material-ui/core";
 
 export default function MultiFileSelectorPropertyFields(props) {
-    const { baseId, fieldName } = props;
+    const { baseId, cosmeticOnly, fieldName } = props;
 
     const { t } = useTranslation(["app_editor", "app_editor_help"]);
 
@@ -34,13 +34,27 @@ export default function MultiFileSelectorPropertyFields(props) {
     return (
         <Grid container direction="column">
             <LabelField baseId={baseId} fieldName={fieldName} />
-            <ArgumentOptionField baseId={baseId} fieldName={fieldName} />
+            <ArgumentOptionField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
             <DescriptionField baseId={baseId} fieldName={fieldName} />
-            <RequiredField baseId={baseId} fieldName={fieldName} />
-            <ExcludeArgumentField baseId={baseId} fieldName={fieldName} />
+
+            <RequiredField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <ExcludeArgumentField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
 
             <FileInfoTypesSelector
                 baseId={baseId}
+                disabled={cosmeticOnly}
                 fieldName={fileParamsFieldName}
                 label={t("multiFileInfoTypeLabel")}
             />
@@ -49,6 +63,7 @@ export default function MultiFileSelectorPropertyFields(props) {
                 baseId={baseId}
                 fieldName={fileParamsFieldName}
                 helperText={t("app_editor_help:IsImplicitFileInput")}
+                disabled={cosmeticOnly}
             />
 
             <FastField
@@ -57,6 +72,7 @@ export default function MultiFileSelectorPropertyFields(props) {
                 label={t("repeatOptionFlag")}
                 helperText={t("app_editor_help:RepeatOptionFlag")}
                 component={FormCheckbox}
+                disabled={cosmeticOnly}
             />
         </Grid>
     );

--- a/src/components/apps/editor/params/MultiLineTextPropertyFields.js
+++ b/src/components/apps/editor/params/MultiLineTextPropertyFields.js
@@ -18,21 +18,39 @@ import { FormMultilineTextField } from "@cyverse-de/ui-lib";
 import { Grid } from "@material-ui/core";
 
 export default function MultiLineTextPropertyFields(props) {
-    const { baseId, fieldName } = props;
+    const { baseId, cosmeticOnly, fieldName } = props;
 
     return (
         <Grid container direction="column">
             <LabelField baseId={baseId} fieldName={fieldName} />
-            <ArgumentOptionField baseId={baseId} fieldName={fieldName} />
+            <ArgumentOptionField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
             <DefaultValueField
                 baseId={baseId}
                 fieldName={fieldName}
                 component={FormMultilineTextField}
+                disabled={cosmeticOnly}
             />
             <DescriptionField baseId={baseId} fieldName={fieldName} />
-            <RequiredField baseId={baseId} fieldName={fieldName} />
-            <VisibleField baseId={baseId} fieldName={fieldName} />
-            <ExcludeArgumentField baseId={baseId} fieldName={fieldName} />
+
+            <RequiredField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <VisibleField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <ExcludeArgumentField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
         </Grid>
     );
 }

--- a/src/components/apps/editor/params/ReferenceGenomePropertyFields.js
+++ b/src/components/apps/editor/params/ReferenceGenomePropertyFields.js
@@ -18,22 +18,40 @@ import ReferenceGenomeSelect from "components/apps/launch/ReferenceGenomeSelect"
 import { Grid } from "@material-ui/core";
 
 export default function ReferenceGenomePropertyFields(props) {
-    const { baseId, fieldName, param } = props;
+    const { baseId, cosmeticOnly, fieldName, param } = props;
 
     return (
         <Grid container direction="column">
             <LabelField baseId={baseId} fieldName={fieldName} />
-            <ArgumentOptionField baseId={baseId} fieldName={fieldName} />
+            <ArgumentOptionField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
             <DefaultValueField
                 baseId={baseId}
                 fieldName={fieldName}
                 component={ReferenceGenomeSelect}
                 param={param}
+                disabled={cosmeticOnly}
             />
             <DescriptionField baseId={baseId} fieldName={fieldName} />
-            <RequiredField baseId={baseId} fieldName={fieldName} />
-            <VisibleField baseId={baseId} fieldName={fieldName} />
-            <ExcludeArgumentField baseId={baseId} fieldName={fieldName} />
+
+            <RequiredField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <VisibleField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <ExcludeArgumentField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
         </Grid>
     );
 }

--- a/src/components/apps/editor/params/SelectionPropertyFields.js
+++ b/src/components/apps/editor/params/SelectionPropertyFields.js
@@ -44,7 +44,14 @@ import { Add, ArrowUpward, ArrowDownward, Delete } from "@material-ui/icons";
 const useStyles = makeStyles(styles);
 
 function SelectionItemEditorRow(props) {
-    const { baseId, fieldName, onMoveUp, onMoveDown, onDelete } = props;
+    const {
+        baseId,
+        cosmeticOnly,
+        fieldName,
+        onMoveUp,
+        onMoveDown,
+        onDelete,
+    } = props;
 
     const { t } = useTranslation("common");
     const classes = useStyles();
@@ -68,6 +75,7 @@ function SelectionItemEditorRow(props) {
                     )}
                     name={`${fieldName}.name`}
                     component={FormTextField}
+                    disabled={cosmeticOnly}
                 />
             </TableCell>
             <TableCell padding="none">
@@ -78,34 +86,43 @@ function SelectionItemEditorRow(props) {
                     )}
                     name={`${fieldName}.value`}
                     component={FormTextField}
+                    disabled={cosmeticOnly}
                 />
             </TableCell>
-            <TableCell padding="none">
-                <ButtonGroup color="primary" variant="text">
-                    <Button
-                        id={buildID(baseParamArgId, ids.BUTTONS.MOVE_UP_BTN)}
-                        aria-label={t("moveUp")}
-                        onClick={onMoveUp}
-                    >
-                        <ArrowUpward />
-                    </Button>
-                    <Button
-                        id={buildID(baseParamArgId, ids.BUTTONS.MOVE_DOWN_BTN)}
-                        aria-label={t("moveDown")}
-                        onClick={onMoveDown}
-                    >
-                        <ArrowDownward />
-                    </Button>
-                    <Button
-                        id={buildID(baseParamArgId, ids.BUTTONS.DELETE_BTN)}
-                        aria-label={t("delete")}
-                        className={classes.deleteIcon}
-                        onClick={onDelete}
-                    >
-                        <Delete />
-                    </Button>
-                </ButtonGroup>
-            </TableCell>
+            {!cosmeticOnly && (
+                <TableCell padding="none">
+                    <ButtonGroup color="primary" variant="text">
+                        <Button
+                            id={buildID(
+                                baseParamArgId,
+                                ids.BUTTONS.MOVE_UP_BTN
+                            )}
+                            aria-label={t("moveUp")}
+                            onClick={onMoveUp}
+                        >
+                            <ArrowUpward />
+                        </Button>
+                        <Button
+                            id={buildID(
+                                baseParamArgId,
+                                ids.BUTTONS.MOVE_DOWN_BTN
+                            )}
+                            aria-label={t("moveDown")}
+                            onClick={onMoveDown}
+                        >
+                            <ArrowDownward />
+                        </Button>
+                        <Button
+                            id={buildID(baseParamArgId, ids.BUTTONS.DELETE_BTN)}
+                            aria-label={t("delete")}
+                            className={classes.deleteIcon}
+                            onClick={onDelete}
+                        >
+                            <Delete />
+                        </Button>
+                    </ButtonGroup>
+                </TableCell>
+            )}
         </TableRow>
     );
 }
@@ -113,6 +130,7 @@ function SelectionItemEditorRow(props) {
 function SelectionItemEditor(props) {
     const {
         baseId,
+        cosmeticOnly,
         fieldName,
         paramArguments,
         onAdd,
@@ -142,20 +160,22 @@ function SelectionItemEditor(props) {
                         <TableCell>{t("paramArgDisplay")}</TableCell>
                         <TableCell>{t("paramArgName")}</TableCell>
                         <TableCell>{t("paramArgValue")}</TableCell>
-                        <TableCell>
-                            <Button
-                                id={buildID(
-                                    baseParamId,
-                                    ids.BUTTONS.ADD_PARAM_ARG
-                                )}
-                                color="primary"
-                                variant="outlined"
-                                startIcon={<Add />}
-                                onClick={onAdd}
-                            >
-                                {t("common:add")}
-                            </Button>
-                        </TableCell>
+                        {!cosmeticOnly && (
+                            <TableCell>
+                                <Button
+                                    id={buildID(
+                                        baseParamId,
+                                        ids.BUTTONS.ADD_PARAM_ARG
+                                    )}
+                                    color="primary"
+                                    variant="outlined"
+                                    startIcon={<Add />}
+                                    onClick={onAdd}
+                                >
+                                    {t("common:add")}
+                                </Button>
+                            </TableCell>
+                        )}
                     </TableRow>
                 </TableHead>
                 <TableBody>
@@ -163,6 +183,7 @@ function SelectionItemEditor(props) {
                         <SelectionItemEditorRow
                             key={paramArg.id || index}
                             baseId={baseId}
+                            cosmeticOnly={cosmeticOnly}
                             fieldName={`${fieldName}.${index}`}
                             onMoveUp={onMoveUp(index)}
                             onMoveDown={onMoveDown(index)}
@@ -176,7 +197,7 @@ function SelectionItemEditor(props) {
 }
 
 export default function SelectionPropertyFields(props) {
-    const { baseId, fieldName, paramArguments } = props;
+    const { baseId, cosmeticOnly, fieldName, paramArguments } = props;
 
     const [confirmDeleteIndex, setConfirmDeleteIndex] = React.useState(-1);
     const onCloseDeleteConfirm = () => setConfirmDeleteIndex(-1);
@@ -197,6 +218,7 @@ export default function SelectionPropertyFields(props) {
                 variant="outlined"
                 margin="normal"
                 size="small"
+                disabled={cosmeticOnly}
             >
                 <MenuItem value="">&nbsp;</MenuItem>
                 {paramArguments?.map((paramArg) => (
@@ -207,8 +229,17 @@ export default function SelectionPropertyFields(props) {
             </DefaultValueField>
 
             <DescriptionField baseId={baseParamId} fieldName={fieldName} />
-            <RequiredField baseId={baseParamId} fieldName={fieldName} />
-            <ExcludeArgumentField baseId={baseParamId} fieldName={fieldName} />
+
+            <RequiredField
+                baseId={baseParamId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <ExcludeArgumentField
+                baseId={baseParamId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
 
             <FieldArray
                 name={`${fieldName}.arguments`}
@@ -247,6 +278,7 @@ export default function SelectionPropertyFields(props) {
                         <>
                             <SelectionItemEditor
                                 baseId={baseId}
+                                cosmeticOnly={cosmeticOnly}
                                 fieldName={`${fieldName}.arguments`}
                                 paramArguments={paramArguments}
                                 onAdd={onAdd}

--- a/src/components/apps/editor/params/TextPropertyFields.js
+++ b/src/components/apps/editor/params/TextPropertyFields.js
@@ -25,24 +25,42 @@ import { build as buildID, FormTextField } from "@cyverse-de/ui-lib";
 import { Grid } from "@material-ui/core";
 
 export default function TextPropertyFields(props) {
-    const { baseId, fieldName, param } = props;
+    const { baseId, cosmeticOnly, fieldName, param } = props;
 
     const validatorsFieldName = `${fieldName}.validators`;
 
     return (
         <Grid container direction="column">
             <LabelField baseId={baseId} fieldName={fieldName} />
-            <ArgumentOptionField baseId={baseId} fieldName={fieldName} />
+            <ArgumentOptionField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
             <DefaultValueField
                 baseId={baseId}
                 fieldName={fieldName}
                 component={FormTextField}
                 inputProps={getTextFieldInputProps(param)}
+                disabled={cosmeticOnly}
             />
             <DescriptionField baseId={baseId} fieldName={fieldName} />
-            <RequiredField baseId={baseId} fieldName={fieldName} />
-            <VisibleField baseId={baseId} fieldName={fieldName} />
-            <ExcludeArgumentField baseId={baseId} fieldName={fieldName} />
+
+            <RequiredField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <VisibleField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
+            <ExcludeArgumentField
+                baseId={baseId}
+                fieldName={fieldName}
+                disabled={cosmeticOnly}
+            />
 
             <FieldArray
                 name={validatorsFieldName}
@@ -61,6 +79,7 @@ export default function TextPropertyFields(props) {
                     return (
                         <ValidationRulesEditor
                             baseId={buildID(baseId, "validators")}
+                            cosmeticOnly={cosmeticOnly}
                             fieldName={validatorsFieldName}
                             validators={param.validators}
                             ruleOptions={[

--- a/src/components/apps/editor/params/common/ArgumentOptionField.js
+++ b/src/components/apps/editor/params/common/ArgumentOptionField.js
@@ -14,7 +14,7 @@ import ids from "../../ids";
 import { build as buildID, FormTextField } from "@cyverse-de/ui-lib";
 
 export default function ArgumentOptionField(props) {
-    const { baseId, fieldName } = props;
+    const { baseId, fieldName, ...custom } = props;
 
     const { t } = useTranslation(["app_editor", "app_editor_help"]);
 
@@ -25,6 +25,7 @@ export default function ArgumentOptionField(props) {
             label={t("argumentOption")}
             helperText={t("app_editor_help:ArgumentOption")}
             component={FormTextField}
+            {...custom}
         />
     );
 }

--- a/src/components/apps/editor/params/common/ExcludeArgumentField.js
+++ b/src/components/apps/editor/params/common/ExcludeArgumentField.js
@@ -14,7 +14,7 @@ import ids from "../../ids";
 import { build as buildID, FormCheckbox } from "@cyverse-de/ui-lib";
 
 export default function ExcludeArgumentField(props) {
-    const { baseId, fieldName } = props;
+    const { baseId, fieldName, ...custom } = props;
 
     const { t } = useTranslation(["app_editor", "app_editor_help"]);
 
@@ -25,6 +25,7 @@ export default function ExcludeArgumentField(props) {
             label={t("excludeWhenEmpty")}
             helperText={t("app_editor_help:ExcludeArgument")}
             component={FormCheckbox}
+            {...custom}
         />
     );
 }

--- a/src/components/apps/editor/params/common/RequiredField.js
+++ b/src/components/apps/editor/params/common/RequiredField.js
@@ -14,7 +14,7 @@ import ids from "../../ids";
 import { build as buildID, FormCheckbox } from "@cyverse-de/ui-lib";
 
 export default function RequiredField(props) {
-    const { baseId, fieldName } = props;
+    const { baseId, fieldName, ...custom } = props;
 
     const { t } = useTranslation("app_editor");
 
@@ -24,6 +24,7 @@ export default function RequiredField(props) {
             name={`${fieldName}.required`}
             label={t("isRequired")}
             component={FormCheckbox}
+            {...custom}
         />
     );
 }

--- a/src/components/apps/editor/params/common/VisibleField.js
+++ b/src/components/apps/editor/params/common/VisibleField.js
@@ -14,7 +14,7 @@ import ids from "../../ids";
 import { build as buildID, FormCheckbox } from "@cyverse-de/ui-lib";
 
 export default function VisibleField(props) {
-    const { baseId, fieldName } = props;
+    const { baseId, fieldName, ...custom } = props;
 
     const { t } = useTranslation("app_editor");
 
@@ -24,6 +24,7 @@ export default function VisibleField(props) {
             name={`${fieldName}.isVisible`}
             label={t("isVisible")}
             component={FormCheckbox}
+            {...custom}
         />
     );
 }

--- a/src/components/apps/editor/params/validators/CharacterLimitField.js
+++ b/src/components/apps/editor/params/validators/CharacterLimitField.js
@@ -12,13 +12,14 @@ import ids from "../../ids";
 import { build as buildID, FormIntegerField } from "@cyverse-de/ui-lib";
 
 export default function CharacterLimitField(props) {
-    const { baseId, fieldName } = props;
+    const { baseId, fieldName, ...custom } = props;
 
     return (
         <FastField
             id={buildID(baseId, ids.PARAM_FIELDS.ARGUMENT_OPTION)}
             name={`${fieldName}.params.0`}
             component={FormIntegerField}
+            {...custom}
         />
     );
 }

--- a/src/components/apps/editor/params/validators/DoubleAboveField.js
+++ b/src/components/apps/editor/params/validators/DoubleAboveField.js
@@ -12,13 +12,14 @@ import ids from "../../ids";
 import { build as buildID, FormNumberField } from "@cyverse-de/ui-lib";
 
 export default function DoubleAboveField(props) {
-    const { baseId, fieldName } = props;
+    const { baseId, fieldName, ...custom } = props;
 
     return (
         <FastField
             id={buildID(baseId, ids.PARAM_FIELDS.ARGUMENT_OPTION)}
             name={`${fieldName}.params.0`}
             component={FormNumberField}
+            {...custom}
         />
     );
 }

--- a/src/components/apps/editor/params/validators/DoubleBelowField.js
+++ b/src/components/apps/editor/params/validators/DoubleBelowField.js
@@ -12,13 +12,14 @@ import ids from "../../ids";
 import { build as buildID, FormNumberField } from "@cyverse-de/ui-lib";
 
 export default function DoubleBelowField(props) {
-    const { baseId, fieldName } = props;
+    const { baseId, fieldName, ...custom } = props;
 
     return (
         <FastField
             id={buildID(baseId, ids.PARAM_FIELDS.ARGUMENT_OPTION)}
             name={`${fieldName}.params.0`}
             component={FormNumberField}
+            {...custom}
         />
     );
 }

--- a/src/components/apps/editor/params/validators/DoubleRangeField.js
+++ b/src/components/apps/editor/params/validators/DoubleRangeField.js
@@ -14,7 +14,7 @@ import { build as buildID, FormNumberField } from "@cyverse-de/ui-lib";
 import { Grid } from "@material-ui/core";
 
 export default function DoubleRangeField(props) {
-    const { baseId, fieldName } = props;
+    const { baseId, fieldName, ...custom } = props;
 
     return (
         <Grid container wrap="nowrap">
@@ -22,11 +22,13 @@ export default function DoubleRangeField(props) {
                 id={buildID(baseId, 0, ids.PARAM_FIELDS.ARGUMENT_OPTION)}
                 name={`${fieldName}.params.0`}
                 component={FormNumberField}
+                {...custom}
             />
             <FastField
                 id={buildID(baseId, 1, ids.PARAM_FIELDS.ARGUMENT_OPTION)}
                 name={`${fieldName}.params.1`}
                 component={FormNumberField}
+                {...custom}
             />
         </Grid>
     );

--- a/src/components/apps/editor/params/validators/IntAboveField.js
+++ b/src/components/apps/editor/params/validators/IntAboveField.js
@@ -12,13 +12,14 @@ import ids from "../../ids";
 import { build as buildID, FormIntegerField } from "@cyverse-de/ui-lib";
 
 export default function IntAboveField(props) {
-    const { baseId, fieldName } = props;
+    const { baseId, fieldName, ...custom } = props;
 
     return (
         <FastField
             id={buildID(baseId, ids.PARAM_FIELDS.ARGUMENT_OPTION)}
             name={`${fieldName}.params.0`}
             component={FormIntegerField}
+            {...custom}
         />
     );
 }

--- a/src/components/apps/editor/params/validators/IntBelowField.js
+++ b/src/components/apps/editor/params/validators/IntBelowField.js
@@ -12,13 +12,14 @@ import ids from "../../ids";
 import { build as buildID, FormIntegerField } from "@cyverse-de/ui-lib";
 
 export default function IntBelowField(props) {
-    const { baseId, fieldName } = props;
+    const { baseId, fieldName, ...custom } = props;
 
     return (
         <FastField
             id={buildID(baseId, ids.PARAM_FIELDS.ARGUMENT_OPTION)}
             name={`${fieldName}.params.0`}
             component={FormIntegerField}
+            {...custom}
         />
     );
 }

--- a/src/components/apps/editor/params/validators/IntRangeField.js
+++ b/src/components/apps/editor/params/validators/IntRangeField.js
@@ -14,7 +14,7 @@ import { build as buildID, FormIntegerField } from "@cyverse-de/ui-lib";
 import { Grid } from "@material-ui/core";
 
 export default function IntRangeField(props) {
-    const { baseId, fieldName } = props;
+    const { baseId, fieldName, ...custom } = props;
 
     return (
         <Grid container wrap="nowrap">
@@ -22,11 +22,13 @@ export default function IntRangeField(props) {
                 id={buildID(baseId, 0, ids.PARAM_FIELDS.ARGUMENT_OPTION)}
                 name={`${fieldName}.params.0`}
                 component={FormIntegerField}
+                {...custom}
             />
             <FastField
                 id={buildID(baseId, 1, ids.PARAM_FIELDS.ARGUMENT_OPTION)}
                 name={`${fieldName}.params.1`}
                 component={FormIntegerField}
+                {...custom}
             />
         </Grid>
     );

--- a/src/components/apps/editor/params/validators/RegexField.js
+++ b/src/components/apps/editor/params/validators/RegexField.js
@@ -12,13 +12,14 @@ import ids from "../../ids";
 import { build as buildID, FormTextField } from "@cyverse-de/ui-lib";
 
 export default function RegexField(props) {
-    const { baseId, fieldName } = props;
+    const { baseId, fieldName, ...custom } = props;
 
     return (
         <FastField
             id={buildID(baseId, ids.PARAM_FIELDS.ARGUMENT_OPTION)}
             name={`${fieldName}.params.0`}
             component={FormTextField}
+            {...custom}
         />
     );
 }

--- a/src/components/apps/editor/params/validators/ValidationRulesEditor.js
+++ b/src/components/apps/editor/params/validators/ValidationRulesEditor.js
@@ -47,7 +47,7 @@ import { Add, Delete } from "@material-ui/icons";
 const useStyles = makeStyles(styles);
 
 function ValidationRulesEditorRow(props) {
-    const { baseId, fieldName, ruleType, onDelete } = props;
+    const { baseId, cosmeticOnly, fieldName, ruleType, onDelete } = props;
 
     const { t } = useTranslation(["app_editor", "common"]);
     const classes = useStyles();
@@ -120,18 +120,21 @@ function ValidationRulesEditorRow(props) {
                 <RuleParamComponent
                     baseId={buildID(baseId, "params")}
                     fieldName={fieldName}
+                    disabled={cosmeticOnly}
                 />
             </TableCell>
-            <TableCell padding="none">
-                <Button
-                    id={buildID(baseId, ids.BUTTONS.DELETE_BTN)}
-                    aria-label={t("common:delete")}
-                    className={classes.deleteIcon}
-                    onClick={onDelete}
-                >
-                    <Delete />
-                </Button>
-            </TableCell>
+            {!cosmeticOnly && (
+                <TableCell padding="none">
+                    <Button
+                        id={buildID(baseId, ids.BUTTONS.DELETE_BTN)}
+                        aria-label={t("common:delete")}
+                        className={classes.deleteIcon}
+                        onClick={onDelete}
+                    >
+                        <Delete />
+                    </Button>
+                </TableCell>
+            )}
         </TableRow>
     );
 }
@@ -139,6 +142,7 @@ function ValidationRulesEditorRow(props) {
 function ValidationRulesEditor(props) {
     const {
         baseId,
+        cosmeticOnly,
         fieldName,
         validators,
         ruleOptions,
@@ -192,20 +196,22 @@ function ValidationRulesEditor(props) {
                             <TableCell>
                                 <Typography>{t("validatorParams")}</Typography>
                             </TableCell>
-                            <TableCell>
-                                <Button
-                                    id={buildID(
-                                        baseId,
-                                        ids.BUTTONS.ADD_PARAM_ARG
-                                    )}
-                                    color="primary"
-                                    variant="outlined"
-                                    startIcon={<Add />}
-                                    onClick={handleAddRuleClick}
-                                >
-                                    {t("common:add")}
-                                </Button>
-                            </TableCell>
+                            {!cosmeticOnly && (
+                                <TableCell>
+                                    <Button
+                                        id={buildID(
+                                            baseId,
+                                            ids.BUTTONS.ADD_PARAM_ARG
+                                        )}
+                                        color="primary"
+                                        variant="outlined"
+                                        startIcon={<Add />}
+                                        onClick={handleAddRuleClick}
+                                    >
+                                        {t("common:add")}
+                                    </Button>
+                                </TableCell>
+                            )}
                         </TableRow>
                     </TableHead>
                     <TableBody>
@@ -213,6 +219,7 @@ function ValidationRulesEditor(props) {
                             <ValidationRulesEditorRow
                                 key={index}
                                 baseId={buildID(baseId, index)}
+                                cosmeticOnly={cosmeticOnly}
                                 fieldName={`${fieldName}.${index}`}
                                 ruleType={rule.type}
                                 onDelete={onDelete(index)}

--- a/src/components/apps/launch/InputSelector.js
+++ b/src/components/apps/launch/InputSelector.js
@@ -110,6 +110,7 @@ const InputSelector = ({
             <InputAdornment position="end">
                 <BrowseButton
                     baseId={id}
+                    disabled={props.disabled}
                     startingPath={startingPath}
                     acceptedType={acceptedType}
                     multiSelect={false}
@@ -127,7 +128,7 @@ const InputSelector = ({
         ),
     };
 
-    if (field.value && !required) {
+    if (field.value && !required && !props.disabled) {
         inputProps.endAdornment = (
             <IconButton
                 id={buildDebugId(field.name, ids.BUTTONS.DELETE)}

--- a/src/components/apps/listing/RowDotMenu.js
+++ b/src/components/apps/listing/RowDotMenu.js
@@ -9,7 +9,7 @@ import { useTranslation } from "i18n";
 import { build, DotMenu } from "@cyverse-de/ui-lib";
 
 import ids from "../ids";
-import { isWritable } from "../utils";
+import { hasOwn, isWritable } from "../utils";
 import { getHost } from "components/utils/getHost";
 import { copyStringToClipboard } from "components/utils/copyStringToClipboard";
 import { copyLinkToClipboardHandler } from "components/utils/copyLinkToClipboardHandler";
@@ -22,7 +22,7 @@ import CopyLinkMenuItem from "components/utils/CopyLinkMenuItem";
 import SharingMenuItem from "components/sharing/SharingMenuItem";
 import shareIds from "components/sharing/ids";
 import { getAppListingLinkRefs } from "components/apps/utils";
-import Permissions from "components/models/Permissions";
+import { useUserProfile } from "contexts/userProfile";
 import PublishAppDialog from "../PublishAppDialog";
 
 function RowDotMenu(props) {
@@ -38,10 +38,14 @@ function RowDotMenu(props) {
         isAdminView,
     } = props;
 
-    const canEdit = isWritable(app.permission);
-    const canPublish = app?.permission === Permissions.OWN;
     const [publishDialogOpen, setPublishDialogOpen] = React.useState(false);
+    const [userProfile] = useUserProfile();
     const { t } = useTranslation("common");
+
+    const canPublish = hasOwn(app?.permission);
+    const canEdit =
+        isWritable(app?.permission) ||
+        app?.integrator_email === userProfile?.attributes?.email;
 
     return (
         <>

--- a/src/components/apps/utils.js
+++ b/src/components/apps/utils.js
@@ -113,6 +113,10 @@ export const canShare = (apps) => {
     );
 };
 
+export const hasOwn = (permission) => {
+    return Permissions.OWN === permission;
+};
+
 export const isWritable = (permission) => {
     return (
         permissionHierarchy(permission) >=

--- a/src/server/api/apps.js
+++ b/src/server/api/apps.js
@@ -81,6 +81,19 @@ export default function appsRouter() {
         })
     );
 
+    logger.info("adding the PATCH /apps/:systemId/:appId handler");
+    api.patch(
+        "/apps/:systemId/:appId",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "PATCH",
+            pathname: "/apps/:systemId/:appId",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        })
+    );
+
     logger.info("adding the PUT /apps/:systemId/:appId handler");
     api.put(
         "/apps/:systemId/:appId",

--- a/src/serviceFacades/apps.js
+++ b/src/serviceFacades/apps.js
@@ -154,6 +154,14 @@ function updateApp({ systemId, appId, app }) {
     });
 }
 
+function updateAppLabels({ systemId, appId, app }) {
+    return callApi({
+        endpoint: `/api/apps/${systemId}/${appId}`,
+        method: "PATCH",
+        body: app,
+    });
+}
+
 function getAppDetails(key, { systemId, appId }) {
     return callApi({
         endpoint: `/api/apps/${systemId}/${appId}/details`,
@@ -428,6 +436,7 @@ export {
     appFavorite,
     rateApp,
     updateApp,
+    updateAppLabels,
     searchApps,
     searchAppsInfiniteQuery,
     getAppDoc,

--- a/stories/apps/Editor.stories.js
+++ b/stories/apps/Editor.stories.js
@@ -55,6 +55,13 @@ mockAxios.onPut(/\/api\/apps\/.*/).reply((config) => {
     return [200, app];
 });
 
+mockAxios.onPatch(/\/api\/apps\/.*/).reply((config) => {
+    const app = JSON.parse(config.data);
+    console.log("Update App Labels", config.url, app);
+
+    return [200, app];
+});
+
 export const NewApp = (props) => {
     return (
         <AppEditor

--- a/stories/apps/Editor.stories.js
+++ b/stories/apps/Editor.stories.js
@@ -77,7 +77,7 @@ export const KitchenSinkEditor = (props) => {
             appDescription={!(loading || loadingError) && AppDescriptionMock}
             loading={loading}
             loadingError={loadingError && mockErrorResponse}
-            cosmeticOnly={cosmeticOnly}
+            cosmeticOnly={!!cosmeticOnly}
         />
     );
 };


### PR DESCRIPTION
This PR will update the App Editor to allow editing only labels and info text in app groups and parameters for public apps.

App integrators lose write permissions for their public apps, so the edit action now also displays if the user's email matches the app's integrator email.

All action buttons for every group and param will be replaced by a single edit button, and each property form will disable all form fields except for label and help text fields.

Also added a warning/help message to the top of the form when editing public apps.

![Public App - step 1 - desktop](https://user-images.githubusercontent.com/996408/116490408-295eed80-a84c-11eb-8d08-82bf446e23e2.png)

![Public App - step 2 - desktop](https://user-images.githubusercontent.com/996408/116491056-d5ed9f00-a84d-11eb-88ce-767ba74cd7b0.png)

![Public App - info param properties - desktop](https://user-images.githubusercontent.com/996408/116488424-36c5a900-a847-11eb-90ad-6cc16f7ef435.png)

![Public App - text param properties - desktop](https://user-images.githubusercontent.com/996408/116491510-e0f4ff00-a84e-11eb-87f7-acc4d9b79967.png)

---

On mobile:
![Public App - step 1 - mobile](https://user-images.githubusercontent.com/996408/116491222-42689e00-a84e-11eb-90a0-c654ad9f90db.png)

![Public App - step 2 - mobile](https://user-images.githubusercontent.com/996408/116491153-13522c80-a84e-11eb-92a5-2f7996538b9f.png)

![Public App - text param properties - mobile](https://user-images.githubusercontent.com/996408/116491331-7b087780-a84e-11eb-89a2-43e0f704f7f6.png)
