### PR TITLE
CORE-1422 Add a `/de` page for redirecting legacy links

### DIFF
--- a/src/components/apps/quickLaunch/QuickLaunchListing.js
+++ b/src/components/apps/quickLaunch/QuickLaunchListing.js
@@ -14,6 +14,8 @@ import Link from "next/link";
 import ids from "../ids";
 import constants from "../constants";
 import QuickLaunch from "./QuickLaunch";
+
+import { getQuickLaunchPath } from "components/apps/utils";
 import { getHost } from "components/utils/getHost";
 import ConfirmationDialog from "components/utils/ConfirmationDialog";
 import GridLoading from "components/utils/GridLoading";
@@ -216,7 +218,11 @@ function ListQuickLaunches(props) {
 
     const getShareUrl = () => {
         const host = getHost();
-        const url = `${host}/${NavigationConstants.APPS}/${systemId}/${appId}/launch?quick-launch-id=${selected?.id}`;
+        const url = `${host}${getQuickLaunchPath(
+            systemId,
+            appId,
+            selected?.id
+        )}`;
         return url;
     };
 

--- a/src/components/apps/utils.js
+++ b/src/components/apps/utils.js
@@ -35,6 +35,19 @@ export const getAppLaunchPath = (systemId, appId) =>
     `/${NavigationConstants.APPS}/${systemId}/${appId}/launch`;
 
 /**
+ * Builds a path to the App Launch Wizard for the Quick Launch with
+ * the given IDs.
+ *
+ * @param {string} systemId The app's system ID.
+ * @param {string} appId The app's ID.
+ * @param {string} quickLaunchId The Quick Launch ID.
+ * @returns The path to the App Launch Wizard for the Quick Launch with
+ * the given IDs.
+ */
+export const getQuickLaunchPath = (systemId, appId, quickLaunchId) =>
+    `/${NavigationConstants.APPS}/${systemId}/${appId}/launch?quick-launch-id=${quickLaunchId}`;
+
+/**
  * Builds a path to the App Editor for the app with the given IDs.
  *
  * @param {string} systemId The app's system ID.

--- a/src/pages/de.js
+++ b/src/pages/de.js
@@ -8,7 +8,11 @@ import React from "react";
 
 import { useRouter } from "next/router";
 
-import { getAppLaunchPath, getQuickLaunchPath } from "components/apps/utils";
+import {
+    getAppLaunchPath,
+    getListingPath,
+    getQuickLaunchPath,
+} from "components/apps/utils";
 import { getFolderPage } from "components/data/utils";
 import systemId from "components/models/systemId";
 import BasicTable from "components/utils/BasicTable";
@@ -20,10 +24,25 @@ export default function DeLegacyRedirector() {
     let redirectPath;
     switch (query?.type) {
         case "apps":
-            redirectPath = getAppLaunchPath(
-                query["system-id"],
-                query["app-id"]
-            );
+            if (query["app-category"]) {
+                redirectPath = getListingPath(
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    JSON.stringify({
+                        system_id: query["system-id"] || systemId.de,
+                        id: query["app-category"],
+                    })
+                );
+            } else {
+                redirectPath = getAppLaunchPath(
+                    query["system-id"],
+                    query["app-id"]
+                );
+            }
+
             break;
 
         case "data":

--- a/src/pages/de.js
+++ b/src/pages/de.js
@@ -1,0 +1,60 @@
+/**
+ * A backwards compatibility page for redirecting legacy links
+ * to their proper current locations.
+ *
+ * @author psarando
+ */
+import React from "react";
+
+import { useRouter } from "next/router";
+
+import { getAppLaunchPath, getQuickLaunchPath } from "components/apps/utils";
+import { getFolderPage } from "components/data/utils";
+import systemId from "components/models/systemId";
+import BasicTable from "components/utils/BasicTable";
+
+export default function DeLegacyRedirector() {
+    const router = useRouter();
+    const query = router.query;
+
+    let redirectPath;
+    switch (query?.type) {
+        case "apps":
+            redirectPath = getAppLaunchPath(
+                query["system-id"],
+                query["app-id"]
+            );
+            break;
+
+        case "data":
+            redirectPath = getFolderPage(query.folder);
+            break;
+
+        case "quick-launch":
+            redirectPath = getQuickLaunchPath(
+                query["system-id"] || systemId.de,
+                query["app-id"],
+                query["quick-launch-id"]
+            );
+            break;
+
+        default:
+            redirectPath = "/";
+            break;
+    }
+
+    // router can only be used client-side.
+    React.useEffect(() => {
+        router.replace(redirectPath);
+    }, [router, redirectPath]);
+
+    return (
+        <BasicTable
+            baseId="legacy-de-redirect-placeholder"
+            loading
+            tableSize="medium"
+            columns={[{ id: 1 }, { id: 2 }, { id: 3 }]}
+            data={[]}
+        />
+    );
+}


### PR DESCRIPTION
This PR will add a `/de` page for redirecting legacy links, such as the following:

* Quick Launch links
  * https://de.cyverse.org/de/?type=quick-launch&quick-launch-id=ff6719c2-90ef-43d8-98bb-7608c9c0a32b&app-id=67d15627-22c5-42bd-8daf-9af5deecceab
* App links
  * https://de.cyverse.org/de/?type=apps&app-id=67d15627-22c5-42bd-8daf-9af5deecceab&system-id=de
* Data links
  * https://de.cyverse.org/de/?type=data&folder=/iplant/home/shared/iplantcollaborative/example_data/wordcount

This page will also redirect to the root URL https://de.cyverse.org/ by default (so it will also handle redirecting https://de.cyverse.org/de to the Dashboard).

An empty, loading table will display while the redirect is handled.
![image](https://user-images.githubusercontent.com/996408/118341240-2feb9700-b4d3-11eb-9d58-2a95fe8f3e13.png)
