### PR TITLE
Hide resource usage when subscriptions not enforced

### DIFF
--- a/src/components/dashboard/dashboardItem/ResourceUsageItem.js
+++ b/src/components/dashboard/dashboardItem/ResourceUsageItem.js
@@ -39,12 +39,17 @@ export default function ResourceUsageItem(props) {
     if (isLoading) {
         return <Skeleton variant="rect" width={800} height={200} />;
     }
+
+    const userPlan = resourceUsageSummary?.user_plan;
     const startDate = formatDateObject(
-        new Date(resourceUsageSummary?.user_plan.effective_start_date)
+        new Date(userPlan?.effective_start_date)
     );
-    const endDate = formatDateObject(
-        new Date(resourceUsageSummary?.user_plan.effective_end_date)
-    );
+    const endDate = formatDateObject(new Date(userPlan?.effective_end_date));
+    const currentPlanName = userPlan?.plan?.name;
+    const dataUsage = resourceUsageSummary?.data_usage;
+    const cpuUsage = resourceUsageSummary?.cpu_usage;
+    const usageSummaryErrors = resourceUsageSummary?.errors;
+
     return (
         <>
             <Typography
@@ -70,72 +75,75 @@ export default function ResourceUsageItem(props) {
             )}
             {!resourceUsageError && (
                 <>
-                    <Grid container spacing={3}>
-                        <Grid item xs={6}>
-                            <Typography>
-                                <Trans
-                                    t={t}
-                                    values={{
-                                        plan: resourceUsageSummary?.user_plan
-                                            ?.plan?.name,
-                                    }}
-                                    i18nKey="currentPlan"
-                                    components={{
-                                        featureMatrixLink: (
-                                            <ExternalLink
-                                                href={FEATURE_MATRIX_URL}
-                                            />
-                                        ),
-                                    }}
-                                />
-                            </Typography>
+                    {resourceUsageSummary && (
+                        <Grid container spacing={3}>
+                            <Grid item xs={6}>
+                                <Typography>
+                                    <Trans
+                                        t={t}
+                                        values={{ plan: currentPlanName }}
+                                        i18nKey="currentPlan"
+                                        components={{
+                                            featureMatrixLink: (
+                                                <ExternalLink
+                                                    href={FEATURE_MATRIX_URL}
+                                                />
+                                            ),
+                                        }}
+                                    />
+                                </Typography>
+                            </Grid>
+                            <Grid item xs={6}>
+                                <Button
+                                    color="primary"
+                                    size="small"
+                                    variant="contained"
+                                    onClick={() =>
+                                        window.open(
+                                            config?.subscriptions?.checkout_url,
+                                            "_blank"
+                                        )
+                                    }
+                                >
+                                    {t("buy")}
+                                </Button>
+                            </Grid>
+                            <Grid item xs={12}>
+                                <Typography>
+                                    {t("effectiveTimePeriod", {
+                                        startDate,
+                                        endDate,
+                                    })}
+                                </Typography>
+                            </Grid>
                         </Grid>
-                        <Grid item xs={6}>
-                            <Button
-                                color="primary"
-                                size="small"
-                                variant="contained"
-                                onClick={() =>
-                                    window.open(
-                                        config?.subscriptions?.checkout_url,
-                                        "_blank"
-                                    )
-                                }
-                            >
-                                {t("buy")}
-                            </Button>
-                        </Grid>
-                        <Grid item xs={12}>
-                            <Typography>
-                                {t("effectiveTimePeriod", {
-                                    startDate,
-                                    endDate,
-                                })}
-                            </Typography>
-                        </Grid>
-                    </Grid>
+                    )}
                     <Grid container spacing={2}>
-                        <Grid item xs={12} md={6}>
-                            <Card>
-                                <DataConsumption
-                                    data={resourceUsageSummary?.data_usage}
-                                    userPlan={resourceUsageSummary?.user_plan}
-                                    isLoading={isLoading}
-                                    errors={resourceUsageSummary?.errors}
-                                />
-                            </Card>
-                        </Grid>
+                        {resourceUsageSummary && (
+                            <Grid item xs={12} md={6}>
+                                <Card>
+                                    <DataConsumption
+                                        data={dataUsage}
+                                        userPlan={userPlan}
+                                        isLoading={isLoading}
+                                        errors={usageSummaryErrors}
+                                    />
+                                </Card>
+                            </Grid>
+                        )}
 
-                        <Grid item xs={12} md={6}>
-                            <Card>
-                                <CPUConsumption
-                                    data={resourceUsageSummary?.cpu_usage}
-                                    userPlan={resourceUsageSummary?.user_plan}
-                                    isLoading={isLoading}
-                                    errors={resourceUsageSummary?.errors}
-                                />
-                            </Card>
-                        </Grid>
+                        {resourceUsageSummary && (
+                            <Grid item xs={12} md={6}>
+                                <Card>
+                                    <CPUConsumption
+                                        data={cpuUsage}
+                                        userPlan={userPlan}
+                                        isLoading={isLoading}
+                                        errors={usageSummaryErrors}
+                                    />
+                                </Card>
+                            </Grid>
+                        )}
                         <Grid item xs={12} md={12}>
                             <Card>
                                 <AnalysesStats />

--- a/stories/dashboard/ResourceUsage.stories.js
+++ b/stories/dashboard/ResourceUsage.stories.js
@@ -6,43 +6,44 @@ export default {
     title: "Dashboard/ResourceUsage",
 };
 
-export const ResourceUsageTest = () => {
-    mockAxios.onGet("/api/resource-usage/summary").reply(200, {
-        cpu_usage: {
-            id: "3ca5f6a3-722f-4135-8ee0-ee20b75bbb40",
-            user_id: "626717be-575e-11ea-8038-008cfa5ae621",
-            username: "sonora_test@iplantcollaborative.org",
-            total: "168.4269529152434",
-            effective_start: "2022-02-03T00:34:41.88739Z",
-            effective_end: "2023-02-03T00:34:41.88739Z",
-            last_modified: "2022-02-03T02:38:17.906799Z",
+const resourceUsageSummary = {
+    cpu_usage: {
+        id: "3ca5f6a3-722f-4135-8ee0-ee20b75bbb40",
+        user_id: "626717be-575e-11ea-8038-008cfa5ae621",
+        username: "sonora_test@iplantcollaborative.org",
+        total: "168.4269529152434",
+        effective_start: "2022-02-03T00:34:41.88739Z",
+        effective_end: "2023-02-03T00:34:41.88739Z",
+        last_modified: "2022-02-03T02:38:17.906799Z",
+    },
+    data_usage: {
+        id: "123456789",
+        user_id: "sriram",
+        username: "sriram@iplantcollaborative.org",
+        total: 161061273600,
+        time: "2021-11-19T16:39:57-07:00",
+        last_modified: "2021-11-19T16:39:57-07:00",
+    },
+    user_plan: {
+        added_by: "",
+        effective_end_date: "",
+        effective_start_date: "2022-02-25T10:45:34.630382-07:00",
+        id: "bbfbd108-9662-11ec-9bd7-62d47aced14b",
+        last_modified_by: "",
+        plan: {
+            description: "Basic plan",
+            id: "99e47c22-950a-11ec-84a4-406c8f3e9cbb",
+            name: "Basic",
         },
-        data_usage: {
-            id: "123456789",
-            user_id: "sriram",
-            username: "sriram@iplantcollaborative.org",
-            total: 161061273600,
-            time: "2021-11-19T16:39:57-07:00",
-            last_modified: "2021-11-19T16:39:57-07:00",
+        quotas: [],
+        users: {
+            id: "bbf25bb4-9662-11ec-9bd7-62d47aced14b",
+            username: "wregglej",
         },
-        user_plan: {
-            added_by: "",
-            effective_end_date: "",
-            effective_start_date: "2022-02-25T10:45:34.630382-07:00",
-            id: "bbfbd108-9662-11ec-9bd7-62d47aced14b",
-            last_modified_by: "",
-            plan: {
-                description: "Basic plan",
-                id: "99e47c22-950a-11ec-84a4-406c8f3e9cbb",
-                name: "Basic",
-            },
-            quotas: [],
-            users: {
-                id: "bbf25bb4-9662-11ec-9bd7-62d47aced14b",
-                username: "wregglej",
-            },
-        },
-    });
+    },
+};
+
+export const ResourceUsageTest = ({ subscriptionsEnforced }) => {
     mockAxios.onGet("/api/analyses/stats").reply(200, {
         "status-count": [
             {
@@ -67,5 +68,23 @@ export const ResourceUsageTest = () => {
             },
         ],
     });
-    return <ResourceUsageItem />;
+
+    return (
+        <ResourceUsageItem
+            resourceUsageSummary={subscriptionsEnforced && resourceUsageSummary}
+        />
+    );
+};
+
+ResourceUsageTest.args = {
+    subscriptionsEnforced: true,
+};
+
+ResourceUsageTest.argTypes = {
+    subscriptionsEnforced: {
+        name: "Subscriptions Enforced",
+        control: {
+            type: "boolean",
+        },
+    },
 };


### PR DESCRIPTION
This PR will hide data and CPU resource usage, plan info, and the buy button when the `subscriptions.enforce` config flag is set to `false`, which disables fetching info from the resource usage summary endpoint; currently resulting in empty or blank info displayed in these components:

![Empty Resource Summaries](https://user-images.githubusercontent.com/996408/194181307-62c75365-d41f-4bfa-abe9-5134e415dd9d.png)

---

This PR will hide these components when this info is empty, except for the Analyses Stats, since those are fetched from a different endpoint:

![Hidden Resource Summaries](https://user-images.githubusercontent.com/996408/194181193-63404345-7430-4992-b393-dd9302acd9d7.png)

Note that this screenshot is in QA, where I have no analyses in the QA db yet.