### PR TITLE
CORE-1531 Add Create App Version page and Editor support

### DIFF
--- a/public/static/locales/en/app_editor.json
+++ b/public/static/locales/en/app_editor.json
@@ -9,6 +9,7 @@
     "appSaved": "App Saved",
     "appSavedSuggestions": "The app is saved, so you can test it out by launching the app, or you can exit the editor now.",
     "appSaveErr": "Unable to save app. Please try again.",
+    "appVersion": "Version",
     "argumentOption": "Argument option",
     "checkboxArgOptionCheckedLabel": "Argument option when checked",
     "checkboxArgValueCheckedLabel": "Value when checked",
@@ -25,6 +26,7 @@
     "confirmDeleteParamTitle": "Delete Parameter?",
     "confirmDeleteParamText": "This action cannot be undone.",
     "createApp": "Create App: {{name}}",
+    "createAppVersion": "Create New Version of \"{{name}}\"",
     "dataSourceLabel": "Source of output file",
     "defaultValue": "Default value",
     "doNotPass": "Do not pass this argument to command line.",
@@ -78,5 +80,6 @@
     "validationRuleRegex": "Matches a reqular expression",
     "validationRuleValueAbove": "Has a lower limit",
     "validationRuleValueBelow": "Has an upper limit",
-    "validationRuleValueRange": "Has a range of allowed values"
+    "validationRuleValueRange": "Has a range of allowed values",
+    "versionDuplicateLabelError": "Another version is already using that label"
 }

--- a/public/static/locales/en/app_editor_help.json
+++ b/public/static/locales/en/app_editor_help.json
@@ -35,7 +35,7 @@
     "Regex": "Indicates that the text the user enters must match the expression you define.",
     "RepeatOptionFlag": "Selecting this option allows the \"Argument option\" defined for this parameter to be included on the command line before each filename selected by the user.",
     "Section": "<p>An app can contain multiple <b>sections</b> that appear as collapsible panels to help organize the app's content.</p><p>For example, you may have one section labeled \"Inputs\" where users select their input data, as well as an \"Options\" section where users select from the various options you have created for your app.</p>",
-    "StepErrorInfo": "Apps require a name and a description.",
+    "StepErrorInfo": "Apps require a name, version, and a description.",
     "StepHelpInfo": "Enter a name and a brief description for this app. The app description will display in app search results and at the top of the app launch form. More detailed documentation for this app may be added when it's made public. A tool selection is required in order for the app to run, but a work in progress may be saved before selecting a tool.",
     "Text": "Will display a text box the user may enter information into. You can also set informative or descriptive default \"background\" text to display in the text box.",
     "TextSelection": "Adds a drop-down list from which the user can make one selection from the options you define.",

--- a/public/static/locales/en/apps.json
+++ b/public/static/locales/en/apps.json
@@ -44,6 +44,7 @@
     "copyWorkflow": "Copy Workflow",
     "create": "Create",
     "createApp": "Create App",
+    "createAppVersion": "Create Version",
     "createSavedLaunchLabel": "Create Saved Launch",
     "createWorkflow": "Create Workflow",
     "declineAuthBtnText": "Not Now",

--- a/public/static/locales/en/workflows.json
+++ b/public/static/locales/en/workflows.json
@@ -5,6 +5,7 @@
     "confirmDeleteStepText": "This action cannot be undone.",
     "confirmDeleteStepTitle": "Delete Step?",
     "createWorkflow": "Create Workflow: {{name}}",
+    "createWorkflowVersion": "Create New Version of \"{{name}}\"",
     "disabledAppsNotAllowed": "Disabled apps can't be included in a workflow.",
     "editWorkflow": "Edit Workflow: {{name}}",
     "exitEditor": "Exit Editor",
@@ -28,5 +29,6 @@
     "workflowInfo": "Workflow Information",
     "workflowSaved": "Workflow Saved",
     "workflowSavedSuggestions": "The workflow is saved, so you can test it out by launching the workflow, or you can exit the editor now.",
-    "workflowSaveErr": "Unable to save workflow. Please try again."
+    "workflowSaveErr": "Unable to save workflow. Please try again.",
+    "workflowVersion": "Version"
 }

