### PR TITLE
Refine the ticks on the data consumption graph display

### DIFF
--- a/src/components/dashboard/dashboardItem/DataConsumption.js
+++ b/src/components/dashboard/dashboardItem/DataConsumption.js
@@ -44,6 +44,22 @@ ChartJS.register(
 );
 
 const options = (usage, quota, date, distance, title, theme, t) => {
+    let quotaGiB = quota / constants.ONE_GiB;
+    let divisor =
+        quotaGiB % 4 === 0
+            ? 4
+            : quotaGiB % 3 === 0
+            ? 3
+            : quotaGiB % 5 === 0
+            ? 5
+            : quotaGiB % 2 === 0
+            ? 2
+            : 4;
+    let maxTicks = 6;
+    let stepSize =
+        usage <= (quota / divisor) * maxTicks
+            ? Math.ceil(quota / divisor)
+            : quota;
     return {
         indexAxis: "y",
         plugins: {
@@ -84,10 +100,9 @@ const options = (usage, quota, date, distance, title, theme, t) => {
             x: {
                 stacked: false,
                 min: 0,
-                max: Math.max(quota, usage),
+                max: Math.max(Math.ceil(usage / stepSize) * stepSize, quota),
                 ticks: {
-                    /*  stepSize:
-                         usage < quota ? 10 : Math.ceil(usage / quota) * 10, */
+                    stepSize: stepSize,
                     callback: function (value, index, values) {
                         if (value === quota) {
                             return t("dataQuotaLimit", {


### PR DESCRIPTION
Since I spent a chunk of the day thinking about it while off doing appointments and errands, I think this works out pretty nicely!

Here's how it works:
1. we set a max number of ticks (6, which seems like a nice enough amount for this small display).
2. we turn the quota into a number of GiB for comparison
3. we attempt to find a nice divisor of the number of GiB in the quota. We try this in an order that hopefully means we get nicer numbers of ticks in the most common display, when a user is under quota -- 4, then 3, then 5, then 2. If nothing works (which is pretty unlikely, but we needed some sort of default), use 4. This divisor is the number of ticks up to the quota value (so if it's 4, the graph will show a tick at 0, at 1/4 of quota, 1/2 of quota, 3/4 of quota, and at quota).
4. The step size is then set based on the divisor, quota, and usage: if setting a step size of `quota / divisor` would result in `maxTicks` (6) or fewer ticks, set the step size to that. Otherwise, set it to increments of the quota.
5. Set the maximum extent of the graph to correspond to an increment of the stepSize, but at the minimum, it should be set to the quota.

This process should work pretty well even with changing/dynamic quotas later on. The only thing that might be weird is if we get any quotas that aren't divisible by 2/3/4/5 GiB, but unless we start doing special sales if you buy prime-numbered data storage quota or something we should be fine. With the current 100GiB quota, it means we get 25GiB ticks when under quota, and also up through 150GiB of usage, and then 100GiB ticks afterwards.