### PR TITLE
CORE-1431 Update button in App Editor "Tool Used" field

### DIFF
--- a/src/components/apps/editor/AppInfo.js
+++ b/src/components/apps/editor/AppInfo.js
@@ -20,8 +20,8 @@ import {
     FormMultilineTextField,
 } from "@cyverse-de/ui-lib";
 
-import { IconButton, InputAdornment } from "@material-ui/core";
-import Search from "@material-ui/icons/Search";
+import { Button, InputAdornment } from "@material-ui/core";
+import { Build as SelectToolIcon } from "@material-ui/icons";
 
 /**
  * An Input Selector form field for picking data store file or folder paths.
@@ -33,7 +33,7 @@ const ToolSelector = (props) => {
 
     const [open, setOpen] = React.useState(false);
 
-    const { t } = useTranslation("app_editor");
+    const { t } = useTranslation(["app_editor", "common"]);
 
     return (
         <FormTextField
@@ -42,15 +42,17 @@ const ToolSelector = (props) => {
                 value: field.value?.name || "",
                 endAdornment: !disabled && (
                     <InputAdornment position="end">
-                        <IconButton
+                        <Button
                             id={buildID(id, ids.BUTTONS.SELECT_TOOL)}
                             aria-label={t("selectTool")}
                             color="primary"
                             size="small"
+                            variant="outlined"
+                            startIcon={<SelectToolIcon />}
                             onClick={() => setOpen(true)}
                         >
-                            <Search />
-                        </IconButton>
+                            {t("common:select")}
+                        </Button>
                         <ToolSelectionDialog
                             open={open}
                             onClose={() => setOpen(false)}


### PR DESCRIPTION
This PR will replace the `Search` icon button with a "Select" text button that uses a `Build` start-icon (same as the "Manage Tools" toolbar button).

This should help with the confusion where some users expect the "Tool used" field to allow searching with its text field.

Before:
![App Editor - Tool used search icon](https://user-images.githubusercontent.com/996408/119586138-f7747480-bd80-11eb-9c73-24053d8c2911.png)

---

After:
![App Editor - Tool used select icon](https://user-images.githubusercontent.com/996408/119586211-0fe48f00-bd81-11eb-8b15-e716b8e12729.png)
