### PR TITLE
Fix image viewer by adding a wrapping div that doesn't impose flexbox on its children

### DIFF
--- a/src/components/data/viewers/ImageViewer.js
+++ b/src/components/data/viewers/ImageViewer.js
@@ -39,12 +39,14 @@ export default function ImageViewer(props) {
                     onRefresh={onRefresh}
                     fileName={fileName}
                 />
-                <img
-                    id={buildID(baseId, ids.VIEWER_IMAGE, fileName)}
-                    src={`${url}`}
-                    alt={fileName}
-                    style={{ overflow: "auto" }}
-                />
+                <div>
+                    <img
+                        id={buildID(baseId, ids.VIEWER_IMAGE, fileName)}
+                        src={`${url}`}
+                        alt={fileName}
+                        style={{ overflow: "auto" }}
+                    />
+                </div>
             </PageWrapper>
         );
     } else {


### PR DESCRIPTION
Small fix, discussed it a little in slack the other month. Before/after:

![flexboxfix-nodiv](https://user-images.githubusercontent.com/106004/161607127-2930a87a-39e0-4477-82ce-2c4d431e88c5.png)
![flexboxfix-div](https://user-images.githubusercontent.com/106004/161607113-c94ce9ef-ea7a-4843-99f0-baedabb50149.png)

