### PR TITLE
Instant Launches should set the output directory 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30530,7 +30530,6 @@
             "version": "3.9.9",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
             "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -34346,7 +34345,8 @@
                 "numeral": "^2.0.6",
                 "react-highlighter": "^0.4.3",
                 "react-loading-overlay": "^1.0.1",
-                "react-scripts": "3.3.0"
+                "react-scripts": "3.3.0",
+                "typescript": "^3.7.3"
             }
         },
         "@dabh/diagnostics": {
@@ -35595,6 +35595,7 @@
                     "integrity": "sha512-qOtwgiqI3LMqT0eXYNV6ykp7qSu0LQGeXxy3wOBGuDDqAizfgnAjomYEWGFcyKp5ahV7HCRCjxbixAklFPUmyw==",
                     "dev": true,
                     "requires": {
+                        "@babel/core": "^7.12.10",
                         "@babel/generator": "^7.12.11",
                         "@babel/parser": "^7.12.11",
                         "@babel/plugin-transform-react-jsx": "^7.12.12",
@@ -57206,8 +57207,7 @@
         "typescript": {
             "version": "3.9.9",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-            "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
-            "peer": true
+            "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w=="
         },
         "uc.micro": {
             "version": "1.0.6",

--- a/src/components/apps/launch/index.js
+++ b/src/components/apps/launch/index.js
@@ -12,7 +12,7 @@ import { useTranslation } from "i18n";
 
 import NavigationConstants from "common/NavigationConstants";
 
-import { useHomePath } from "components/data/utils";
+import { useDefaultOutputDir } from "components/data/utils";
 
 import { useConfig } from "contexts/config";
 import { useBootstrapInfo } from "contexts/bootstrap";
@@ -37,10 +37,10 @@ const Launch = ({ app, launchError, viceQuota, runningJobs, loading }) => {
         React.useState(false);
     const [bootstrapInfo] = useBootstrapInfo();
     const [config] = useConfig();
-    const homePath = useHomePath();
 
     const router = useRouter();
     const { t } = useTranslation("vice");
+    const defaultOutputDir = useDefaultOutputDir();
 
     const [submitAnalysisMutation] = useMutation(
         ({ submission }) => submitAnalysis(submission),
@@ -72,13 +72,6 @@ const Launch = ({ app, launchError, viceQuota, runningJobs, loading }) => {
     );
 
     const preferences = bootstrapInfo?.preferences;
-
-    const defaultOutputDir =
-        preferences?.default_output_folder?.path ||
-        preferences?.system_default_output_dir?.path ||
-        (homePath && `${homePath}/analyses`) ||
-        "";
-
     const notify = preferences?.enableAnalysisEmailNotification || false;
 
     const defaultMaxCPUCores = config?.tools?.private.max_cpu_limit;

--- a/src/components/data/utils.js
+++ b/src/components/data/utils.js
@@ -175,6 +175,19 @@ const useSelectorDefaultFolderPath = () => {
     );
 };
 
+const useDefaultOutputDir = () => {
+    const homePath = useHomePath();
+    const [bootstrapInfo] = useBootstrapInfo();
+    const preferences = bootstrapInfo?.preferences;
+
+    return (
+        preferences?.default_output_folder?.path ||
+        preferences?.system_default_output_dir?.path ||
+        (homePath && `${homePath}/analyses`) ||
+        ""
+    );
+};
+
 const isPathInTrash = (path, trash_path) =>
     path && trash_path && path.startsWith(trash_path);
 
@@ -204,6 +217,7 @@ export {
     useDataNavigationLink,
     useHomePath,
     useSelectorDefaultFolderPath,
+    useDefaultOutputDir,
     containsFolders,
     isPathInTrash,
     formatFileSize,

--- a/src/components/instantlaunches/index.js
+++ b/src/components/instantlaunches/index.js
@@ -21,11 +21,10 @@ import { useTranslation } from "i18n";
 import { build as buildID } from "@cyverse-de/ui-lib";
 import ids from "components/instantlaunches/ids";
 import { instantlyLaunch } from "serviceFacades/instantlaunches";
-import { useBootstrapInfo } from "contexts/bootstrap";
 
 import { useMutation } from "react-query";
 import { getHost } from "components/utils/getHost";
-import { useHomePath } from "components/data/utils";
+import { useDefaultOutputDir } from "components/data/utils";
 
 const useStyles = makeStyles((theme) => ({
     progress: {
@@ -110,16 +109,7 @@ const InstantLaunchButton = ({
     const [open, setOpen] = React.useState(false);
     const [ilUrl, setIlUrl] = React.useState();
     const theme = useTheme();
-    const [bootstrapInfo] = useBootstrapInfo();
-    const homePath = useHomePath();
-
-    const preferences = bootstrapInfo?.preferences;
-
-    const output_dir =
-        preferences?.default_output_folder?.path ||
-        preferences?.system_default_output_dir?.path ||
-        (homePath && `${homePath}/analyses`) ||
-        "";
+    const output_dir = useDefaultOutputDir();
 
     React.useEffect(() => {
         if (ilUrl) {

--- a/src/components/instantlaunches/index.js
+++ b/src/components/instantlaunches/index.js
@@ -21,8 +21,11 @@ import { useTranslation } from "i18n";
 import { build as buildID } from "@cyverse-de/ui-lib";
 import ids from "components/instantlaunches/ids";
 import { instantlyLaunch } from "serviceFacades/instantlaunches";
+import { useBootstrapInfo } from "contexts/bootstrap";
+
 import { useMutation } from "react-query";
 import { getHost } from "components/utils/getHost";
+import { useHomePath } from "components/data/utils";
 
 const useStyles = makeStyles((theme) => ({
     progress: {
@@ -107,6 +110,16 @@ const InstantLaunchButton = ({
     const [open, setOpen] = React.useState(false);
     const [ilUrl, setIlUrl] = React.useState();
     const theme = useTheme();
+    const [bootstrapInfo] = useBootstrapInfo();
+    const homePath = useHomePath();
+
+    const preferences = bootstrapInfo?.preferences;
+
+    const output_dir =
+        preferences?.default_output_folder?.path ||
+        preferences?.system_default_output_dir?.path ||
+        (homePath && `${homePath}/analyses`) ||
+        "";
 
     React.useEffect(() => {
         if (ilUrl) {
@@ -151,7 +164,7 @@ const InstantLaunchButton = ({
                 event.preventDefault();
 
                 setOpen(true);
-                launch({ instantLaunch, resource });
+                launch({ instantLaunch, resource, output_dir });
             }}
         >
             <InstantLaunchSubmissionDialog open={open} />

--- a/src/serviceFacades/instantlaunches.js
+++ b/src/serviceFacades/instantlaunches.js
@@ -307,7 +307,6 @@ export const instantlyLaunch = async ({
         })
         .then((submission) => {
             submission.output_dir = output_dir;
-            console.log(submission);
             return submission;
         })
         .then((submission) => submitAnalysis(submission)) // submit the analysis

--- a/src/serviceFacades/instantlaunches.js
+++ b/src/serviceFacades/instantlaunches.js
@@ -215,7 +215,11 @@ export const deleteInstantLaunchHandler = async (id) => {
  * @param {Object} instantLaunch - The instant launch object returned by defaultInstantLaunch().
  * @param {Object} resource - An array of resources to use as inputs to the instantly launched app.
  */
-export const instantlyLaunch = async ({ instantLaunch, resource }) => {
+export const instantlyLaunch = async ({
+    instantLaunch,
+    resource,
+    output_dir,
+}) => {
     let qID; // The quick launch ID, used to get app information.
     let qlp; // The promise used to get quick launch information.
 
@@ -299,6 +303,11 @@ export const instantlyLaunch = async ({ instantLaunch, resource }) => {
                 }
             }
 
+            return submission;
+        })
+        .then((submission) => {
+            submission.output_dir = output_dir;
+            console.log(submission);
             return submission;
         })
         .then((submission) => submitAnalysis(submission)) // submit the analysis


### PR DESCRIPTION
The quick launch that is used to form the instant launch can have a output directory set that the launching user can't access. The output directory should be set to the user's default output directory during the instant launch process. Additionally work needs to be done to support the `Go to output folder` option in the analyses view.