### PR TITLE
CORE-1408 Add last modified and size to default columns

### DIFF
--- a/src/components/data/listing/TableView.js
+++ b/src/components/data/listing/TableView.js
@@ -100,7 +100,12 @@ const invalidRowStyles = makeStyles((theme) => ({
 }));
 
 function getDefaultCols(rowDotMenuVisibility, dataRecordFields) {
-    const defCols = [dataRecordFields.CHECKBOX.key, dataRecordFields.NAME.key];
+    const defCols = [
+        dataRecordFields.CHECKBOX.key,
+        dataRecordFields.NAME.key,
+        dataRecordFields.LAST_MODIFIED.key,
+        dataRecordFields.SIZE.key,
+    ];
     if (rowDotMenuVisibility) {
         defCols.push(dataRecordFields.DOT_MENU.key);
     }


### PR DESCRIPTION
From the discussion, it sounded like we're not concerned about mobile view having horizontal scroll with the extra columns.  If that's not the case, I can try to make it so the default for mobile is just the checkbox, name, and dot menu like before.

NOTE: This will not affect anyone who has already customized their columns.  Local storage gets priority.

Desktop:
![image](https://user-images.githubusercontent.com/8909156/117901252-c9bb0600-b27f-11eb-9800-9bf7b9302258.png)

Mobile:
![image](https://user-images.githubusercontent.com/8909156/117901269-d2134100-b27f-11eb-8111-6d637a4e26f4.png)
