### PR TITLE
Fix reporting of URL import submission errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "sonora",
             "version": "0.0.1",
             "license": "BSD-3-Clause",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "sonora",
             "version": "0.0.1",
             "license": "BSD-3-Clause",
             "dependencies": {

--- a/src/components/urlImport/index.js
+++ b/src/components/urlImport/index.js
@@ -137,17 +137,28 @@ const URLImportTextField = (props) => {
             errorCallback(null);
             setUploadURL("");
         },
+
         onError: (error) => {
             successCallback(null);
+
             const errorPath = getErrorData(error)?.path;
-            const duplicateName = urlFileName(errorPath);
-            const text =
-                getErrorCode(error) === ERROR_CODES.ERR_EXISTS
-                    ? t("fileExists", {
-                          name: duplicateName,
-                          path: path,
-                      })
-                    : t("fileImportFail");
+            var text = "";
+
+            // default to a generic error message if the errorPath could not
+            // be determined and is therefore undefined.
+            if (errorPath) {
+                const duplicateName = urlFileName(errorPath);
+                text =
+                    getErrorCode(error) === ERROR_CODES.ERR_EXISTS
+                        ? t("fileExists", {
+                              name: duplicateName,
+                              path: path,
+                          })
+                        : t("fileImportFail");
+            } else {
+                text = t("fileImportFail");
+            }
+
             errorCallback(text);
         },
     });

--- a/src/components/urlImport/index.js
+++ b/src/components/urlImport/index.js
@@ -142,21 +142,17 @@ const URLImportTextField = (props) => {
             successCallback(null);
 
             const errorPath = getErrorData(error)?.path;
-            var text = "";
 
             // default to a generic error message if the errorPath could not
             // be determined and is therefore undefined.
-            if (errorPath) {
+            let text = t("fileImportFail");
+
+            if (errorPath && getErrorCode(error) === ERROR_CODES.ERR_EXISTS) {
                 const duplicateName = urlFileName(errorPath);
-                text =
-                    getErrorCode(error) === ERROR_CODES.ERR_EXISTS
-                        ? t("fileExists", {
-                              name: duplicateName,
-                              path: path,
-                          })
-                        : t("fileImportFail");
-            } else {
-                text = t("fileImportFail");
+                text = t("fileExists", {
+                    name: duplicateName,
+                    path: path,
+                });
             }
 
             errorCallback(text);


### PR DESCRIPTION
If the URL import dialog runs into an unknown error type, then it effectively hangs and makes it appear that it's taking forever to submit. This PR fixes that by allowing the logic to return a generic error message if the error type passed into onError() isn't in the format that we expect.