### PR TITLE
Fix IDs not being set on next/link

### DIFF
--- a/src/components/search/GlobalSearchField.js
+++ b/src/components/search/GlobalSearchField.js
@@ -157,12 +157,10 @@ const SearchOption = React.forwardRef((props, ref) => {
     const classes = useStyles();
     const theme = useTheme();
 
-    const LinkType = onOptionSelected ? MuiLink : Link;
-
-    return (
+    const OptionLink = () => (
         <>
             <span className={classes.optionIcon}>{icon}</span>
-            <LinkType
+            <MuiLink
                 href={href}
                 as={as}
                 onClick={(event) => {
@@ -194,8 +192,16 @@ const SearchOption = React.forwardRef((props, ref) => {
                         </Highlighter>
                     </Typography>
                 </div>
-            </LinkType>
+            </MuiLink>
         </>
+    );
+
+    return onOptionSelected ? (
+        <OptionLink />
+    ) : (
+        <Link href={href} as={as} passHref>
+            <OptionLink />
+        </Link>
     );
 });
 


### PR DESCRIPTION
Nextjs's Link doesn't accept an ID attribute, so I refactored the options to always have MUI's Link, which does accept an ID. 