### PR TITLE
CORE-1418 Refactor toolbar dot menus to have text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "version": "0.0.1",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@cyverse-de/ui-lib": "^7.0.1",
+                "@cyverse-de/ui-lib": "^7.1.1",
                 "@material-ui/core": "^4.11.0",
                 "@material-ui/icons": "^4.9.1",
                 "@material-ui/lab": "^4.0.0-alpha.56",
@@ -1488,9 +1488,9 @@
             "license": "CC0-1.0"
         },
         "node_modules/@cyverse-de/ui-lib": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@cyverse-de/ui-lib/-/ui-lib-7.0.1.tgz",
-            "integrity": "sha512-uOkxGOrNPQ0IttmihgMmgMjY8zpxxak5YLUnXHN4ybwQCUlM/XGuE6ojxLhCwPOC2JyaBa98tjWL8HQBPXSeTA==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@cyverse-de/ui-lib/-/ui-lib-7.1.1.tgz",
+            "integrity": "sha512-HM0d5mB71KsD01DiSWvmi+NMR8ePwvG8tFOb7bNRb5/WwomkjwLM7SdFnI/mJpJJUyChRFLHIpssoom7DkKwtA==",
             "dependencies": {
                 "@date-fns/upgrade": "^1.0.3",
                 "classnames": "^2.2.6",
@@ -29517,9 +29517,9 @@
             "version": "10.1.0"
         },
         "@cyverse-de/ui-lib": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@cyverse-de/ui-lib/-/ui-lib-7.0.1.tgz",
