### PR TITLE
CORE-1801 Add unique Resource Query Keys to launch pages

### DIFF
--- a/src/pages/analyses/[analysisId]/relaunch.js
+++ b/src/pages/analyses/[analysisId]/relaunch.js
@@ -16,16 +16,15 @@ import {
     ANALYSIS_RELAUNCH_QUERY_KEY,
 } from "serviceFacades/analyses";
 
-import {
-    getResourceUsageSummary,
-    RESOURCE_USAGE_QUERY_KEY,
-} from "serviceFacades/dashboard";
+import { getResourceUsageSummary } from "serviceFacades/dashboard";
 import { useConfig } from "contexts/config";
 import { getUserQuota } from "../../../common/resourceUsage";
 import withErrorAnnouncer from "components/error/withErrorAnnouncer";
 
 import AppLaunch from "components/apps/launch";
 import { useUserProfile } from "contexts/userProfile";
+
+import { APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY } from "pages/apps/[systemId]/[appId]/launch";
 
 const Relaunch = ({ showErrorAnnouncer }) => {
     const { t } = useTranslation("dashboard");
@@ -87,7 +86,7 @@ const Relaunch = ({ showErrorAnnouncer }) => {
     });
 
     const { isFetching: fetchingUsageSummary } = useQuery({
-        queryKey: [RESOURCE_USAGE_QUERY_KEY],
+        queryKey: [APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY],
         queryFn: getResourceUsageSummary,
         enabled: !!config?.subscriptions?.enforce,
         onSuccess: (respData) => {

--- a/src/pages/apps/[systemId]/[appId]/launch.js
+++ b/src/pages/apps/[systemId]/[appId]/launch.js
@@ -33,6 +33,9 @@ import { getUserQuota } from "../../../../common/resourceUsage";
 import globalConstants from "../../../../constants";
 import withErrorAnnouncer from "components/error/withErrorAnnouncer";
 
+export const APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY =
+    RESOURCE_USAGE_QUERY_KEY + "AppLaunch";
+
 function Launch({ showErrorAnnouncer }) {
     const { t } = useTranslation("dashboard");
     const [config] = useConfig();
@@ -113,7 +116,7 @@ function Launch({ showErrorAnnouncer }) {
     });
 
     const { isFetching: fetchingUsageSummary } = useQuery({
-        queryKey: [RESOURCE_USAGE_QUERY_KEY],
+        queryKey: [APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY],
         queryFn: getResourceUsageSummary,
         enabled: !!config?.subscriptions?.enforce,
         onSuccess: (respData) => {


### PR DESCRIPTION
This PR will add unique Resource Query Keys to the app launch and analysis relaunch pages, which will prevent the `Browse` button for analysis output or inputs from resetting the form, since the data listing also uses the `RESOURCE_USAGE_QUERY_KEY` to look up data usage, which caused the App Launch page query to also enter a fetching state, which reset the launch form's `loading` prop, causing the entire `AppLaunch` component to re-render.