### PR TITLE
CORE-1465 Add `tools.admin.max_*` resource config support

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -23,6 +23,15 @@ module.exports = withBundleAnalyzer({
         SESSION_POLL_INTERVAL_MS: config.has("sessions.poll_interval_ms")
             ? config.get("sessions.poll_interval_ms")
             : 5000,
+        TOOLS_ADMIN_MAX_CPU_LIMIT: config.has("tools.admin.max_cpu_limit")
+            ? config.get("tools.admin.max_cpu_limit")
+            : 8,
+        TOOLS_ADMIN_MAX_MEMORY_LIMIT: config.has("tools.admin.max_memory_limit")
+            ? config.get("tools.admin.max_memory_limit")
+            : 16 * ONE_GiB,
+        TOOLS_ADMIN_MAX_DISK_LIMIT: config.has("tools.admin.max_disk_limit")
+            ? config.get("tools.admin.max_disk_limit")
+            : 512 * ONE_GiB,
         TOOLS_PRIVATE_MAX_CPU_LIMIT: config.has("tools.private.max_cpu_limit")
             ? config.get("tools.private.max_cpu_limit")
             : 8,

--- a/src/components/apps/launch/ResourceRequirements.js
+++ b/src/components/apps/launch/ResourceRequirements.js
@@ -55,6 +55,10 @@ function buildLimitList(startValue, minValue, maxValue) {
         value *= 2;
     }
 
+    if (limits[limits.length - 1] !== maxValue) {
+        limits.push(maxValue);
+    }
+
     return limits;
 }
 

--- a/src/components/tools/edit/EditTool.js
+++ b/src/components/tools/edit/EditTool.js
@@ -68,9 +68,12 @@ function EditToolDialog(props) {
     const [toolTypeQueryEnabled, setToolTypesQueryEnabled] = useState();
 
     const [config] = useConfig();
-    const maxCPUCore = config?.tools?.private.max_cpu_limit;
-    const maxMemory = config?.tools?.private.max_memory_limit;
-    const maxDiskSpace = config?.tools?.private.max_disk_limit;
+    const resourceConfigs = isAdmin
+        ? config?.tools?.admin
+        : config?.tools?.private;
+    const maxCPUCore = resourceConfigs?.max_cpu_limit;
+    const maxMemory = resourceConfigs?.max_memory_limit;
+    const maxDiskSpace = resourceConfigs?.max_disk_limit;
 
     const toolTypesCache = queryCache.getQueryData(TOOL_TYPES_QUERY_KEY);
 
@@ -274,7 +277,7 @@ function EditToolDialog(props) {
                             <Grid
                                 container
                                 direction="row"
-                                justify="flex-end"
+                                justifyContent="flex-end"
                                 alignItems="flex-end"
                                 spacing={1}
                             >

--- a/src/components/tools/edit/ToolRestrictions.js
+++ b/src/components/tools/edit/ToolRestrictions.js
@@ -21,15 +21,18 @@ const formatGBListItem = (size) => size && numeral(size).format("0 ib");
 const formatGBValue = (size) => size && numeral(size).format("0.0 ib");
 
 function buildLimitList(startValue, maxValue) {
-    let limits = [];
-    limits.push(0);
-    limits.push(startValue);
+    const limits = [0];
 
     let value = startValue;
-    while (value < maxValue) {
-        value *= 2;
+    while (value <= maxValue) {
         limits.push(value);
+        value *= 2;
     }
+
+    if (limits[limits.length - 1] !== maxValue) {
+        limits.push(maxValue);
+    }
+
     return limits;
 }
 

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -156,6 +156,12 @@ function MyApp({ Component, pageProps }) {
             poll_interval_ms: publicRuntimeConfig.SESSION_POLL_INTERVAL_MS,
         };
         const tools = {
+            admin: {
+                max_cpu_limit: publicRuntimeConfig.TOOLS_ADMIN_MAX_CPU_LIMIT,
+                max_memory_limit:
+                    publicRuntimeConfig.TOOLS_ADMIN_MAX_MEMORY_LIMIT,
+                max_disk_limit: publicRuntimeConfig.TOOLS_ADMIN_MAX_DISK_LIMIT,
+            },
             private: {
                 max_cpu_limit: publicRuntimeConfig.TOOLS_PRIVATE_MAX_CPU_LIMIT,
                 max_memory_limit:

--- a/stories/apps/launch/DEWordCount.stories.js
+++ b/stories/apps/launch/DEWordCount.stories.js
@@ -23,6 +23,9 @@ export const DEWordCount = ({
     loading,
     loadingError,
     submissionError,
+    defaultMaxCPUCores,
+    defaultMaxMemory,
+    defaultMaxDiskSpace,
 }) => {
     const [appError, setAppError] = React.useState(null);
 
@@ -50,9 +53,9 @@ export const DEWordCount = ({
             app={!loadingError && app}
             loading={loading}
             appError={appError || (loadingError && errorObject)}
-            defaultMaxCPUCores={8}
-            defaultMaxMemory={4 * constants.ONE_GiB}
-            defaultMaxDiskSpace={64 * constants.ONE_GiB}
+            defaultMaxCPUCores={defaultMaxCPUCores}
+            defaultMaxMemory={defaultMaxMemory}
+            defaultMaxDiskSpace={defaultMaxDiskSpace}
             submitAnalysis={(submission, onSuccess, onError) => {
                 setAppError(null);
                 submitAnalysis(
@@ -104,6 +107,24 @@ DEWordCount.argTypes = {
             type: "boolean",
         },
     },
+    defaultMaxCPUCores: {
+        name: "Max CPU Cores",
+        control: {
+            type: "number",
+        },
+    },
+    defaultMaxMemory: {
+        name: "Max Memory",
+        control: {
+            type: "number",
+        },
+    },
+    defaultMaxDiskSpace: {
+        name: "Max Disk Space",
+        control: {
+            type: "number",
+        },
+    },
 };
 
 DEWordCount.args = {
@@ -112,4 +133,7 @@ DEWordCount.args = {
     loading: false,
     loadingError: false,
     submissionError: false,
+    defaultMaxCPUCores: 8,
+    defaultMaxMemory: 4 * constants.ONE_GiB,
+    defaultMaxDiskSpace: 64 * constants.ONE_GiB,
 };

--- a/stories/configMock.js
+++ b/stories/configMock.js
@@ -20,6 +20,11 @@ export default {
         trash_path: "/iplant/trash/home/de-irods",
     },
     tools: {
+        admin: {
+            max_cpu_limit: 48,
+            max_memory_limit: 256 * constants.ONE_GiB,
+            max_disk_limit: 1024 * constants.ONE_GiB,
+        },
         private: {
             max_cpu_limit: 8,
             max_memory_limit: 16 * constants.ONE_GiB,

--- a/stories/configMock.js
+++ b/stories/configMock.js
@@ -22,7 +22,7 @@ export default {
     tools: {
         admin: {
             max_cpu_limit: 48,
-            max_memory_limit: 256 * constants.ONE_GiB,
+            max_memory_limit: 244 * constants.ONE_GiB,
             max_disk_limit: 1024 * constants.ONE_GiB,
         },
         private: {

--- a/stories/tools/EditTool.stories.js
+++ b/stories/tools/EditTool.stories.js
@@ -55,20 +55,30 @@ export function EditToolTest({ admin, adminPub, newTool }) {
         );
     }
 }
+
 EditToolTest.argTypes = {
     admin: {
+        name: "Admin",
         control: {
             type: "boolean",
         },
     },
     adminPub: {
+        name: "Admin Publishing",
         control: {
             type: "boolean",
         },
     },
     newTool: {
+        name: "New Tool",
         control: {
             type: "boolean",
         },
     },
+};
+
+EditToolTest.args = {
+    admin: false,
+    adminPub: false,
+    newTool: false,
 };


### PR DESCRIPTION
This PR will add `tools.admin.max_*` resource config support, and also allow arbitrary max resource limits in app/tool forms.

The app and tool resource request/limit select fields will still be populated with powers of 2, but the configs can set a max value that is not a power of 2 (such as our actual limits in the cluster), and that max value will still display as the upper limit in the selection list.

For example, if `tools.admin.max_memory_limit` is set to 244GiB, then the tool admin form list would be populated like this:
![Tool Admin Max Memory list](https://user-images.githubusercontent.com/996408/127723715-1ade52f4-db6f-4ba0-a521-9821055ddfab.png)


This PR will also fix a bug in the Edit Tool form that could display a power of 2 beyond the actual limit set in the configs.