### PR TITLE
Fix req body parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@next/bundle-analyzer": "^9.4.0",
                 "amqplib": "^0.7.1",
                 "animated-number-react": "^0.1.1",
-                "axios": "^0.19.2",
+                "axios": "^0.21.1",
                 "bowser": "^2.9.0",
                 "camelcase": "^5.3.1",
                 "classnames": "^2.2.6",
@@ -9568,12 +9568,11 @@
             }
         },
         "node_modules/axios": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-            "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-            "deprecated": "Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410",
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+            "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
             "dependencies": {
-                "follow-redirects": "1.5.10"
+                "follow-redirects": "^1.10.0"
             }
         },
         "node_modules/axios-mock-adapter": {
@@ -15126,28 +15125,23 @@
             "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
         },
         "node_modules/follow-redirects": {
-            "version": "1.5.10",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-            "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-            "dependencies": {
-                "debug": "=3.1.0"
-            },
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+            "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
             "engines": {
                 "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
             }
-        },
-        "node_modules/follow-redirects/node_modules/debug": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/follow-redirects/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "node_modules/for-in": {
             "version": "1.0.2",
@@ -37359,11 +37353,11 @@
             "dev": true
         },
         "axios": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-            "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+            "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
             "requires": {
-                "follow-redirects": "1.5.10"
+                "follow-redirects": "^1.10.0"
             }
         },
         "axios-mock-adapter": {
@@ -41850,27 +41844,9 @@
             "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
         },
         "follow-redirects": {
-            "version": "1.5.10",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-            "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-            "requires": {
-                "debug": "=3.1.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-                }
-            }
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+            "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
         },
         "for-in": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "@next/bundle-analyzer": "^9.4.0",
         "amqplib": "^0.7.1",
         "animated-number-react": "^0.1.1",
-        "axios": "^0.19.2",
+        "axios": "^0.21.1",
         "bowser": "^2.9.0",
         "camelcase": "^5.3.1",
         "classnames": "^2.2.6",

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -83,6 +83,7 @@ app.prepare()
         logger.info("configuring the express logging middleware");
         server.use(errorLogger);
         server.use(requestLogger);
+        server.use(express.json());
 
         logger.info("DEBUG: adding middleware to log cookies");
         server.use(authn.logSessionCookie);


### PR DESCRIPTION
I was digging into this because I noticed that the exact same request body for a POST request when used in a DELETE request would return an error from the service that the body was not a map and was nil. This appears to be the first DELETE request with a request body added to the new DE. 

Reading through [the express docs](https://expressjs.com/en/4x/api.html#req.body), I saw that they recommend using `express.json()` to parse the req body otherwise it's undefined.  Not sure how it was working so well before this, but either way, this seems to be the recommended way to do things.

I also bumped the axios version since we keep getting dependabot PRs for it.  I tested several different requests in the DE and didn't notice any issues.