### PR TITLE
CORE-1483 Show running time for analyses in dashboard

### DIFF
--- a/public/static/locales/en/dashboard.json
+++ b/public/static/locales/en/dashboard.json
@@ -1,6 +1,7 @@
 {
     "addToCalendarAria": "add to calendar",
     "analysisOrigination": "<bold>{{status}}</bold> - {{date}}",
+    "analysisRunningOrigination": "<bold>{{status}}</bold> - {{runningTime}} ({{date}})",
     "banner": "Banner",
     "by": "By",
     "changeSettings": "Change Settings",

--- a/public/static/locales/en/dashboard.json
+++ b/public/static/locales/en/dashboard.json
@@ -1,7 +1,7 @@
 {
     "addToCalendarAria": "add to calendar",
-    "analysisOrigination": "<bold>{{status}}</bold> - {{date}}",
-    "analysisRunningOrigination": "<bold>{{status}}</bold> - {{runningTime}} ({{date}})",
+    "analysisOrigination": "<status><bold>{{status}}</bold></status> - {{date}}",
+    "analysisRunningOrigination": "<status><bold>{{status}}</bold></status> - {{runningTime}} ({{date}})",
     "banner": "Banner",
     "by": "By",
     "changeSettings": "Change Settings",

--- a/src/components/analyses/useAnalysisRunTime.js
+++ b/src/components/analyses/useAnalysisRunTime.js
@@ -34,7 +34,7 @@ function useAnalysisRunTime(
         queryKey: [ANALYSIS_HISTORY_QUERY_KEY, { id: analysis?.id }],
         queryFn: getAnalysisHistory,
         config: {
-            enabled: !!isRunning,
+            enabled: isRunning,
             onSuccess: (resp) => {
                 // Make sure we're looking at the correct step
                 // (e.g. step_type === "Interactive" or step_number === 1)
@@ -44,7 +44,7 @@ function useAnalysisRunTime(
                     (update) => update.status === analysisStatus.RUNNING
                 );
                 // Record the timestamp
-                setRunningStart(parseInt(runningUpdate.timestamp));
+                setRunningStart(parseInt(runningUpdate?.timestamp || 0));
             },
         },
     });

--- a/src/components/analyses/useAnalysisRunTime.js
+++ b/src/components/analyses/useAnalysisRunTime.js
@@ -1,0 +1,69 @@
+/**
+ * @author aramsey
+ *
+ * A hook to return how long an analysis has been running.
+ *
+ * The run time is based off the analysis history's first recorded Running update
+ * for a specified step. You can specify the step by providing a function to filter
+ * for that step.  By default, the first step will be used.
+ *
+ * Updates the values every minute.
+ */
+
+import { useEffect, useState } from "react";
+
+import { formatDistanceToNow } from "date-fns";
+import { useQuery } from "react-query";
+
+import analysisStatus from "components/models/analysisStatus";
+import {
+    ANALYSIS_HISTORY_QUERY_KEY,
+    getAnalysisHistory,
+} from "serviceFacades/analyses";
+
+function useAnalysisRunTime(
+    analysis,
+    stepFilterFn = (step) => step.step_number === 1
+) {
+    const isRunning = analysis?.status === analysisStatus.RUNNING;
+
+    const [runningStart, setRunningStart] = useState(0);
+    const [elapsedTime, setElapsedTime] = useState(null);
+
+    useQuery({
+        queryKey: [ANALYSIS_HISTORY_QUERY_KEY, { id: analysis?.id }],
+        queryFn: getAnalysisHistory,
+        config: {
+            enabled: !!isRunning,
+            onSuccess: (resp) => {
+                // Make sure we're looking at the correct step
+                // (e.g. step_type === "Interactive" or step_number === 1)
+                const step = resp?.steps?.find(stepFilterFn);
+                // Find the first Running update
+                const runningUpdate = step?.updates?.find(
+                    (update) => update.status === analysisStatus.RUNNING
+                );
+                // Record the timestamp
+                setRunningStart(parseInt(runningUpdate.timestamp));
+            },
+        },
+    });
+
+    useEffect(() => {
+        const handleUpdateRunningTime = () => {
+            setElapsedTime(formatDistanceToNow(new Date(runningStart)));
+        };
+
+        let interval;
+        if (runningStart) {
+            interval = setInterval(handleUpdateRunningTime, 60000);
+            handleUpdateRunningTime();
+        }
+
+        return () => clearInterval(interval);
+    }, [analysis, runningStart]);
+
+    return { elapsedTime, runningStart };
+}
+
+export default useAnalysisRunTime;

--- a/src/components/dashboard/dashboardItem/ItemBase.js
+++ b/src/components/dashboard/dashboardItem/ItemBase.js
@@ -1,6 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import clsx from "clsx";
-import { formatDistanceToNow } from "date-fns";
 import { Trans, useTranslation } from "i18n";
 import ReactPlayer from "react-player/youtube";
 
@@ -16,8 +15,8 @@ import {
     useTheme,
 } from "@material-ui/core";
 
+import useAnalysisRunTime from "components/analyses/useAnalysisRunTime";
 import buildID from "components/utils/DebugIDUtil";
-import { isTerminated } from "components/analyses/utils";
 
 import ids from "../ids";
 import * as constants from "../constants";
@@ -48,36 +47,20 @@ const DashboardLink = ({ target, kind, children }) => {
 function AnalysisSubheader(props) {
     const { analysis, date: formattedDate } = props;
     const { t } = useTranslation(["dashboard", "apps"]);
-    const terminated = isTerminated(analysis);
-
-    const [runningTime, setRunningTime] = useState(null);
-
-    useEffect(() => {
-        const handleUpdateRunningTime = () => {
-            setRunningTime(formatDistanceToNow(new Date(analysis.start_date)));
-        };
-
-        let interval;
-        if (!terminated) {
-            interval = setInterval(handleUpdateRunningTime, 60000);
-            handleUpdateRunningTime();
-        }
-
-        return () => clearInterval(interval);
-    }, [analysis, terminated]);
+    const { elapsedTime } = useAnalysisRunTime(analysis);
 
     return (
         <Trans
             t={t}
             i18nKey={
-                terminated
-                    ? "analysisOrigination"
-                    : "analysisRunningOrigination"
+                elapsedTime
+                    ? "analysisRunningOrigination"
+                    : "analysisOrigination"
             }
             values={{
                 status: analysis.status,
                 date: formattedDate,
-                runningTime,
+                runningTime: elapsedTime,
             }}
             components={{ bold: <strong /> }}
         />

--- a/src/components/dashboard/dashboardItem/ItemBase.js
+++ b/src/components/dashboard/dashboardItem/ItemBase.js
@@ -17,6 +17,7 @@ import {
 
 import useAnalysisRunTime from "components/analyses/useAnalysisRunTime";
 import buildID from "components/utils/DebugIDUtil";
+import analysisStatus from "components/models/analysisStatus";
 
 import ids from "../ids";
 import * as constants from "../constants";
@@ -48,6 +49,17 @@ function AnalysisSubheader(props) {
     const { analysis, date: formattedDate } = props;
     const { t } = useTranslation(["dashboard", "apps"]);
     const { elapsedTime } = useAnalysisRunTime(analysis);
+    const theme = useTheme();
+
+    const status = analysis.status;
+    const statusColor =
+        status === analysisStatus.COMPLETED
+            ? theme.palette.primary.main
+            : status === analysisStatus.RUNNING
+            ? theme.palette.success.main
+            : status === analysisStatus.FAILED
+            ? theme.palette.error.main
+            : null;
 
     return (
         <Trans
@@ -58,11 +70,14 @@ function AnalysisSubheader(props) {
                     : "analysisOrigination"
             }
             values={{
-                status: analysis.status,
+                status,
                 date: formattedDate,
                 runningTime: elapsedTime,
             }}
-            components={{ bold: <strong /> }}
+            components={{
+                bold: <strong />,
+                status: <span style={{ color: statusColor }} />,
+            }}
         />
     );
 }

--- a/src/components/dashboard/dashboardItem/ItemBase.js
+++ b/src/components/dashboard/dashboardItem/ItemBase.js
@@ -13,7 +13,6 @@ import {
     Typography,
     useMediaQuery,
     Tooltip,
-    MenuItem,
     useTheme,
 } from "@material-ui/core";
 
@@ -211,22 +210,6 @@ export const ItemAction = ({ children, tooltipKey, ariaLabel }) => {
     return (
         <Tooltip title={t(tooltipKey)} aria-label={ariaLabel}>
             <div>{children}</div>
-        </Tooltip>
-    );
-};
-
-export const MenuAction = ({
-    children,
-    ariaLabel,
-    handleClick,
-    tooltipKey,
-}) => {
-    const { t } = useTranslation(["dashboard", "apps"]);
-    return (
-        <Tooltip title={t(tooltipKey)}>
-            <MenuItem onClick={handleClick} aria-label={ariaLabel}>
-                {children}
-            </MenuItem>
         </Tooltip>
     );
 };


### PR DESCRIPTION
The first running analysis under `Recent Analyses` is the example in this screenshot. It shows the amount of time that has passed (the text is coming from [date-fns](https://date-fns.org/v2.23.0/docs/formatDistanceToNow)) and the date in parentheses. Completed analyses only show the date.

![image](https://user-images.githubusercontent.com/8909156/131567566-b677fe11-ba1b-4904-846c-1ea1dbe1e409.png)



Also removed some unused code.