-            "integrity": "sha512-uOkxGOrNPQ0IttmihgMmgMjY8zpxxak5YLUnXHN4ybwQCUlM/XGuE6ojxLhCwPOC2JyaBa98tjWL8HQBPXSeTA==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@cyverse-de/ui-lib/-/ui-lib-7.1.1.tgz",
+            "integrity": "sha512-HM0d5mB71KsD01DiSWvmi+NMR8ePwvG8tFOb7bNRb5/WwomkjwLM7SdFnI/mJpJJUyChRFLHIpssoom7DkKwtA==",
             "requires": {
                 "@date-fns/upgrade": "^1.0.3",
                 "classnames": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         ]
     },
     "dependencies": {
-        "@cyverse-de/ui-lib": "^7.0.1",
+        "@cyverse-de/ui-lib": "^7.1.1",
         "@material-ui/core": "^4.11.0",
         "@material-ui/icons": "^4.9.1",
         "@material-ui/lab": "^4.0.0-alpha.56",

--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -24,6 +24,7 @@
     "discovery": "<b>D</b>iscovery",
     "doiRequests": "DOI Requests",
     "done": "Done",
+    "dotMenuText": "More Actions",
     "drawerMenuAriaLabel": "drawer menu",
     "edit": "Edit",
     "email": "Email",

--- a/src/components/analyses/toolbar/AnalysesDotMenu.js
+++ b/src/components/analyses/toolbar/AnalysesDotMenu.js
@@ -345,6 +345,7 @@ function AnalysesDotMenu({
 }) {
     // These props need to be spread down into DotMenuItems below.
     const { baseId, isSingleSelection } = props;
+    const { t } = useTranslation("common");
 
     const selectedAnalyses = getSelectedAnalyses ? getSelectedAnalyses() : null;
 
@@ -375,6 +376,7 @@ function AnalysesDotMenu({
         <DotMenu
             baseId={baseId}
             ButtonProps={ButtonProps}
+            buttonText={t("common:dotMenuText")}
             render={(onClose) => (
                 <DotMenuItems
                     {...props}

--- a/src/components/apps/toolbar/AppsDotMenu.js
+++ b/src/components/apps/toolbar/AppsDotMenu.js
@@ -46,7 +46,7 @@ function AppsDotMenu(props) {
         onDocSelected,
         onQLSelected,
     } = props;
-    const { t } = useTranslation("apps");
+    const { t } = useTranslation(["apps", "common"]);
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down("xs"));
     if (!detailsEnabled && !canShare && !isMobile) {
@@ -56,6 +56,7 @@ function AppsDotMenu(props) {
         <DotMenu
             baseId={baseId}
             ButtonProps={ButtonProps}
+            buttonText={t("common:dotMenuText")}
             render={(onClose) => [
                 detailsEnabled && (
                     <MenuItem

--- a/src/components/data/toolbar/DataDotMenu.js
+++ b/src/components/data/toolbar/DataDotMenu.js
@@ -10,7 +10,7 @@ import { useRouter } from "next/router";
 
 import ids from "../ids";
 import shareIds from "components/sharing/ids";
-import { isOwner, isWritable, containsFolders } from "../utils";
+import { containsFolders, isOwner, isWritable } from "../utils";
 import CreateFolderDialog from "../CreateFolderDialog";
 import UploadMenuItems from "./UploadMenuItems";
 
@@ -30,8 +30,8 @@ import ResourceTypes from "components/models/ResourceTypes";
 import constants from "../../../constants";
 
 import {
-    MULTI_INPUT_PATH_LIST,
     HT_ANALYSIS_PATH_LIST,
+    MULTI_INPUT_PATH_LIST,
 } from "serviceFacades/filesystem";
 
 import { build, DotMenu } from "@cyverse-de/ui-lib";
@@ -45,8 +45,8 @@ import {
     CreateNewFolder,
     ListAlt,
     Queue as AddToBagIcon,
-    Send as RequestIcon,
     Refresh,
+    Send as RequestIcon,
 } from "@material-ui/icons";
 import NavigationConstants from "common/NavigationConstants";
 import TrashMenuItems from "./TrashMenuItems";
@@ -87,7 +87,7 @@ function DataDotMenu(props) {
         onMoveSelected,
     } = props;
 
-    const { t } = useTranslation("data");
+    const { t } = useTranslation(["data", "common"]);
 
     const [createFolderDlgOpen, setCreateFolderDlgOpen] = useState(false);
     const [pathListDlgOpen, setPathListDlgOpen] = useState(false);
@@ -132,6 +132,8 @@ function DataDotMenu(props) {
             <DotMenu
                 baseId={baseId}
                 ButtonProps={ButtonProps}
+                buttonText={t("common:dotMenuText")}
+                iconOnlyBreakpoint="sm"
                 render={(onClose) => [
                     isSmall
                         ? [

--- a/src/components/metadata/form/MetadataFormToolbar.js
+++ b/src/components/metadata/form/MetadataFormToolbar.js
@@ -80,6 +80,8 @@ const MetadataFormToolbar = (props) => {
             <DotMenu
                 baseId={baseId}
                 buttonText={t("common:dotMenuText")}
+                ButtonProps={{ classes: { root: classes.dotMenu } }}
+                iconOnlyBreakpoint="sm"
                 render={(onClose) => [
                     showViewInTemplate && (
                         <MenuItem

--- a/src/components/metadata/form/MetadataFormToolbar.js
+++ b/src/components/metadata/form/MetadataFormToolbar.js
@@ -79,6 +79,7 @@ const MetadataFormToolbar = (props) => {
 
             <DotMenu
                 baseId={baseId}
+                buttonText={t("common:dotMenuText")}
                 render={(onClose) => [
                     showViewInTemplate && (
                         <MenuItem

--- a/src/components/metadata/styles.js
+++ b/src/components/metadata/styles.js
@@ -41,6 +41,7 @@ const styles = (theme) => ({
         paddingLeft: theme.typography.pxToRem(4),
         paddingRight: theme.typography.pxToRem(4),
     },
+    dotMenu: { marginLeft: theme.spacing(2) },
 });
 
 export default styles;

--- a/src/components/tools/toolbar/ToolsDotMenu.js
+++ b/src/components/tools/toolbar/ToolsDotMenu.js
@@ -163,6 +163,7 @@ export default function ToolsDotMenu({
     ...props
 }) {
     const { baseId, isSingleSelection, isAdmin } = props;
+    const { t } = useTranslation("common");
     const selectedTools = getSelectedTools ? getSelectedTools() : null;
     const allowEditing =
         canEdit &&
@@ -179,6 +180,7 @@ export default function ToolsDotMenu({
         <DotMenu
             baseId={baseId}
             ButtonProps={ButtonProps}
+            buttonText={t("dotMenuText")}
             render={(onClose) => (
                 <DotMenuItems
                     {...props}


### PR DESCRIPTION
Buttons with text on large screens, regular icon buttons with no text on smaller screens

Desktop Data:
![image](https://user-images.githubusercontent.com/8909156/118202828-91e2c880-b40f-11eb-99e4-8c8a1a2511d1.png)

SM and below Data:
<img width="904" alt="image" src="https://user-images.githubusercontent.com/8909156/118202852-9d35f400-b40f-11eb-963f-fc2dcf4c15cb.png">

Apps, no change

Desktop Analyses:
<img width="1193" alt="image" src="https://user-images.githubusercontent.com/8909156/118203033-0cabe380-b410-11eb-9157-4cd8d86b045b.png">

XS size Analyses:
<img width="564" alt="image" src="https://user-images.githubusercontent.com/8909156/118203090-2cdba280-b410-11eb-9808-0f0547f2c925.png">

Desktop metadata:
![image](https://user-images.githubusercontent.com/8909156/118204377-eb002b80-b412-11eb-8c19-7e8b48cfc3b1.png)

Small metadata:
![image](https://user-images.githubusercontent.com/8909156/118204398-f7848400-b412-11eb-9b4a-2887d834800f.png)
