### PR TITLE
Cancel consumer when websocket is closed.

### DIFF
--- a/src/server/amqp.js
+++ b/src/server/amqp.js
@@ -58,7 +58,8 @@ export function getNotifications(user, ws) {
     }
 
     const QUEUE = NOTIFICATION_QUEUE + user;
-    ws.on("close", function () {
+
+    const connectionCleanUp = () => {
         msgChannel.unbindQueue(
             QUEUE,
             config.amqpExchangeName,
@@ -71,17 +72,15 @@ export function getNotifications(user, ws) {
                 " consumer Tag:" +
                 consumerTag
         );
+    };
+
+    ws.on("close", function () {
+        connectionCleanUp();
     });
 
     ws.on("error", function (error) {
         logger.info("Websocket error: " + error);
-        msgChannel.unbindQueue(
-            QUEUE,
-            config.amqpExchangeName,
-            NOTIFICATION_ROUTING_KEY + user
-        );
-        msgChannel.cancel(consumerTag);
-        ws.close();
+        connectionCleanUp();
     });
 
     if (msgChannel) {


### PR DESCRIPTION
SSIA.
Notes on how to test:
* Login to RabbitMQ web console and go to your queue in the `Queues` tab. Your queue name will look like `de_notifications.sriram`. You can easily find you queue by filtering with your cyverse username. Click on the queue name.

![image](https://user-images.githubusercontent.com/1250790/117196422-7430b600-adb4-11eb-9adf-ad6b1eccbe12.png)

* Now login to DE.  Copy the consumer tag information printed on the server console.
* Use browser find to find that consumer tag in your queue's list of consumers.
![image](https://user-images.githubusercontent.com/1250790/117196707-d093d580-adb4-11eb-87aa-31101099b515.png)

* Now close the DE browser tab and refresh your RabbitMQ web console browser tab. The consumer tag should have disappeared from your queue. 
