### PR TITLE
CORE-1400 Add newly designed maintenance page

### DIFF
--- a/public/maintenance.css
+++ b/public/maintenance.css
@@ -78,6 +78,11 @@ a {
     justify-content: space-around !important;
 }
 
+.btn-maintenance {
+    background-color: #0971ab;
+    color: #ffff
+}
+
 .btn-outline-secondary {
     color: #004471;
     border-color: #004471;

--- a/public/maintenance.css
+++ b/public/maintenance.css
@@ -1,52 +1,115 @@
-:root {
-    --primary-color: #0971AB;
-    --primary-hover: rgb(6, 79, 119);
-    --secondary-color: #99D9EA;
-}
-
 body {
-    margin: 0;
-    padding: 0;
-    background-color: #fafafa;
     font-family: "Roboto", "Helvetica", "Arial", sans-serif;
-    height: 100vh;
-    overflow: auto;
 }
 
-.main {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    padding-top: 25vh;
+.icons {
+    margin-left: 8px;
+    margin-top: 4px;
+    width: 150px;
 }
 
-.primary {
-    color: var(--primary-color);
+.icon {
+    margin: 1rem;
+    width: 25px;
 }
 
-.card {
-    box-shadow: 0px 2px 1px -1px rgba(0, 0, 0, 0.2), 0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 1px 3px 0px rgba(0, 0, 0, 0.12);
-    border-radius: 4px;
-    padding: 12px;
+a {
+    text-decoration: none;
 }
 
-.cardActions {
-    display: flex;
-    justify-content: space-evenly;
+.cyverse-blue-bg {
+    background-color: rgba(9, 113, 171, .2);
+    color: #004471;
 }
 
-button {
-    color: white;
-    background-color: var(--primary-color);
-    padding: 6px 16px;
-    margin: 6px;
+.cyverse-silver-bg {
+    background-color: rgba(72, 81, 95, .2);
+    color: #004471;
+}
+
+.cyverse-dk-navy-bg {
+    background-color: rgba(0, 68, 113, .2);
+    color: #004471;
+}
+
+.cyverse-blue {
+    color: #0971ab;
+}
+
+.bottomDiv {
+    margin: 0.5rem;
+    padding: 8px;
+    flex-grow: 1;
+}
+
+.bottomButton {
+    padding: 0;
     border: none;
-    box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
-    border-radius: 4px;
+    background: none;
+    outline: none;
+    margin: 8px;
+    text-decoration-line: none;
     cursor: pointer;
 }
 
-button:hover {
-    background-color: var(--primary-hover);
+.bottomButton:hover {
+    text-decoration-line: underline;
+    color: #000000;
+}
+
+.center {
+    margin: auto;
+    text-align: center;
+}
+
+.d-flex {
+    display: flex !important;
+}
+
+.justify-content-center {
+    justify-content: center !important;
+}
+
+.justify-content-between {
+    justify-content: space-between !important;
+}
+
+.justify-content-around {
+    justify-content: space-around !important;
+}
+
+.btn-outline-secondary {
+    color: #004471;
+    border-color: #004471;
+}
+
+.btn-outline-secondary:hover {
+    color: #004471;
+    background-color: #99d9ea;
+    border-color: #99d9ea;
+}
+
+.btn-outline-light {
+    color: #004471;
+    border-color: #004471
+}
+
+.btn-outline-light:hover {
+    color: #000000;
+    background-color: #f8f9fa;
+    border-color: #f8f9fa;
+}
+
+.flex-col {
+    flex-direction: column !important;
+}
+
+.col-content {
+    position: relative;
+    min-height: 175px;
+}
+
+.align-self-end {
+    position: absolute;
+    bottom: 0px;
 }

--- a/public/maintenance.html
+++ b/public/maintenance.html
@@ -38,15 +38,15 @@
                 back online.</p>
             <div class="d-grid gap-2 d-md-block mx-auto my-5">
                 <a class="btn btn-lg btn-maintenance" href="https://status.cyverse.org/"
-                   target="_blank">
+                   target="_blank" rel="noopener noreferrer">
                     View Status of All Services
                 </a>
                 <a class="btn btn-lg btn-maintenance"
-                   href="https://cyverse.org/maintenance" target="_blank">
+                   href="https://cyverse.org/maintenance" target="_blank" rel="noopener noreferrer">
                     View Maintenance Calendar
                 </a>
                 <a class="btn btn-lg btn-maintenance"
-                   href="https://user.cyverse.org/account" target="_blank">
+                   href="https://user.cyverse.org/account" target="_blank" rel="noopener noreferrer">
                     Enable Maintenance Reminders
                 </a>
             </div>
@@ -54,37 +54,38 @@
     </div>
 </div>
 <div class="center mt">
-    <a href="https://user.cyverse.org" target="_blank">
+    <a href="https://user.cyverse.org" target="_blank" rel="noopener noreferrer">
         <button type="button" class="cyverse-blue bottomButton"> Manage My Account</button>
     </a>
-    <a href="https://de.cyverse.org" target="_blank">
+    <a href="https://de.cyverse.org" target="_blank" rel="noopener noreferrer">
         <button type="button" class="cyverse-blue bottomButton"> Discovery Environment</button>
     </a>
-    <a href="https://cyverse.org/data-store" target="_blank">
+    <a href="https://cyverse.org/data-store" target="_blank" rel="noopener noreferrer">
         <button type="button" class="cyverse-blue bottomButton"> Data Store</button>
     </a>
-    <a href="https://bisque.cyverse.org" target="_blank">
+    <a href="https://bisque.cyverse.org" target="_blank" rel="noopener noreferrer">
         <button type="button" class="cyverse-blue bottomButton"> BisQue Image Analysis</button>
     </a>
-    <a href="https://dnasubway.cyverse.org" target="_blank">
+    <a href="https://dnasubway.cyverse.org" target="_blank" rel="noopener noreferrer">
         <button type="button" class="cyverse-blue bottomButton"> DNA Subway</button>
     </a>
-    <a href="https://cyverse.org/Science-APIs" target="_blank">
+    <a href="https://cyverse.org/Science-APIs" target="_blank" rel="noopener noreferrer">
         <button type="button" class="cyverse-blue bottomButton"> Science APIs</button>
     </a>
 </div>
 <div class="center mt">
-    <a href="https://twitter.com/CyVerseOrg" target="_blank"><img
+    <a href="https://twitter.com/CyVerseOrg" target="_blank" rel="noopener noreferrer"><img
         src="https://cyverse.org/sites/default/files/inline-images/social_icon-01.png" class="icon" alt="twitter" /></a>
-    <a href="https://www.facebook.com/CyVerse.org/" target="_blank"> <img
+    <a href="https://www.facebook.com/CyVerse.org/" target="_blank" rel="noopener noreferrer"> <img
         src="https://cyverse.org/sites/default/files/inline-images/social_icon-02.png" class="icon"
         alt="facebook" /></a>
-    <a href="https://www.youtube.com/channel/UC-gvdjTz9rq6RovZ57LoDDA/featured" target="_blank"><img
+    <a href="https://www.youtube.com/channel/UC-gvdjTz9rq6RovZ57LoDDA/featured" target="_blank"
+       rel="noopener noreferrer"><img
         src="https://cyverse.org/sites/default/files/inline-images/social_icon-03.png" class="icon" alt="youtube" /></a>
-    <a href="https://www.linkedin.com/company/cyverse.org/" target="_blank"> <img
+    <a href="https://www.linkedin.com/company/cyverse.org/" target="_blank" rel="noopener noreferrer"> <img
         src="https://cyverse.org/sites/default/files/inline-images/social_icon-04.png" class="icon"
         alt="linkedin" /></a>
-    <a href="https://github.com/cyverse/" target="_blank"> <img
+    <a href="https://github.com/cyverse/" target="_blank" rel="noopener noreferrer"> <img
         src="https://cyverse.org/sites/default/files/inline-images/social_icon-05.png" class="icon" alt="github" /></a>
 </div>
 <div class="cyverse-blue center pb-2">

--- a/public/maintenance.html
+++ b/public/maintenance.html
@@ -24,7 +24,7 @@
     <div class="text-center mt-4">
         <div class="row align-items-center justify-content-center mx-auto">
             <div class="col-md-6 col-sm-12">
-                <h1 class="display-5" style="color:#0971ab;"> Sorry, this service is under maintenance right now. </h1>
+                <h1 class="display-5 cyverse-blue"> Sorry, this service is under maintenance right now. </h1>
             </div>
             <div class="col-md-5 col-sm-12">
                 <img src="https://cyverse.org/sites/default/files/inline-images/site-under-construction.png"
@@ -37,15 +37,15 @@
             <p class="fs-3 text-muted"> Don't worry, your projects, analyses, and data will be here for you when we come
                 back online.</p>
             <div class="d-grid gap-2 d-md-block mx-auto my-5">
-                <a class="btn btn-lg" style="background-color:#0971ab;color:#ffff;" href="https://status.cyverse.org/"
+                <a class="btn btn-lg btn-maintenance" href="https://status.cyverse.org/"
                    target="_blank">
                     View Status of All Services
                 </a>
-                <a class="btn btn-lg" style="background-color:#0971ab;color:#ffff;"
+                <a class="btn btn-lg btn-maintenance"
                    href="https://cyverse.org/maintenance" target="_blank">
                     View Maintenance Calendar
                 </a>
-                <a class="btn btn-lg" style="background-color:#0971ab;color:#ffff;"
+                <a class="btn btn-lg btn-maintenance"
                    href="https://user.cyverse.org/account" target="_blank">
                     Enable Maintenance Reminders
                 </a>

--- a/public/maintenance.html
+++ b/public/maintenance.html
@@ -1,32 +1,92 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="utf-8">
-    <link
-        rel="stylesheet"
-        href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
-    />
-    <link rel="stylesheet" href="maintenance.css">
-    <title>Discovery Environment - Maintenance</title>
-</head>
+<meta charset="UTF-8">
+<title>CyVerse Maintenance</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css"
+      integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+<link rel="stylesheet" type="text/css" href="maintenance.css" />
+
+<!--Intercom settings-->
+<script src="maintenance.js"></script>
+
 <body>
-<div class="main">
-    <div class="card">
+<div class="container-fluid pt-5 mw-75 px-2">
+    <div class="text-center">
+        <a href="https://www.cyverse.org">
+            <img class="icons" src="https://cyverse.org/sites/default/files/cyverse_logo_0.png"
+                 alt="cyverse logo" style="width:300px;" />
+        </a>
+    </div>
 
-        <p class="primary">The Discovery Environment Is Currently Under Maintenance</p>
+    <div class="text-center mt-4">
+        <div class="row align-items-center justify-content-center mx-auto">
+            <div class="col-md-6 col-sm-12">
+                <h1 class="display-5" style="color:#0971ab;"> Sorry, this service is under maintenance right now. </h1>
+            </div>
+            <div class="col-md-5 col-sm-12">
+                <img src="https://cyverse.org/sites/default/files/inline-images/site-under-construction.png"
+                     width="100%" alt="illustration of a construction worker" />
+            </div>
+        </div>
 
-        <div class="cardActions">
-
-            <button title="maintenance calendar link" onclick="window.open('https://cyverse.org/maintenance', '_blank')">
-                Maintenance Calendar
-            </button>
-
-            <button title="refresh" onclick="window.location.reload(true)">
-                Refresh
-            </button>
-
+        <div class="container mt-4">
+            <p class="fs-2 text-muted"> Go ahead and take a break, you deserve it! </p>
+            <p class="fs-3 text-muted"> Don't worry, your projects, analyses, and data will be here for you when we come
+                back online.</p>
+            <div class="d-grid gap-2 d-md-block mx-auto my-5">
+                <a class="btn btn-lg" style="background-color:#0971ab;color:#ffff;" href="https://status.cyverse.org/"
+                   target="_blank">
+                    View Status of All Services
+                </a>
+                <a class="btn btn-lg" style="background-color:#0971ab;color:#ffff;"
+                   href="https://cyverse.org/maintenance" target="_blank">
+                    View Maintenance Calendar
+                </a>
+                <a class="btn btn-lg" style="background-color:#0971ab;color:#ffff;"
+                   href="https://user.cyverse.org/account" target="_blank">
+                    Enable Maintenance Reminders
+                </a>
+            </div>
         </div>
     </div>
+</div>
+<div class="center mt">
+    <a href="https://user.cyverse.org" target="_blank">
+        <button type="button" class="cyverse-blue bottomButton"> Manage My Account</button>
+    </a>
+    <a href="https://de.cyverse.org" target="_blank">
+        <button type="button" class="cyverse-blue bottomButton"> Discovery Environment</button>
+    </a>
+    <a href="https://cyverse.org/data-store" target="_blank">
+        <button type="button" class="cyverse-blue bottomButton"> Data Store</button>
+    </a>
+    <a href="https://bisque.cyverse.org" target="_blank">
+        <button type="button" class="cyverse-blue bottomButton"> BisQue Image Analysis</button>
+    </a>
+    <a href="https://dnasubway.cyverse.org" target="_blank">
+        <button type="button" class="cyverse-blue bottomButton"> DNA Subway</button>
+    </a>
+    <a href="https://cyverse.org/Science-APIs" target="_blank">
+        <button type="button" class="cyverse-blue bottomButton"> Science APIs</button>
+    </a>
+</div>
+<div class="center mt">
+    <a href="https://twitter.com/CyVerseOrg" target="_blank"><img
+        src="https://cyverse.org/sites/default/files/inline-images/social_icon-01.png" class="icon" alt="twitter" /></a>
+    <a href="https://www.facebook.com/CyVerse.org/" target="_blank"> <img
+        src="https://cyverse.org/sites/default/files/inline-images/social_icon-02.png" class="icon"
+        alt="facebook" /></a>
+    <a href="https://www.youtube.com/channel/UC-gvdjTz9rq6RovZ57LoDDA/featured" target="_blank"><img
+        src="https://cyverse.org/sites/default/files/inline-images/social_icon-03.png" class="icon" alt="youtube" /></a>
+    <a href="https://www.linkedin.com/company/cyverse.org/" target="_blank"> <img
+        src="https://cyverse.org/sites/default/files/inline-images/social_icon-04.png" class="icon"
+        alt="linkedin" /></a>
+    <a href="https://github.com/cyverse/" target="_blank"> <img
+        src="https://cyverse.org/sites/default/files/inline-images/social_icon-05.png" class="icon" alt="github" /></a>
+</div>
+<div class="cyverse-blue center pb-2">
+    CyVerse © 2021
 </div>
 </body>
 </html>

--- a/public/maintenance.html
+++ b/public/maintenance.html
@@ -1,14 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
-<meta charset="UTF-8">
-<title>CyVerse Maintenance</title>
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css"
-      integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-<link rel="stylesheet" type="text/css" href="maintenance.css" />
+<head>
+    <meta charset="UTF-8">
+    <title>CyVerse Maintenance</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css"
+          integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    <link rel="stylesheet" type="text/css" href="maintenance.css" />
 
-<!--Intercom settings-->
-<script src="maintenance.js"></script>
+    <!--Intercom settings-->
+    <script src="maintenance.js"></script>
+</head>
 
 <body>
 <div class="container-fluid pt-5 mw-75 px-2">

--- a/public/maintenance.js
+++ b/public/maintenance.js
@@ -1,0 +1,35 @@
+window.intercomSettings = {
+    app_id: "tpwq3d9w",
+};
+
+(function () {
+    var w = window;
+    var ic = w.Intercom;
+    if (typeof ic === "function") {
+        ic("reattach_activator");
+        ic("update", w.intercomSettings);
+    } else {
+        var d = document;
+        var i = function () {
+            i.c(arguments);
+        };
+        i.q = [];
+        i.c = function (args) {
+            i.q.push(args);
+        };
+        w.Intercom = i;
+        var l = function () {
+            var s = d.createElement("script");
+            s.type = "text/javascript";
+            s.async = true;
+            s.src = "https://widget.intercom.io/widget/tpwq3d9w";
+            var x = d.getElementsByTagName("script")[0];
+            x.parentNode.insertBefore(s, x);
+        };
+        if (w.attachEvent) {
+            w.attachEvent("onload", l);
+        } else {
+            w.addEventListener("load", l, false);
+        }
+    }
+})();


### PR DESCRIPTION
This is pretty much copy-paste of Mariah's codepen, but with some changes:
* Updated link URLs (some were duplicates)
* Added some fallback fonts 
* Intercom
* The `Enable Maintenance Reminders` button

TO NOTE: I wasn't sure what URLs to put for `Data Store` and `Science APIs` so I linked to the cyverse.org pages for those.  I'm open to suggestions.

Desktop:
![image](https://user-images.githubusercontent.com/8909156/127380480-fca7a1ed-46a7-42b4-a48d-72cec79e5d54.png)

Mobile:
![image](https://user-images.githubusercontent.com/8909156/127380534-3fa02f72-25c4-4d5f-a501-9c89ee924b10.png)
![image](https://user-images.githubusercontent.com/8909156/127380561-f9a5faac-49aa-48f4-9955-6c7c50ee8ae7.png)
![image](https://user-images.githubusercontent.com/8909156/127380595-f27a9fc5-ab99-465d-b6e8-3bd7c09a0050.png)
