### PR TITLE
CORE-1398 Fix display of App Editor Selection param default values

### DIFF
--- a/src/components/apps/editor/ParamPropertyForm.js
+++ b/src/components/apps/editor/ParamPropertyForm.js
@@ -68,7 +68,14 @@ function ParamPreview(props) {
 }
 
 function PropertyFormFields(props) {
-    const { baseId, cosmeticOnly, fieldName, param } = props;
+    const {
+        baseId,
+        cosmeticOnly,
+        keyCount,
+        setKeyCount,
+        fieldName,
+        param,
+    } = props;
 
     const baseParamId = buildID(baseId, fieldName);
 
@@ -132,6 +139,8 @@ function PropertyFormFields(props) {
                     cosmeticOnly={cosmeticOnly}
                     fieldName={fieldName}
                     paramArguments={param.arguments}
+                    keyCount={keyCount}
+                    setKeyCount={setKeyCount}
                 />
             );
 
@@ -214,7 +223,15 @@ function PropertyFormFields(props) {
 }
 
 function ParamPropertyForm(props) {
-    const { baseId, cosmeticOnly, values, fieldName, onClose } = props;
+    const {
+        baseId,
+        cosmeticOnly,
+        keyCount,
+        setKeyCount,
+        values,
+        fieldName,
+        onClose,
+    } = props;
 
     const { t } = useTranslation(["app_editor", "app_param_types", "common"]);
 
@@ -264,6 +281,8 @@ function ParamPropertyForm(props) {
                     cosmeticOnly={cosmeticOnly}
                     fieldName={fieldName}
                     param={param}
+                    keyCount={keyCount}
+                    setKeyCount={setKeyCount}
                 />
             </CardContent>
             <CardActions>{doneBtn}</CardActions>

--- a/src/components/apps/editor/index.js
+++ b/src/components/apps/editor/index.js
@@ -401,6 +401,8 @@ const AppEditor = (props) => {
                                     }}
                                     fieldName={editParamField}
                                     cosmeticOnly={cosmeticOnly}
+                                    keyCount={keyCount}
+                                    setKeyCount={setKeyCount}
                                     values={values}
                                 />
                             ) : activeStepInfo === stepAppInfo ? (

--- a/src/components/apps/launch/params/Selection.js
+++ b/src/components/apps/launch/params/Selection.js
@@ -22,7 +22,13 @@ export default function Selection({ param, ...props }) {
             {...props}
         >
             {param?.arguments?.map((arg) => (
-                <MenuItem key={arg.value} value={arg}>
+                // MenuItem.key can use arg.key or arg.id,
+                // which should always be set (from the service or app editor),
+                // but `name.value` should also be a reasonable fallback.
+                <MenuItem
+                    key={arg.key || arg.id || `${arg.name}.${arg.value}`}
+                    value={arg}
+                >
                     {arg.display}
                 </MenuItem>
             ))}


### PR DESCRIPTION
This PR will fix some display issues in the App Editor Selection param default values.

The App Editor will now add unique keys to selection list items in the form, which will allow the Selection param property editor to reset its default value to the actual instance of the list item with the matching key.

Before this fix, the Selection param property editor's "Default value" field would not update as changes were made to list items (since the common `DefaultValueField` uses a `FastField`). Also, when editing the "Display", "Argument", or "Value" field of a list item that is also selected as the parameter's default value, then the preview list at the top of the form would appear to clear the selected value (it uses a form `Field` so it updates right away, but editing the selected list item causes formik to create a new instance of that item which was not getting reset in the preview field). 

For example, in the following Selection param property editor "New Argument 2" is the list item selected as the default value:
![App Editor - Selection param property editor](https://user-images.githubusercontent.com/996408/116927805-0009dd00-ac11-11eb-91db-affffcf0efed.png)

The display bugs in this editor are shown the following screenshot, after simply editing the default value's "Display" label to "Edited Argument 2":
![App Editor - Selection param property editor display bug](https://user-images.githubusercontent.com/996408/116927916-2fb8e500-ac11-11eb-8067-b6a62c1e298f.png)

This is only a display bug in this editor form, and does not affect the actual default value when saving the app.