--- a/src/components/apps/constants.js
+++ b/src/components/apps/constants.js
@@ -5,7 +5,6 @@ export default {
     STATE: "state",
     APPS: "apps",
     DATA: "data",
-    AGAVE: "agave",
     SAVED_LAUNCH_EMBED_ICON: "Powered-By-CyVerse-blue.svg",
     APP_NAME_RESTRICTED_CHARS: ":@/\\|^#;[]{}<>",
     APP_NAME_RESTRICTED_STARTING_CHARS: "~.$",

--- a/src/components/apps/editor/AppInfo.js
+++ b/src/components/apps/editor/AppInfo.js
@@ -85,6 +85,13 @@ export default function AppInfo(props) {
                 disabled={cosmeticOnly}
             />
             <FastField
+                id={buildID(baseId, ids.APP_VERSION)}
+                name="version"
+                label={t("appVersion")}
+                required
+                component={FormTextField}
+            />
+            <FastField
                 id={buildID(baseId, ids.APP_DESCRIPTION)}
                 name="description"
                 label={t("appDescription")}

--- a/src/components/apps/editor/formatters.js
+++ b/src/components/apps/editor/formatters.js
@@ -39,7 +39,7 @@ const FILE_PARAMETER_FORMAT_DEFAULT = "Unspecified";
  * @returns Initial form values.
  */
 const initAppValues = (app) => {
-    const groups = app?.groups;
+    const { groups, version, version_id } = app || {};
 
     const initializedGroups = groups?.map(({ name, ...group }, groupIndex) => ({
         ...group,
@@ -116,7 +116,13 @@ const initAppValues = (app) => {
 
     return {
         ...app,
+
         groups: initializedGroups,
+
+        // If the version_id is empty, then keep the version label empty as well,
+        // to force the user to enter a new version label.
+        version: version_id ? version : "",
+
         // The editorSteps array is only required for preserving touched state
         // after any onSubmit errors:
         // https://github.com/formium/formik/issues/445#issuecomment-366952762

--- a/src/components/apps/editor/ids.js
+++ b/src/components/apps/editor/ids.js
@@ -5,6 +5,7 @@ export default {
     APP_DESCRIPTION: "appDescription",
     APP_EDITOR_VIEW: "appEditorView",
     APP_NAME: "appName",
+    APP_VERSION: "appVersion",
     CMD_LINE_PREVIEW: "cmdLinePreview",
     DELETE_CONFIRM_DIALOG: "deleteConfirmDialog",
     GROUP: "group",

--- a/src/components/apps/ids.js
+++ b/src/components/apps/ids.js
@@ -16,6 +16,7 @@ export default {
     COPY_MENU_ITEM: "copy",
     CREATE_APP_BTN: "createAppButton",
     CREATE_APP_MENU_ITEM: "createAppMenuItem",
+    CREATE_APP_VERSION_MENU_ITEM: "createAppVersionMenuItem",
     CREATE_MENU_ITEM: "createMenuItem",
     CREATE_WORKFLOW_MENU_ITEM: "createWorkflowMenuItem",
     DIALOG: "dialog",

--- a/src/components/apps/listing/RowDotMenu.js
+++ b/src/components/apps/listing/RowDotMenu.js
@@ -16,6 +16,7 @@ import { getHost } from "components/utils/getHost";
 import { copyStringToClipboard } from "components/utils/copyStringToClipboard";
 import { copyLinkToClipboardHandler } from "components/utils/copyLinkToClipboardHandler";
 import CopyMenuItem from "../menuItems/CopyMenuItem";
+import CreateVersionMenuItem from "../menuItems/CreateVersionMenuItem";
 import DeleteMenuItem from "../menuItems/DeleteMenuItem";
 import DetailsMenuItem from "../menuItems/DetailsMenuItem";
 import DocMenuItem from "../menuItems/DocMenuItem";
@@ -57,9 +58,9 @@ function RowDotMenu(props) {
     const canPublish = isOwner && !isAppPublic;
     const canDelete = isOwner && !isAppPublic;
     const canCopy = isReadable(app?.permission);
-    const canEdit =
-        isWritable(app?.permission) ||
-        (isAppPublic && !isWorkflow && isAppIntegrator);
+    const canEdit = isWritable(app?.permission);
+    const canEditLabels =
+        canEdit || (isAppPublic && !isWorkflow && isAppIntegrator);
 
     return (
         <>
@@ -73,8 +74,16 @@ function RowDotMenu(props) {
                         onClose={onClose}
                         onDetailsSelected={onDetailsSelected}
                     />,
+                    canEdit && (
+                        <CreateVersionMenuItem
+                            key={ids.CREATE_APP_VERSION_MENU_ITEM}
+                            baseId={baseId}
+                            onClose={onClose}
+                            app={app}
+                        />
+                    ),
                     !isAdminView && [
-                        canEdit && (
+                        canEditLabels && (
                             <EditMenuItem
                                 key={buildID(baseId, ids.EDIT_MENU_ITEM)}
                                 baseId={baseId}

--- a/src/components/apps/listing/RowDotMenu.js
+++ b/src/components/apps/listing/RowDotMenu.js
@@ -10,6 +10,7 @@ import { useTranslation } from "i18n";
 import buildID from "components/utils/DebugIDUtil";
 import DotMenu from "components/dotMenu/DotMenu";
 
+import SystemIds from "components/models/systemId";
 import ids from "../ids";
 import { hasOwn, isReadable, isWritable } from "../utils";
 import { getHost } from "components/utils/getHost";
@@ -57,7 +58,8 @@ function RowDotMenu(props) {
 
     const canPublish = isOwner && !isAppPublic;
     const canDelete = isOwner && !isAppPublic;
-    const canCopy = isReadable(app?.permission);
+    const canCopy =
+        isReadable(app?.permission) && app?.system_id === SystemIds.de;
     const canEdit = isWritable(app?.permission);
     const canEditLabels =
         canEdit || (isAppPublic && !isWorkflow && isAppIntegrator);

--- a/src/components/apps/menuItems/CopyMenuItem.js
+++ b/src/components/apps/menuItems/CopyMenuItem.js
@@ -44,7 +44,13 @@ function CopyMenuItem(props) {
                     text: t("appCopySuccess", { appName: app?.name }),
                     variant: SUCCESS,
                 });
-                router.push(getAppEditPath(appCopy.system_id, appCopy.id));
+                router.push(
+                    getAppEditPath(
+                        appCopy.system_id,
+                        appCopy.id,
+                        appCopy.version_id
+                    )
+                );
             },
             onError: (error) => {
                 showErrorAnnouncer(

--- a/src/components/apps/menuItems/CopyMenuItem.js
+++ b/src/components/apps/menuItems/CopyMenuItem.js
@@ -66,7 +66,11 @@ function CopyMenuItem(props) {
             id={buildID(baseId, ids.COPY_MENU_ITEM)}
             disabled={isLoading}
             onClick={() => {
-                onCopyApp({ systemId: app?.system_id, appId: app?.id });
+                onCopyApp({
+                    systemId: app?.system_id,
+                    appId: app?.id,
+                    versionId: app?.version_id,
+                });
             }}
         >
             <ListItemIcon>

--- a/src/components/apps/menuItems/CreateVersionMenuItem.js
+++ b/src/components/apps/menuItems/CreateVersionMenuItem.js
@@ -4,37 +4,37 @@ import { useRouter } from "next/router";
 
 import { useTranslation } from "i18n";
 import ids from "../ids";
-import { getAppEditPath } from "../utils";
+import { getAppVersionCreatePath } from "../utils";
 
 import buildID from "components/utils/DebugIDUtil";
 
 import { ListItemIcon, ListItemText, MenuItem } from "@material-ui/core";
 import { Edit } from "@material-ui/icons";
 
-export default function EditMenuItem(props) {
+export default function CreateVersionMenuItem(props) {
     const { baseId, app, onClose } = props;
 
     const router = useRouter();
     const { t } = useTranslation("apps");
 
-    const isWorkflow = app?.step_count > 1;
-
     return (
         <MenuItem
-            id={buildID(baseId, ids.EDIT_MENU_ITEM)}
+            id={buildID(baseId, ids.CREATE_APP_VERSION_MENU_ITEM)}
             onClick={() => {
                 onClose();
                 router.push(
-                    getAppEditPath(app.system_id, app.id, app.version_id)
+                    getAppVersionCreatePath(
+                        app.system_id,
+                        app.id,
+                        app.version_id
+                    )
                 );
             }}
         >
             <ListItemIcon>
                 <Edit fontSize="small" />
             </ListItemIcon>
-            <ListItemText
-                primary={t(isWorkflow ? "editWorkflow" : "editApp")}
-            />
+            <ListItemText primary={t("createAppVersion")} />
         </MenuItem>
     );
 }

--- a/src/components/apps/savedLaunch/SavedLaunchListing.js
+++ b/src/components/apps/savedLaunch/SavedLaunchListing.js
@@ -16,6 +16,7 @@ import constants from "../constants";
 import SavedLaunch from "./SavedLaunch";
 
 import { getSavedLaunchPath } from "components/apps/utils";
+import SystemIds from "components/models/systemId";
 import { getHost } from "components/utils/getHost";
 import ConfirmationDialog from "components/utils/ConfirmationDialog";
 import GridLoading from "components/utils/GridLoading";
@@ -262,7 +263,7 @@ function ListSavedLaunches(props) {
     }
 
     if (!savedLaunches || savedLaunches.length === 0) {
-        if (systemId !== constants.AGAVE) {
+        if (systemId !== SystemIds.agave) {
             const href = `/${NavigationConstants.APPS}/[systemId]/[appId]/launch`;
             const as = `/${NavigationConstants.APPS}/${systemId}/${appId}/launch`;
             return (

--- a/src/components/apps/utils.js
+++ b/src/components/apps/utils.js
@@ -51,9 +51,21 @@ export const getSavedLaunchPath = (systemId, appId, launchId) =>
  *
  * @param {string} systemId The app's system ID.
  * @param {string} appId The app's ID.
+ * @param {string} versionId The app's version ID.
  */
-export const getAppEditPath = (systemId, appId) =>
-    `/${NavigationConstants.APPS}/${systemId}/${appId}/edit`;
+export const getAppEditPath = (systemId, appId, versionId) =>
+    `/${NavigationConstants.APPS}/${systemId}/${appId}/versions/${versionId}/edit`;
+
+/**
+ * Builds a path to the App Editor for creating a new version
+ * of the app with the given IDs.
+ *
+ * @param {string} systemId The app's system ID.
+ * @param {string} appId The app's ID.
+ * @param {string} versionId The app's version ID.
+ */
+export const getAppVersionCreatePath = (systemId, appId, versionId) =>
+    `/${NavigationConstants.APPS}/${systemId}/${appId}/versions/${versionId}/create`;
 
 /**
  *

--- a/src/components/apps/workflows/Editor.js
+++ b/src/components/apps/workflows/Editor.js
@@ -180,7 +180,9 @@ const WorkflowEditor = (props) => {
 
     const onRedirectToEditPage = (workflow) =>
         workflow.id &&
-        router.replace(getAppEditPath(workflow.system_id, workflow.id));
+        router.replace(
+            getAppEditPath(workflow.system_id, workflow.id, workflow.version_id)
+        );
 
     const { mutate: savePipeline } = useMutation(
         ({ workflow }) => {

--- a/src/components/apps/workflows/Editor.js
+++ b/src/components/apps/workflows/Editor.js
@@ -35,7 +35,11 @@ import useComponentHeight from "components/utils/useComponentHeight";
 import WrappedErrorHandler from "components/error/WrappedErrorHandler";
 import withErrorAnnouncer from "components/error/withErrorAnnouncer";
 
-import { addPipeline, updatePipeline } from "serviceFacades/pipelines";
+import {
+    addPipeline,
+    addPipelineVersion,
+    updatePipeline,
+} from "serviceFacades/pipelines";
 
 import { announce } from "components/announcer/CyVerseAnnouncer";
 import { SUCCESS } from "components/announcer/AnnouncerConstants";
@@ -166,7 +170,7 @@ const WorkflowEditor = (props) => {
         setStepperRef(stepperRef);
     }, [stepperRef, setStepperRef]);
 
-    const { t } = useTranslation(["workflows", "common"]);
+    const { t } = useTranslation(["workflows", "app_editor", "common"]);
     const classes = useStyles();
     const router = useRouter();
     const theme = useTheme();
@@ -186,10 +190,14 @@ const WorkflowEditor = (props) => {
 
     const { mutate: savePipeline } = useMutation(
         ({ workflow }) => {
-            const { id: appId } = workflow;
-            const request = { appId, workflow };
+            const { id: appId, version_id: versionId } = workflow;
+            const request = { appId, versionId, workflow };
 
-            return appId ? updatePipeline(request) : addPipeline(request);
+            return appId
+                ? versionId
+                    ? updatePipeline(request)
+                    : addPipelineVersion(request)
+                : addPipeline(request);
         },
         {
             onSuccess: (resp, { onSuccess }) => {
@@ -253,15 +261,24 @@ const WorkflowEditor = (props) => {
                 const errors = {};
                 const workflowSteps = [];
 
-                if (!values.name) {
+                ["name", "description", "version"].forEach((fieldName) => {
+                    if (!values[fieldName]) {
+                        workflowSteps[0] = true;
+                        errors.error = true;
+                        errors[fieldName] = t("common:required");
+                    }
+                });
+
+                if (
+                    appDescription.versions?.find(
+                        (versionInfo) =>
+                            versionInfo.version === values.version &&
+                            versionInfo.version_id !== values.version_id
+                    )
+                ) {
                     workflowSteps[0] = true;
                     errors.error = true;
-                    errors.name = t("common:required");
-                }
-                if (!values.description) {
-                    workflowSteps[0] = true;
-                    errors.error = true;
-                    errors.description = t("common:required");
+                    errors.version = t("app_editor:versionDuplicateLabelError");
                 }
 
                 const tooFewSteps = values.steps.length < 2;
@@ -300,7 +317,7 @@ const WorkflowEditor = (props) => {
                         onExit();
                     } else if (launchOnSave) {
                         onLaunch(workflow);
-                    } else if (!values.id) {
+                    } else if (!values.id || !values.version_id) {
                         // A new workflow was saved, so redirect to new URL
                         onRedirectToEditPage(workflow);
                     }
@@ -369,9 +386,9 @@ const WorkflowEditor = (props) => {
 
                 const displayStepError = (stepIndex) => {
                     if (stepIndex === 0) {
-                        return (
-                            getFormError("name", touched, errors) ||
-                            getFormError("description", touched, errors)
+                        return ["name", "description", "version"].find(
+                            (fieldName) =>
+                                getFormError(fieldName, touched, errors)
                         );
                     }
 
@@ -427,7 +444,9 @@ const WorkflowEditor = (props) => {
                             <Typography variant="h6">
                                 {t(
                                     values.id
-                                        ? "editWorkflow"
+                                        ? values.version_id
+                                            ? "editWorkflow"
+                                            : "createWorkflowVersion"
                                         : "createWorkflow",
                                     {
                                         name: values.name,

--- a/src/components/apps/workflows/WorkflowInfo.js
+++ b/src/components/apps/workflows/WorkflowInfo.js
@@ -18,22 +18,29 @@ import FormMultilineTextField from "components/forms/FormMultilineTextField";
 export default function WorkflowInfo(props) {
     const { baseId, cosmeticOnly } = props;
 
-    const { t } = useTranslation("common");
+    const { t } = useTranslation(["workflows", "common"]);
 
     return (
         <>
             <FastField
                 id={buildID(baseId, ids.WORKFLOW_NAME)}
                 name="name"
-                label={t("name")}
+                label={t("common:name")}
                 required
                 component={FormTextField}
                 disabled={cosmeticOnly}
             />
             <FastField
+                id={buildID(baseId, ids.WORKFLOW_VERSION)}
+                name="version"
+                label={t("workflowVersion")}
+                required
+                component={FormTextField}
+            />
+            <FastField
                 id={buildID(baseId, ids.WORKFLOW_DESCRIPTION)}
                 name="description"
-                label={t("description")}
+                label={t("common:description")}
                 required
                 component={FormMultilineTextField}
             />

--- a/src/components/apps/workflows/formatters.js
+++ b/src/components/apps/workflows/formatters.js
@@ -16,7 +16,8 @@ import { groupBy } from "common/functions";
  * @returns A workflow with steps formatted for use in the form.
  */
 export const initWorkflowValues = (appDescription) => {
-    const { steps, tasks, mappings } = appDescription || {};
+    const { steps, tasks, mappings, version, version_id } =
+        appDescription || {};
 
     // First format each task by adding a source step key to each output.
     let formattedTasks = tasks?.map((task) => ({
@@ -56,7 +57,13 @@ export const initWorkflowValues = (appDescription) => {
         // after onSubmit:
         // https://github.com/formium/formik/issues/445#issuecomment-366952762
         workflowSteps: [null, null, null, null],
+
         ...appDescription,
+
+        // If the version_id is empty, then keep the version label empty as well,
+        // to force the user to enter a new version label.
+        version: version_id ? version : "",
+
         steps:
             steps?.map((step) => ({
                 ...step,
@@ -72,7 +79,7 @@ export const initWorkflowValues = (appDescription) => {
  * @returns A workflow JSON formatted for submission to the service.
  */
 export const formatWorkflowSubmission = (workflow) => {
-    const { id, name, description, steps } = workflow;
+    const { id, name, version, version_id, description, steps } = workflow;
 
     // Build the mappings array from the formatted task inputs in each step.
     const mappings = steps
@@ -103,6 +110,8 @@ export const formatWorkflowSubmission = (workflow) => {
     return {
         id,
         name,
+        version,
+        version_id,
         description,
         mappings,
         steps: steps.map(

--- a/src/components/apps/workflows/ids.js
+++ b/src/components/apps/workflows/ids.js
@@ -7,6 +7,7 @@ export default {
     WORKFLOW_DESCRIPTION: "description",
     WORKFLOW_EDITOR_FORM: "workflowEditorForm",
     WORKFLOW_NAME: "name",
+    WORKFLOW_VERSION: "version",
 
     BUTTONS: {
         ADD_APPS: "addAppsBtn",

--- a/src/pages/apps/[systemId]/[appId]/versions/[versionId]/create.js
+++ b/src/pages/apps/[systemId]/[appId]/versions/[versionId]/create.js
@@ -108,9 +108,9 @@ export default function AppVersionCreate() {
     });
 
     const { isFetching: workflowUILoading } = useQuery({
-        queryKey: [PIPELINE_UI_QUERY_KEY, { appId }],
-        queryFn: () => getPipelineUI({ appId }),
-        enabled: !!(userProfile?.id && appId && isWorkflow),
+        queryKey: [PIPELINE_UI_QUERY_KEY, { appId, versionId }],
+        queryFn: () => getPipelineUI({ appId, versionId }),
+        enabled: !!(userProfile?.id && appId && versionId && isWorkflow),
         onSuccess: (workflowUI) => {
             const { version_id, ...workflowCopy } = workflowUI;
             setWorkflowDescription(workflowCopy);

--- a/src/pages/apps/[systemId]/[appId]/versions/[versionId]/create.js
+++ b/src/pages/apps/[systemId]/[appId]/versions/[versionId]/create.js
@@ -1,0 +1,163 @@
+/**
+ * A page for displaying the App Editor for creating a new app version.
+ *
+ * @author psarando
+ */
+import React from "react";
+
+import { useRouter } from "next/router";
+import { useQuery } from "react-query";
+
+import AppEditor from "components/apps/editor";
+import ids from "components/apps/editor/ids";
+import WorkflowEditor from "components/apps/workflows/Editor";
+import WorkflowIds from "components/apps/workflows/ids";
+import { signInErrorResponse } from "components/error/errorCode";
+
+import { useUserProfile } from "contexts/userProfile";
+
+import {
+    APP_DETAILS_QUERY_KEY,
+    APP_UI_QUERY_KEY,
+    getAppDetails,
+    getAppUI,
+} from "serviceFacades/apps";
+
+import { getPipelineUI, PIPELINE_UI_QUERY_KEY } from "serviceFacades/pipelines";
+
+/**
+ * Formats an item in an app parameter's `arguments` list as a copy,
+ * suitable for saving in a new version, by removing its `id`,
+ * as well as formatting any of its own `arguments` or `groups`.
+ *
+ * @param {Object} paramArg An item in an app parameter's `arguments` list.
+ * @returns The argument item formatted as a copy.
+ */
+const appParamArgCopy = ({ id, ...paramArg }) => {
+    paramArg.arguments = paramArg.arguments?.map(appParamArgCopy);
+    paramArg.groups = paramArg.groups?.map(appParamArgCopy);
+
+    return paramArg;
+};
+
+/**
+ * Formats an app parameter as a copy, suitable for saving in a new version,
+ * by removing its `id`, as well as formatting any of its `arguments`.
+ *
+ * @param {Object} param An app parameter.
+ * @returns The app parameter formatted as a copy.
+ */
+const appParamCopy = ({ id, ...param }) => {
+    param.arguments = param.arguments?.map(appParamArgCopy);
+
+    return param;
+};
+
+/**
+ * Formats an app parameter group as a copy, suitable for saving in a new version,
+ * by removing its `id`, as well as formatting all of its `parameters`.
+ *
+ * @param {Object} group An app parameter group.
+ * @returns The app parameter group formatted as a copy.
+ */
+const appGroupCopy = ({ id, ...group }) => {
+    group.parameters = group.parameters?.map(appParamCopy);
+
+    return group;
+};
+
+export default function AppVersionCreate() {
+    const [appDescription, setAppDescription] = React.useState(null);
+    const [workflowDescription, setWorkflowDescription] = React.useState(null);
+    const [appDetails, setAppDetails] = React.useState(null);
+    const [loadingError, setLoadingError] = React.useState(null);
+
+    const [userProfile] = useUserProfile();
+
+    const router = useRouter();
+    const { systemId, appId, versionId } = router.query;
+
+    const isWorkflow = appDetails?.step_count > 1;
+
+    const { isFetching: appInfoLoading } = useQuery({
+        queryKey: [APP_DETAILS_QUERY_KEY, { systemId, appId }],
+        queryFn: () => getAppDetails({ systemId, appId }),
+        enabled: !!(userProfile?.id && systemId && appId),
+        onSuccess: setAppDetails,
+        onError: setLoadingError,
+    });
+
+    const { isFetching: appUILoading } = useQuery({
+        queryKey: [APP_UI_QUERY_KEY, { systemId, appId, versionId }],
+        queryFn: () => getAppUI({ systemId, appId, versionId }),
+        enabled: !!(
+            userProfile?.id &&
+            systemId &&
+            appId &&
+            versionId &&
+            appDetails &&
+            !isWorkflow
+        ),
+        onSuccess: (appUI) => {
+            const { version_id, ...appCopy } = appUI;
+            appCopy.groups = appCopy.groups?.map(appGroupCopy);
+
+            setAppDescription(appCopy);
+        },
+        onError: setLoadingError,
+    });
+
+    const { isFetching: workflowUILoading } = useQuery({
+        queryKey: [PIPELINE_UI_QUERY_KEY, { appId }],
+        queryFn: () => getPipelineUI({ appId }),
+        enabled: !!(userProfile?.id && appId && isWorkflow),
+        onSuccess: (workflowUI) => {
+            const { version_id, ...workflowCopy } = workflowUI;
+            setWorkflowDescription(workflowCopy);
+        },
+        onError: setLoadingError,
+    });
+
+    React.useEffect(() => {
+        if (userProfile?.id) {
+            setLoadingError(null);
+        } else {
+            setLoadingError(signInErrorResponse);
+        }
+    }, [userProfile]);
+
+    const loading = appInfoLoading || appUILoading || workflowUILoading;
+
+    if (isWorkflow) {
+        return (
+            <WorkflowEditor
+                baseId={WorkflowIds.WORKFLOW_EDITOR_FORM}
+                appDescription={workflowDescription}
+                loading={loading}
+                loadingError={loadingError}
+            />
+        );
+    }
+
+    return (
+        <AppEditor
+            baseId={ids.APP_EDITOR_VIEW}
+            appDescription={appDescription}
+            loading={loading}
+            loadingError={loadingError}
+        />
+    );
+}
+
+AppVersionCreate.getInitialProps = async () => ({
+    namespacesRequired: [
+        "app_editor",
+        "app_editor_help",
+        "app_param_types",
+        "apps",
+        "common",
+        "data",
+        "launch",
+        "workflows",
+    ],
+});

--- a/src/pages/apps/[systemId]/[appId]/versions/[versionId]/edit.js
+++ b/src/pages/apps/[systemId]/[appId]/versions/[versionId]/edit.js
@@ -35,7 +35,7 @@ export default function AppEdit() {
     const [userProfile] = useUserProfile();
 
     const router = useRouter();
-    const { systemId, appId } = router.query;
+    const { systemId, appId, versionId } = router.query;
 
     const isPublic = appListingInfo?.is_public;
     const isWorkflow = appListingInfo?.step_count > 1;
@@ -51,12 +51,13 @@ export default function AppEdit() {
     });
 
     const { isFetching: appUILoading } = useQuery({
-        queryKey: [APP_UI_QUERY_KEY, { systemId, appId }],
-        queryFn: () => getAppUI({ systemId, appId }),
+        queryKey: [APP_UI_QUERY_KEY, { systemId, appId, versionId }],
+        queryFn: () => getAppUI({ systemId, appId, versionId }),
         enabled: !!(
             userProfile?.id &&
             systemId &&
             appId &&
+            versionId &&
             appListingInfo &&
             !isWorkflow
         ),

--- a/src/pages/apps/[systemId]/[appId]/versions/[versionId]/edit.js
+++ b/src/pages/apps/[systemId]/[appId]/versions/[versionId]/edit.js
@@ -66,9 +66,9 @@ export default function AppEdit() {
     });
 
     const { isFetching: workflowUILoading } = useQuery({
-        queryKey: [PIPELINE_UI_QUERY_KEY, { appId }],
-        queryFn: () => getPipelineUI({ appId }),
-        enabled: !!(userProfile?.id && appId && isWorkflow),
+        queryKey: [PIPELINE_UI_QUERY_KEY, { appId, versionId }],
+        queryFn: () => getPipelineUI({ appId, versionId }),
+        enabled: !!(userProfile?.id && appId && versionId && isWorkflow),
         onSuccess: setWorkflowDescription,
         onError: setLoadingError,
     });

--- a/src/server/api/apps.js
+++ b/src/server/api/apps.js
@@ -127,32 +127,6 @@ export default function appsRouter() {
         })
     );
 
-    logger.info("adding the PATCH /apps/:systemId/:appId handler");
-    api.patch(
-        "/apps/:systemId/:appId",
-        auth.authnTokenMiddleware,
-        terrainHandler({
-            method: "PATCH",
-            pathname: "/apps/:systemId/:appId",
-            headers: {
-                "Content-Type": "application/json",
-            },
-        })
-    );
-
-    logger.info("adding the PUT /apps/:systemId/:appId handler");
-    api.put(
-        "/apps/:systemId/:appId",
-        auth.authnTokenMiddleware,
-        terrainHandler({
-            method: "PUT",
-            pathname: "/apps/:systemId/:appId",
-            headers: {
-                "Content-Type": "application/json",
-            },
-        })
-    );
-
     logger.info("adding the GET /apps/:systemId/:appId/listing handler");
     api.get(
         "/apps/:systemId/:appId/listing",
@@ -246,6 +220,61 @@ export default function appsRouter() {
         terrainHandler({
             method: "GET",
             pathname: "/apps/:systemId/:appId/ui",
+        })
+    );
+
+    logger.info("adding the POST /apps/:systemId/:appId/versions handler");
+    api.post(
+        "/apps/:systemId/:appId/versions",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "POST",
+            pathname: "/apps/:systemId/:appId/versions",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        })
+    );
+
+    logger.info(
+        "adding the PATCH /apps/:systemId/:appId/versions/:versionId handler"
+    );
+    api.patch(
+        "/apps/:systemId/:appId/versions/:versionId",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "PATCH",
+            pathname: "/apps/:systemId/:appId/versions/:versionId",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        })
+    );
+
+    logger.info(
+        "adding the PUT /apps/:systemId/:appId/versions/:versionId handler"
+    );
+    api.put(
+        "/apps/:systemId/:appId/versions/:versionId",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "PUT",
+            pathname: "/apps/:systemId/:appId/versions/:versionId",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        })
+    );
+
+    logger.info(
+        "adding the GET /apps/:systemId/:appId/versions/:versionId/ui handler"
+    );
+    api.get(
+        "/apps/:systemId/:appId/versions/:versionId/ui",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "GET",
+            pathname: "/apps/:systemId/:appId/versions/:versionId/ui",
         })
     );
 

--- a/src/server/api/apps.js
+++ b/src/server/api/apps.js
@@ -137,19 +137,6 @@ export default function appsRouter() {
         })
     );
 
-    logger.info("adding the POST /apps/:systemId/:appId/copy handler");
-    api.post(
-        "/apps/:systemId/:appId/copy",
-        auth.authnTokenMiddleware,
-        terrainHandler({
-            method: "POST",
-            pathname: "/apps/:systemId/:appId/copy",
-            headers: {
-                "Content-Type": "application/json",
-            },
-        })
-    );
-
     logger.info("adding the GET /apps/:systemId/:appId/details handler");
     api.get(
         "/apps/:systemId/:appId/details",
@@ -260,6 +247,21 @@ export default function appsRouter() {
         terrainHandler({
             method: "PUT",
             pathname: "/apps/:systemId/:appId/versions/:versionId",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        })
+    );
+
+    logger.info(
+        "adding the POST /apps/:systemId/:appId/versions/:versionId/copy handler"
+    );
+    api.post(
+        "/apps/:systemId/:appId/versions/:versionId/copy",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "POST",
+            pathname: "/apps/:systemId/:appId/versions/:versionId/copy",
             headers: {
                 "Content-Type": "application/json",
             },

--- a/src/server/api/pipelines.js
+++ b/src/server/api/pipelines.js
@@ -28,19 +28,6 @@ export default function pipelinesRouter() {
         })
     );
 
-    logger.info("adding the PUT /apps/pipelines/:appId handler");
-    api.put(
-        "/apps/pipelines/:appId",
-        auth.authnTokenMiddleware,
-        terrainHandler({
-            method: "PUT",
-            pathname: "/apps/pipelines/:appId",
-            headers: {
-                "Content-Type": "application/json",
-            },
-        })
-    );
-
     logger.info("adding the POST /apps/pipelines/:appId/copy handler");
     api.post(
         "/apps/pipelines/:appId/copy",
@@ -61,6 +48,46 @@ export default function pipelinesRouter() {
         terrainHandler({
             method: "GET",
             pathname: "/apps/pipelines/:appId/ui",
+        })
+    );
+
+    logger.info("adding the POST /apps/pipelines/:appId/versions handler");
+    api.post(
+        "/apps/pipelines/:appId/versions",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "POST",
+            pathname: "/apps/pipelines/:appId/versions",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        })
+    );
+
+    logger.info(
+        "adding the PUT /apps/pipelines/:appId/versions/:versionId handler"
+    );
+    api.put(
+        "/apps/pipelines/:appId/versions/:versionId",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "PUT",
+            pathname: "/apps/pipelines/:appId/versions/:versionId",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        })
+    );
+
+    logger.info(
+        "adding the GET /apps/pipelines/:appId/versions/:versionId/ui handler"
+    );
+    api.get(
+        "/apps/pipelines/:appId/versions/:versionId/ui",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "GET",
+            pathname: "/apps/pipelines/:appId/versions/:versionId/ui",
         })
     );
 

--- a/src/server/api/pipelines.js
+++ b/src/server/api/pipelines.js
@@ -28,19 +28,6 @@ export default function pipelinesRouter() {
         })
     );
 
-    logger.info("adding the POST /apps/pipelines/:appId/copy handler");
-    api.post(
-        "/apps/pipelines/:appId/copy",
-        auth.authnTokenMiddleware,
-        terrainHandler({
-            method: "POST",
-            pathname: "/apps/pipelines/:appId/copy",
-            headers: {
-                "Content-Type": "application/json",
-            },
-        })
-    );
-
     logger.info("adding the GET /apps/pipelines/:appId/ui handler");
     api.get(
         "/apps/pipelines/:appId/ui",
@@ -73,6 +60,21 @@ export default function pipelinesRouter() {
         terrainHandler({
             method: "PUT",
             pathname: "/apps/pipelines/:appId/versions/:versionId",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        })
+    );
+
+    logger.info(
+        "adding the POST /apps/pipelines/:appId/versions/:versionId/copy handler"
+    );
+    api.post(
+        "/apps/pipelines/:appId/versions/:versionId/copy",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "POST",
+            pathname: "/apps/pipelines/:appId/versions/:versionId/copy",
             headers: {
                 "Content-Type": "application/json",
             },

--- a/src/serviceFacades/apps.js
+++ b/src/serviceFacades/apps.js
@@ -153,6 +153,14 @@ function addApp({ systemId, app }) {
     });
 }
 
+function addAppVersion({ systemId, appId, app }) {
+    return callApi({
+        endpoint: `/api/apps/${systemId}/${appId}/versions`,
+        method: "POST",
+        body: app,
+    });
+}
+
 function deleteApp({ systemId, appId }) {
     return callApi({
         endpoint: `/api/apps/${systemId}/${appId}`,
@@ -167,17 +175,17 @@ function getAppDescription({ systemId, appId }) {
     });
 }
 
-function updateApp({ systemId, appId, app }) {
+function updateApp({ systemId, appId, versionId, app }) {
     return callApi({
-        endpoint: `/api/apps/${systemId}/${appId}`,
+        endpoint: `/api/apps/${systemId}/${appId}/versions/${versionId}`,
         method: "PUT",
         body: app,
     });
 }
 
-function updateAppLabels({ systemId, appId, app }) {
+function updateAppLabels({ systemId, appId, versionId, app }) {
     return callApi({
-        endpoint: `/api/apps/${systemId}/${appId}`,
+        endpoint: `/api/apps/${systemId}/${appId}/versions/${versionId}`,
         method: "PATCH",
         body: app,
     });
@@ -290,11 +298,16 @@ function getAppTasks({ systemId, appId }) {
     });
 }
 
-function getAppUI({ systemId, appId }) {
-    return callApi({
-        endpoint: `/api/apps/${systemId}/${appId}/ui`,
-        method: "GET",
-    });
+function getAppUI({ systemId, appId, versionId }) {
+    return versionId
+        ? callApi({
+              endpoint: `/api/apps/${systemId}/${appId}/versions/${versionId}/ui`,
+              method: "GET",
+          })
+        : callApi({
+              endpoint: `/api/apps/${systemId}/${appId}/ui`,
+              method: "GET",
+          });
 }
 
 // start of admin end-points
@@ -485,6 +498,7 @@ function adminPublishApp({ appId, systemId }) {
 
 export {
     addApp,
+    addAppVersion,
     copyApp,
     deleteApp,
     getApps,

--- a/src/serviceFacades/apps.js
+++ b/src/serviceFacades/apps.js
@@ -191,9 +191,9 @@ function updateAppLabels({ systemId, appId, versionId, app }) {
     });
 }
 
-function copyApp({ systemId, appId }) {
+function copyApp({ systemId, appId, versionId }) {
     return callApi({
-        endpoint: `/api/apps/${systemId}/${appId}/copy`,
+        endpoint: `/api/apps/${systemId}/${appId}/versions/${versionId}/copy`,
         method: "POST",
     });
 }

--- a/src/serviceFacades/pipelines.js
+++ b/src/serviceFacades/pipelines.js
@@ -29,9 +29,9 @@ function updatePipeline({ appId, versionId, workflow }) {
     });
 }
 
-function copyPipeline({ appId }) {
+function copyPipeline({ appId, versionId }) {
     return callApi({
-        endpoint: `/api/apps/pipelines/${appId}/copy`,
+        endpoint: `/api/apps/pipelines/${appId}/versions/${versionId}/copy`,
         method: "POST",
     });
 }

--- a/src/serviceFacades/pipelines.js
+++ b/src/serviceFacades/pipelines.js
@@ -13,9 +13,17 @@ function addPipeline({ workflow }) {
     });
 }
 
-function updatePipeline({ appId, workflow }) {
+function addPipelineVersion({ appId, workflow }) {
     return callApi({
-        endpoint: `/api/apps/pipelines/${appId}`,
+        endpoint: `/api/apps/pipelines/${appId}/versions`,
+        method: "POST",
+        body: workflow,
+    });
+}
+
+function updatePipeline({ appId, versionId, workflow }) {
+    return callApi({
+        endpoint: `/api/apps/pipelines/${appId}/versions/${versionId}`,
         method: "PUT",
         body: workflow,
     });
@@ -28,15 +36,21 @@ function copyPipeline({ appId }) {
     });
 }
 
-function getPipelineUI({ appId }) {
-    return callApi({
-        endpoint: `/api/apps/pipelines/${appId}/ui`,
-        method: "GET",
-    });
+function getPipelineUI({ appId, versionId }) {
+    return versionId
+        ? callApi({
+              endpoint: `/api/apps/pipelines/${appId}/versions/${versionId}/ui`,
+              method: "GET",
+          })
+        : callApi({
+              endpoint: `/api/apps/pipelines/${appId}/ui`,
+              method: "GET",
+          });
 }
 
 export {
     addPipeline,
+    addPipelineVersion,
     copyPipeline,
     getPipelineUI,
     updatePipeline,

--- a/stories/apps/AppDescriptionMocks.js
+++ b/stories/apps/AppDescriptionMocks.js
@@ -144,6 +144,12 @@ export const AppDescriptionMock = {
     name: "kitchen sink",
     description: "everything but deprecated params",
     edited_date: "2020-06-25T22:43:19.000Z",
+    version: "v2",
+    version_id: "b9e1e332-0d34-11ed-ab8a-62d47aced14b",
+    versions: [
+        { version: "v1", version_id: "8a1e3b3c-0d34-11ed-8b77-62d47aced14b" },
+        { version: "v2", version_id: "b9e1e332-0d34-11ed-ab8a-62d47aced14b" },
+    ],
     groups: [
         {
             id: "177a671a-5a83-11ea-9e38-008cfa5ae621",

--- a/stories/apps/AppMocks.js
+++ b/stories/apps/AppMocks.js
@@ -51,6 +51,8 @@ export const appListing = {
     total: 645,
     apps: [
         {
+            version_id: "8c6f09fc-127a-11ed-9c8c-008cfa5ae621",
+            version: "Unversioned",
             integration_date: "2016-01-22T00:24:54.000Z",
             description: "16sblaster",
             deleted: false,
@@ -76,6 +78,8 @@ export const appListing = {
             rating: { average: 5, total: 1 },
         },
         {
+            version_id: "8c7f2846-127a-11ed-9c8c-008cfa5ae621",
+            version: "Unversioned",
             integration_date: "2013-05-24T21:44:49.000Z",
             description:
                 "This App will add existing reference annotation information to newly assembled transcripts in GFF format.",
@@ -104,6 +108,8 @@ export const appListing = {
             rating: { average: 1, total: 1 },
         },
         {
+            version_id: "8c91535e-127a-11ed-9c8c-008cfa5ae621",
+            version: "Unversioned",
             integration_date: "2018-04-26T18:22:58.000Z",
             description:
                 "Outputs counts at each position of a genome marked in the BAM input file.",
@@ -130,6 +136,8 @@ export const appListing = {
             rating: { average: 0, total: 0 },
         },
         {
+            version_id: "8c897814-127a-11ed-9c8c-008cfa5ae621",
+            version: "Unversioned",
             integration_date: "2014-08-06T14:55:45.000Z",
             description:
                 "This app lets the user blast two sequences without having to run formatdb on the subject sequence.",
@@ -158,6 +166,8 @@ export const appListing = {
             rating: { average: 2.5, total: 2 },
         },
         {
+            version_id: "8c94519e-127a-11ed-9c8c-008cfa5ae621",
+            version: "Unversioned",
             description: "Test tooltip for checkbox",
             deleted: false,
             pipeline_eligibility: { is_valid: true, reason: "" },
@@ -182,6 +192,8 @@ export const appListing = {
             rating: { average: 0, total: 0 },
         },
         {
+            version_id: "7cdbff8e-984f-11e4-bb1d-bb8a86c22997",
+            version: "Unversioned",
             description:
                 "RSEM is an app for counting the number of hits for each gene or transcript in a BAM file from a read to transcript mapping.",
             deleted: false,
@@ -207,6 +219,8 @@ export const appListing = {
             rating: { average: 0, total: 0 },
         },
         {
+            version_id: "8c97ccf2-127a-11ed-9c8c-008cfa5ae621",
+            version: "Unversioned",
             integration_date: "2015-08-04T16:30:16.000Z",
             description: "Counts the number of words in a file",
             deleted: false,
@@ -238,6 +252,8 @@ export const appListing = {
             },
         },
         {
+            version_id: "8c8c566a-127a-11ed-9c8c-008cfa5ae621",
+            version: "Unversioned",
             integration_date: "2020-10-16T20:07:34.000Z",
             description:
                 "NOTE: Don't use unless you're sure! This app is for testing. It may not work as you expect!\n\nThis app will run `wc` on its first argument, if provided, then exit with exit code 1 after printing some stuff to stdout.",
@@ -264,6 +280,8 @@ export const appListing = {
             rating: { average: 0, total: 0 },
         },
         {
+            version_id: "8c9654d0-127a-11ed-9c8c-008cfa5ae621",
+            version: "Unversioned",
             integration_date: "2019-09-12T17:44:37.000Z",
             description:
                 "Launches a Jupyter Lab with ScyPy \n\nMaintained here: https://github.com/cyverse-vice/jupyterlab-scipy ",
@@ -307,6 +325,8 @@ export const appListing = {
             rating: { average: 4, total: 5 },
         },
         {
+            version_id: "8c96822a-127a-11ed-9c8c-008cfa5ae621",
+            version: "Unversioned",
             integration_date: "2019-09-28T04:20:25.000Z",
             description:
                 "PlantCV is an open-source image analysis software package targeted for plant phenotyping. Homepage: https://plantcv.danforthcenter.org/",
@@ -350,6 +370,8 @@ export const appListing = {
             rating: { average: 3.3333333333333335, total: 3 },
         },
         {
+            version_id: "8c83ce46-127a-11ed-9c8c-008cfa5ae621",
+            version: "Unversioned",
             integration_date: "2019-10-18T21:10:53.000Z",
             description:
                 "Jupyter Notebooks for: Ten simple rules for writing and sharing computational analyses in Jupyter Notebooks. Rule A, Birmingham A, Zuniga C, Altintas I, Huang SC, Knight R, Moshiri N, Nguyen MH, Rosenthal SB, Pérez F, Rose PW. PLoS Comput Biol. 2019 Jul 25;15(7):e1007007. doi: 10.1371/journal.pcbi.1007007",
@@ -393,6 +415,8 @@ export const appListing = {
             rating: { average: 5, total: 1 },
         },
         {
+            version_id: "8c894010-127a-11ed-9c8c-008cfa5ae621",
+            version: "Unversioned",
             description: "testing pipelines",
             deleted: false,
             pipeline_eligibility: {
@@ -426,6 +450,8 @@ export const appListing = {
             },
         },
         {
+            version_id: "12940286-05e2-11e7-9fd7-008cfa5ae621",
+            version: "Unversioned",
             description: "Folder testing",
             deleted: false,
             pipeline_eligibility: { is_valid: true, reason: "" },
@@ -450,6 +476,8 @@ export const appListing = {
             rating: { average: 0, total: 0 },
         },
         {
+            version_id: "8c6db2fa-127a-11ed-9c8c-008cfa5ae621",
+            version: "Unversioned",
             integration_date: "2015-12-09T12:04:24.000Z",
             description:
                 "Tuexdo suite of tools to assess levels of differential expression between up to 4 separate conditions. The Tuxedo suite: Tophat2>Cufflinks>Cuffmerge>Cuffdiff>CummRbund. http://www.nature.com/nprot/journal/v7/n3/full/nprot.2012.016.html \nworkflow v1.0\n",
@@ -478,6 +506,8 @@ export const appListing = {
     ],
 };
 export const selectedApp = {
+    version_id: "8c7f2846-127a-11ed-9c8c-008cfa5ae621",
+    version: "Unversioned",
     integration_date: "2013-05-24T21:44:49.000Z",
     description:
         "This App will add existing reference annotation information to newly assembled transcripts in GFF format.",
@@ -514,6 +544,8 @@ export const listingById = {
     total: 1,
     apps: [
         {
+            version_id: "8c7f2846-127a-11ed-9c8c-008cfa5ae621",
+            version: "Unversioned",
             integration_date: "2013-05-24T21:44:49.000Z",
             description:
                 "This App will add existing reference annotation information to newly assembled transcripts in GFF format.",
@@ -555,6 +587,15 @@ export const appDetails = {
     deleted: false,
     integrator_name: "Roger Barthelson",
     disabled: false,
+    version_id: "8c7f2846-127a-11ed-9c8c-008cfa5ae621",
+    version: "Unversioned",
+    versions: [
+        {
+            version: "Unversioned",
+            version_id: "8c7f2846-127a-11ed-9c8c-008cfa5ae621",
+        },
+        { version: "v2", version_id: "b9e1e332-0d34-11ed-ab8a-62d47aced14b" },
+    ],
     suggested_categories: [
         {
             id: "f9f22c5a-09f5-4630-997c-4e3a00ae924b",
@@ -748,6 +789,7 @@ export const appDetails = {
 };
 export const appDocumentation = {
     app_id: "67d15627-22c5-42bd-8daf-9af5deecceab",
+    version_id: "8c97ccf2-127a-11ed-9c8c-008cfa5ae621",
     documentation:
         "### DE Word Count\n> #### Description and Quick Start\n>> To use Word Count, upload your data in plain text format.\n>> Resources: http://www.gnu.org/software/coreutils/manual/coreutils.html#wc-invocation\n> #### Test Data\n>> Community Data > iplantcollaborative > example_data > wordcount\n> #### Input File(s)\n>> Use SampleText.txt  as test data.\n> #### Parameters Used in App\n>> no parameters to selecgt\n> #### Output File(s)\n>> Look under the logs folder. Results are stored in condor-stdout-0.",
     references: ["https://learning.cyverse.org/", "https://cyverse.org/"],

--- a/stories/apps/Editor.stories.js
+++ b/stories/apps/Editor.stories.js
@@ -50,7 +50,13 @@ const initMockAxiosForAppEditor = () => {
         const app = JSON.parse(config.data);
         console.log("Save New App", config.url, app);
 
-        return [200, { ...app, id: "new-uuid" }];
+        const resp = {
+            ...app,
+            id: app.id || "new-uuid",
+            version_id: "new-version-uuid",
+        };
+
+        return [200, resp];
     });
 
     mockAxios.onPut(/\/api\/apps\/.*/).reply((config) => {
@@ -120,6 +126,19 @@ KitchenSinkEditor.argTypes = {
             type: "boolean",
         },
     },
+};
+
+export const KitchenSinkNewVersionEditor = () => {
+    initMockAxiosForAppEditor();
+
+    const { version_id, ...appDescription } = AppDescriptionMock;
+
+    return (
+        <AppEditor
+            baseId={ids.APP_EDITOR_VIEW}
+            appDescription={appDescription}
+        />
+    );
 };
 
 export default { title: "Apps / Editor" };

--- a/stories/apps/Listing.stories.js
+++ b/stories/apps/Listing.stories.js
@@ -30,7 +30,7 @@ function ListingTest(props) {
     mockAxios.onPost(/\/api\/apps\/.*\/copy/).reply((config) => {
         console.log("Copy App", config.url);
         const url = config.url.split("/");
-        return [200, { system_id: url[3], id: url[4] }];
+        return [200, { system_id: url[3], id: url[4], version_id: url[6] }];
     });
 
     mockAxios.onDelete(/\/api\/apps\/.*/).replyOnce(500, errorResponseJSON);
@@ -101,8 +101,6 @@ export const AppsListingTest = () => {
     );
 };
 
-AppsListingTest.story = {
-    parameters: {
-        chromatic: { delay: AXIOS_DELAY * 2 + 500 },
-    },
+AppsListingTest.parameters = {
+    chromatic: { delay: AXIOS_DELAY * 2 + 500 },
 };

--- a/stories/apps/Workflow.stories.js
+++ b/stories/apps/Workflow.stories.js
@@ -131,4 +131,17 @@ export const DeprecatedToolsPipeline = (props) => {
 DeprecatedToolsPipeline.argTypes = { loading };
 DeprecatedToolsPipeline.args = { loading: false };
 
+export const SimplePipelineNewVersion = () => {
+    initAxiosMocks();
+
+    const { version_id, ...appDescription } = workflowDescription;
+
+    return (
+        <WorkflowEditor
+            baseId={ids.WORKFLOW_EDITOR_FORM}
+            appDescription={appDescription}
+        />
+    );
+};
+
 export default { title: "Apps / Workflows" };

--- a/stories/apps/WorkflowMocks.js
+++ b/stories/apps/WorkflowMocks.js
@@ -4,6 +4,8 @@ export const concatTasksMock = {
     description:
         "Joins two or more files together head to tail using latest Dockerized version of cat.",
     system_id: "de",
+    version: "Unversioned",
+    version_id: "77830f32-084a-11e8-a871-008cfa5ae621",
     tasks: [
         {
             system_id: "de",
@@ -74,6 +76,8 @@ export const wordCountTasksMock = {
     name: "DE Word Count",
     description: "Counts the number of words in a file",
     system_id: "de",
+    version: "Unversioned",
+    version_id: "67d15627-22c5-42bd-8daf-9af5deecceab",
     tasks: [
         {
             system_id: "de",
@@ -144,6 +148,12 @@ export const workflowDescription = {
     system_id: "de",
     name: "Simple Pipeline",
     description: "A simple pipeline with 2 steps.",
+    version: "v1",
+    version_id: "8a1e3b3c-0d34-11ed-8b77-62d47aced14b",
+    versions: [
+        { version: "v1", version_id: "8a1e3b3c-0d34-11ed-8b77-62d47aced14b" },
+        { version: "v2", version_id: "b9e1e332-0d34-11ed-ab8a-62d47aced14b" },
+    ],
     steps: [
         {
             name: concatTasksMock.name,
@@ -179,6 +189,8 @@ export const deprecatedWordCountTasksMock = {
     description:
         "Counts and summarizes the number of lines, words, and bytes in a target file",
     system_id: "de",
+    version: "Unversioned",
+    version_id: "c7f05682-23c8-4182-b9a2-e09650a5f49b",
     tasks: [
         {
             system_id: "de",
@@ -268,6 +280,8 @@ export const deprecatedConcatTasksMock = {
     description:
         "Concatenate multiple files. Compatible with Workflows in the DE.",
     system_id: "de",
+    version: "Unversioned",
+    version_id: "af334df2-ad6e-4bf4-b7e8-5686525b63b0",
     tasks: [
         {
             system_id: "de",
@@ -363,6 +377,12 @@ export const deprecatedToolsWorkflowDescription = {
     system_id: "de",
     name: "test deprecated tools pipeline",
     description: "testing deprecated tools",
+    version: "v1",
+    version_id: "8a1e3b3c-0d34-11ed-8b77-62d47aced14b",
+    versions: [
+        { version: "v1", version_id: "8a1e3b3c-0d34-11ed-8b77-62d47aced14b" },
+        { version: "v2", version_id: "b9e1e332-0d34-11ed-ab8a-62d47aced14b" },
+    ],
     steps: [
         {
             name: deprecatedWordCountTasksMock.name,


### PR DESCRIPTION
This PR will add a page for creating new app and workflow versions, and update the app and workflow editors to support creating new versions.

The app edit page also now requires a version ID, and has been renamed to include `versions/[versionId]/` in its path, and the UI will now always use a version ID when updating and copying apps and workflows.

Creating a new app or workflow version will fetch the UI for the latest version, but leave the version label blank in the editor to force the user to enter a new version (which is a required field):
![Create App Version - Info Step](https://user-images.githubusercontent.com/996408/191629319-a301c1fe-f119-44ac-b65e-5dae72cb3251.png)

---

![Create Workflow Version - Info Step](https://user-images.githubusercontent.com/996408/191630242-5868ff6e-62cc-44db-9aec-3591e26961bd.png)

---

The editor will also validate that the version label does not conflict with any other version labels:
![App Editor Version Validation](https://user-images.githubusercontent.com/996408/191629512-340baa3b-8d5b-4042-b057-ac7d9de16777.png)

The editor allows the user to update any fields in a new app version, including changing the tool, or adding and removing any parameters or groups; and in workflows, the user may change app steps and mappings.