### PR TITLE
Fix unexpected error when refreshing Data page

### DIFF
--- a/src/components/data/toolbar/Navigation.js
+++ b/src/components/data/toolbar/Navigation.js
@@ -416,27 +416,25 @@ function Navigation(props) {
          * SHARED_WITH_ME_PATH: "/iplant/home",
          */
         if (dataRoots.length > 0 && path) {
+            let index = 0;
             if (path.startsWith(userHomePath)) {
-                setSelectedIndex(
-                    dataRoots.findIndex((root) => root.path === userHomePath)
+                index = dataRoots.findIndex(
+                    (root) => root.path === userHomePath
                 );
             } else if (path.startsWith(userTrashPath)) {
-                setSelectedIndex(
-                    dataRoots.findIndex((root) => root.path === userTrashPath)
+                index = dataRoots.findIndex(
+                    (root) => root.path === userTrashPath
                 );
             } else if (path.startsWith(communityDataPath)) {
-                setSelectedIndex(
-                    dataRoots.findIndex(
-                        (root) => root.path === communityDataPath
-                    )
+                index = dataRoots.findIndex(
+                    (root) => root.path === communityDataPath
                 );
             } else if (path.startsWith(sharedWithMePath)) {
-                setSelectedIndex(
-                    dataRoots.findIndex(
-                        (root) => root.path === sharedWithMePath
-                    )
+                index = dataRoots.findIndex(
+                    (root) => root.path === sharedWithMePath
                 );
             }
+            setSelectedIndex(index < 0 ? 0 : index);
         }
     }, [
         dataRoots,


### PR DESCRIPTION
There might be a race condition between when the user is considered logged in vs out.  The case I saw in the console was where the path was `/cyverse/home/aramsey`, but the `dataRoots` were all set for the anonymous user.  This resulted in the `selectedIndex` being set to `-1` which threw an error in the render function when trying to access `dataRoots[selectedIndex]`.