### PR TITLE
CORE-1411 Display analysis details input params as links

### DIFF
--- a/public/static/locales/en/analyses.json
+++ b/public/static/locales/en/analyses.json
@@ -40,6 +40,7 @@
     "email": "Email",
     "emptyValue": "-",
     "endDate": "End date",
+    "errorCheckingInputStat": "Error checking the status of this input.",
     "errorInputDoesNotExist": "The input file/folder no longer exists at that location: {{path}}",
     "extend": "Extend",
     "extendTime": "Extend Time Limit",

--- a/public/static/locales/en/analyses.json
+++ b/public/static/locales/en/analyses.json
@@ -40,6 +40,7 @@
     "email": "Email",
     "emptyValue": "-",
     "endDate": "End date",
+    "errorInputDoesNotExist": "The input file/folder no longer exists at that location: {{path}}",
     "extend": "Extend",
     "extendTime": "Extend Time Limit",
     "extendTimeLimitMessage": "This analysis is scheduled to be terminated at {{timeLimit}}. Do you wish to extend the time limit?",

--- a/src/components/analyses/details/ParamsPanel.js
+++ b/src/components/analyses/details/ParamsPanel.js
@@ -25,8 +25,7 @@ import AppParamTypes from "components/models/AppParamTypes";
 
 import DELink from "components/utils/DELink";
 import DETableHead from "components/utils/DETableHead";
-import DEErrorDialog from "components/utils/error/DEErrorDialog";
-import ErrorTypography from "components/utils/error/ErrorTypography";
+import ErrorTypographyWithDialog from "components/utils/error/ErrorTypographyWithDialog";
 import { ERROR_CODES, getErrorCode } from "components/utils/error/errorCode";
 import TableLoading from "components/utils/TableLoading";
 
@@ -51,10 +50,12 @@ function InputParameterValue(props) {
     const { id, param_type, path } = props;
 
     const [statError, setStatError] = React.useState();
+    const [otherError, setOtherError] = React.useState();
 
     React.useEffect(() => {
         if (!path) {
             setStatError(null);
+            setOtherError(null);
         }
     }, [path]);
 
@@ -72,14 +73,17 @@ function InputParameterValue(props) {
             enabled: path,
             onSuccess: () => {
                 setStatError(null);
+                setOtherError(null);
             },
             onError: (error) => {
                 if (ERROR_CODES.ERR_DOES_NOT_EXIST === getErrorCode(error)) {
                     setStatError(
                         t("errorInputDoesNotExist", { path: linkTarget })
                     );
+                    setOtherError(null);
                 } else {
                     setStatError(null);
+                    setOtherError(error);
                 }
             },
         },
@@ -104,6 +108,13 @@ function InputParameterValue(props) {
             <Typography variant="caption" color="error">
                 {statError}
             </Typography>
+            {otherError && (
+                <ErrorTypographyWithDialog
+                    baseId={id}
+                    errorMessage={t("errorCheckingInputStat")}
+                    errorObject={otherError}
+                />
+            )}
         </>
     );
 }
@@ -160,7 +171,7 @@ function AnalysisParams(props) {
     const { t } = useTranslation("analyses");
     const [order] = useState("desc");
     const [orderBy] = useState("Name");
-    const [errorDialogOpen, setErrorDialogOpen] = useState(false);
+
     let columns = columnData(t);
 
     if (isParamsFetching) {
@@ -173,20 +184,11 @@ function AnalysisParams(props) {
 
     if (paramsFetchError) {
         return (
-            <>
-                <ErrorTypography
-                    errorMessage={t("analysisParamFetchError")}
-                    onDetailsClick={() => setErrorDialogOpen(true)}
-                />
-                <DEErrorDialog
-                    open={errorDialogOpen}
-                    baseId={baseId}
-                    errorObject={paramsFetchError}
-                    handleClose={() => {
-                        setErrorDialogOpen(false);
-                    }}
-                />
-            </>
+            <ErrorTypographyWithDialog
+                baseId={baseId}
+                errorMessage={t("analysisParamFetchError")}
+                errorObject={paramsFetchError}
+            />
         );
     }
     return (

--- a/stories/analyses/AnalysesMocks.js
+++ b/stories/analyses/AnalysesMocks.js
@@ -164,7 +164,8 @@ export const params = {
             is_default_value: true,
             param_name: "Provide a reference annotation file (GTF/GFF)",
             param_value: {
-                value: "",
+                value:
+                    "/iplant/home/shared/iplantcollaborative/example_data/wordcount/SampleText.txt",
             },
             is_visible: true,
             full_param_id:
@@ -365,7 +366,8 @@ export const params = {
             is_default_value: true,
             param_name: "Masking file containing transcripts to ignore (.GTF)",
             param_value: {
-                value: "",
+                value:
+                    "/iplant/home/shared/cyverse_training/example/coffee_cake.txt",
             },
             is_visible: true,
             full_param_id:

--- a/stories/analyses/AnalysesParam.stories.js
+++ b/stories/analyses/AnalysesParam.stories.js
@@ -1,13 +1,34 @@
 import React from "react";
-import ParamsPanel from "../../src/components/analyses/details/ParamsPanel";
+
+import { mockAxios, errorResponseJSON } from "../axiosMock";
+
 import { params } from "./AnalysesMocks";
-import { UploadTrackingProvider } from "../../src/contexts/uploadTracking";
+
+import ParamsPanel from "components/analyses/details/ParamsPanel";
+import { UploadTrackingProvider } from "contexts/uploadTracking";
 
 export default {
     title: "Analyses / Param",
 };
 
 export function AnalysisParamTest(props) {
+    mockAxios.onPost("/api/filesystem/stat").replyOnce(404, {
+        error_code: "ERR_DOES_NOT_EXIST",
+        reason: "Not Found!",
+    });
+    mockAxios.onPost("/api/filesystem/stat").replyOnce(500, errorResponseJSON);
+    mockAxios.onPost("/api/filesystem/stat").reply((config) => {
+        const req = JSON.parse(config.data);
+        const path = req.paths[0];
+
+        return [
+            200,
+            {
+                paths: { [path]: { path } },
+            },
+        ];
+    });
+
     return (
         <UploadTrackingProvider>
             <ParamsPanel parameters={params.parameters} baseId="baseParamId" />


### PR DESCRIPTION
This PR updates the analysis details `ParamsPanel` to display input params as links that will navigate to the target folder, or parent folder for file params. It will also display a "not found" error message below the input's display name if the input no longer exists at that location.

The links are display using a `DELink`, which includes a tooltip of the link's target, which is the input's folder location.

![Input param not found](https://user-images.githubusercontent.com/996408/118551221-8692e400-b712-11eb-85a8-1283a49f70b4.png)
...
![Input param link](https://user-images.githubusercontent.com/996408/118551319-a75b3980-b712-11eb-956d-14ccdfee0946.png)
