### PR TITLE
Add notification categories to i18n

### DIFF
--- a/public/static/locales/en/notifications.json
+++ b/public/static/locales/en/notifications.json
@@ -1,12 +1,17 @@
 {
     "addMemberFail": "Failed to add {{0}} to {{1}}. Please try again.",
     "admin": "Admin",
+    "all": "All",
+    "analysis": "Analysis",
     "approveBtnText": "Approve",
     "approveRequestFailed": "Failed to approve request to join team.  Please try again.",
+    "apps": "Apps",
     "arialApproveOrDeny": "Approve or Deny",
     "cancelBtnText": "Cancel",
     "category": "Category",
+    "community": "Collection",
     "created_date": "Created Date",
+    "data": "Data",
     "denyAdminLabel": "Message from the team admin",
     "denyBtnText": "Deny",
     "denyDetailsHeader": "Request to Join Team Denied",
@@ -27,8 +32,10 @@
     "markSeen": "Mark as Seen",
     "message": "Message",
     "name": "Name",
+    "new": "New",
     "noNotifications": "No notifications to display.",
     "okBtnText": "OK",
+    "permanent_id_request": "Permanent ID Request",
     "read": "Member",
     "refresh": "Refresh",
     "requesterEmailLabel": "Email",
@@ -36,5 +43,7 @@
     "requesterNameLabel": "Name",
     "setPrivilegesHeading": "Set Privileges",
     "setPrivilegesText": "Please select which team privileges you would like to assign to {{name}} within {{team}}",
-    "teamLabel": "Team"
+    "team": "Team",
+    "teamLabel": "Team",
+    "tool_request": "Tool Request"
 }

--- a/src/components/models/NotificationCategory.js
+++ b/src/components/models/NotificationCategory.js
@@ -17,7 +17,7 @@ const NotificationCategory = {
 };
 
 export const notificationTypeToCategory = (type) => {
-    return NotificationCategory[type?.replace(/\s/g, "_").toUpperCase()];
+    return type?.replace(/\s/g, "_");
 };
 
 export default NotificationCategory;

--- a/src/components/notifications/Toolbar.js
+++ b/src/components/notifications/Toolbar.js
@@ -65,7 +65,7 @@ const NotificationToolbar = (props) => {
                         id={buildID(filterId, key)}
                         value={NotificationCategory[key]}
                     >
-                        {NotificationCategory[key]}
+                        {t(key.toLowerCase())}
                     </MenuItem>
                 ))}
             </TextField>

--- a/src/components/notifications/listing/TableView.js
+++ b/src/components/notifications/listing/TableView.js
@@ -239,8 +239,10 @@ const TableView = (props) => {
                                             </TableCell>
                                             <TableCell className={className}>
                                                 <Typography>
-                                                    {notificationTypeToCategory(
-                                                        n.type
+                                                    {t(
+                                                        notificationTypeToCategory(
+                                                            n.type
+                                                        )
                                                     )}
                                                 </Typography>
                                             </TableCell>


### PR DESCRIPTION
Switching from using the text in the `NotificationCategory` model as what's displayed to the user, to what we have in the notification i18n strings. Also display the Community category as Collection instead. Since the model is unchanged, all the service calls which use the model to create filters should still work as expected.

![image](https://user-images.githubusercontent.com/8909156/132047476-b951a2ea-942d-487a-96a3-e6e99042a761.png)

![image](https://user-images.githubusercontent.com/8909156/132047451-18467306-d3be-414c-af2b-0545b441f93a.png)

From storybook to help show at least one of each type:
![image](https://user-images.githubusercontent.com/8909156/132047751-22a74444-9764-4114-b339-54497a54d6d3.png)

