### PR TITLE
CORE-1736 Prevent duplicate completion/canceled stop requests

### DIFF
--- a/src/components/analyses/toolbar/TerminateAnalysisDialog.js
+++ b/src/components/analyses/toolbar/TerminateAnalysisDialog.js
@@ -35,8 +35,12 @@ function TerminateAnalysisDialog(props) {
         const viceAnalyses = mapIsVice?.true;
         const condorAnalyses = mapIsVice?.false;
 
-        handleSaveAndComplete(viceAnalyses);
-        handleCancel(condorAnalyses);
+        if (viceAnalyses) {
+            handleSaveAndComplete(viceAnalyses);
+        }
+        if (condorAnalyses) {
+            handleCancel(condorAnalyses);
+        }
     };
 
     return (


### PR DESCRIPTION
This PR will update the `handleTerminateConfirmed` callback in the `TerminateAnalysisDialog` so that it checks for filtered analyses before calling `handleSaveAndComplete` or `handleCancel`, since `AnalysisSubmissionLanding` does not check the arguments for these callbacks before calling the stop endpoint, the way the analyses `Listing` does:

https://github.com/cyverse-de/sonora/blob/c3495c6cb721f0dd08fccc5e3230cedaa0f5ae2b/src/components/analyses/listing/Listing.js#L651-L666
https://github.com/cyverse-de/sonora/blob/c3495c6cb721f0dd08fccc5e3230cedaa0f5ae2b/src/components/analyses/landing/AnalysisSubmissionLanding.js#L303-L313