### PR TITLE
CORE-1533 Add admin app sharing support

### DIFF
--- a/src/components/apps/listing/Listing.js
+++ b/src/components/apps/listing/Listing.js
@@ -101,7 +101,7 @@ function Listing(props) {
         return apps.filter((app) => selected.find((id) => app.id === id));
     }, [data, selected]);
 
-    const shareEnabled = canShare(getSelectedApps());
+    const shareEnabled = canShare(getSelectedApps(), isAdminView);
 
     const [sharingDlgOpen, setSharingDlgOpen] = useState(false);
     const [docDlgOpen, setDocDlgOpen] = useState(false);
@@ -765,6 +765,7 @@ function Listing(props) {
                 open={sharingDlgOpen}
                 onClose={() => setSharingDlgOpen(false)}
                 resources={sharingApps}
+                isAdminView={isAdminView}
             />
             <AppDocDialog
                 baseId={buildID(baseId, ids.DOCUMENTATION)}

--- a/src/components/apps/listing/RowDotMenu.js
+++ b/src/components/apps/listing/RowDotMenu.js
@@ -86,26 +86,23 @@ function RowDotMenu(props) {
                             app={app}
                         />
                     ),
+                    !isAdminView && canEditLabels && (
+                        <EditMenuItem
+                            key={buildID(baseId, ids.EDIT_MENU_ITEM)}
+                            baseId={baseId}
+                            onClose={onClose}
+                            app={app}
+                        />
+                    ),
+                    canShare && (
+                        <SharingMenuItem
+                            key={buildID(baseId, shareIds.SHARING_MENU_ITEM)}
+                            baseId={baseId}
+                            onClose={onClose}
+                            setSharingDlgOpen={setSharingDlgOpen}
+                        />
+                    ),
                     !isAdminView && [
-                        canEditLabels && (
-                            <EditMenuItem
-                                key={buildID(baseId, ids.EDIT_MENU_ITEM)}
-                                baseId={baseId}
-                                onClose={onClose}
-                                app={app}
-                            />
-                        ),
-                        canShare && (
-                            <SharingMenuItem
-                                key={buildID(
-                                    baseId,
-                                    shareIds.SHARING_MENU_ITEM
-                                )}
-                                baseId={baseId}
-                                onClose={onClose}
-                                setSharingDlgOpen={setSharingDlgOpen}
-                            />
-                        ),
                         canPublish && (
                             <PublishMenuItem
                                 key={buildID(baseId, ids.PUBLISH_MENU_ITEM)}

--- a/src/components/apps/utils.js
+++ b/src/components/apps/utils.js
@@ -136,14 +136,6 @@ export const useAppLaunchLink = (systemId, appId) => {
     return [href, as];
 };
 
-export const canShare = (apps) => {
-    return (
-        apps &&
-        apps.length > 0 &&
-        !apps.find((app) => app?.permission !== Permissions.OWN)
-    );
-};
-
 export const hasOwn = (permission) => {
     return Permissions.OWN === permission;
 };
@@ -158,6 +150,16 @@ export const isWritable = (permission) => {
 export const isReadable = (permission) => {
     return (
         permissionHierarchy(permission) >= permissionHierarchy(Permissions.READ)
+    );
+};
+
+export const canShare = (apps, isAdmin) => {
+    return (
+        apps &&
+        apps.length > 0 &&
+        !apps.find((app) =>
+            isAdmin ? !isReadable(app?.permission) : !hasOwn(app?.permission)
+        )
     );
 };
 

--- a/src/components/sharing/index.js
+++ b/src/components/sharing/index.js
@@ -49,6 +49,7 @@ import { useUserProfile } from "contexts/userProfile";
 import { useTranslation } from "i18n";
 import Permissions from "components/models/Permissions";
 import {
+    adminAppSharing,
     doSharingUpdates,
     GET_PERMISSIONS_QUERY_KEY,
     getPermissions,
@@ -61,7 +62,7 @@ import DEErrorDialog from "components/error/DEErrorDialog";
 const useStyles = makeStyles(styles);
 
 function Sharing(props) {
-    const { open, onClose, resources } = props;
+    const { open, onClose, isAdminView, resources } = props;
 
     const [permissions, setPermissions] = useState([]);
     const [originalUsers, setOriginalUsers] = useState({});
@@ -82,7 +83,11 @@ function Sharing(props) {
 
     const { isFetching: fetchPermissions } = useQuery({
         queryKey: [GET_PERMISSIONS_QUERY_KEY, { resources }],
-        queryFn: () => getPermissions({ resources }),
+        queryFn: () =>
+            getPermissions({
+                resources,
+                appParams: { "full-listing": isAdminView },
+            }),
         enabled: open && resources !== null,
         onSuccess: (results) => {
             setPermissions(results);
@@ -162,7 +167,7 @@ function Sharing(props) {
     const onUserSelected = (user, onUserAdded) => {
         const userExist = userMap[user.id];
         const isSelf = user.id === userProfile.id;
-        isSelf
+        isSelf && !isAdminView
             ? setErrorDetails({
                   message: tSharing("cannotAddSelf"),
               })
@@ -196,7 +201,7 @@ function Sharing(props) {
     };
 
     const { mutate: sendSharingUpdates, isLoading: isSaving } = useMutation(
-        doSharingUpdates,
+        isAdminView ? adminAppSharing : doSharingUpdates,
         {
             onSuccess: (results) => {
                 let failures = [];

--- a/src/server/api/sharing.js
+++ b/src/server/api/sharing.js
@@ -69,6 +69,32 @@ export default function sharingRouter() {
         })
     );
 
+    logger.info("adding the POST /admin/apps/sharing handler");
+    api.post(
+        "/admin/apps/sharing",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "POST",
+            pathname: "/admin/apps/sharing",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        })
+    );
+
+    logger.info("adding the POST /admin/apps/unsharing handler");
+    api.post(
+        "/admin/apps/unsharing",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "POST",
+            pathname: "/admin/apps/unsharing",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        })
+    );
+
     logger.info("adding the POST /analyses/sharing handler");
     api.post(
         "/analyses/sharing",

--- a/src/serviceFacades/apps.js
+++ b/src/serviceFacades/apps.js
@@ -276,13 +276,14 @@ function searchAppsInfiniteQuery({
     });
 }
 
-function getAppPermissions({ apps }) {
+function getAppPermissions({ apps, params }) {
     return callApi({
         endpoint: `/api/apps/permission-lister`,
         method: "POST",
         body: {
             apps,
         },
+        params,
     });
 }
 

--- a/src/serviceFacades/sharing.js
+++ b/src/serviceFacades/sharing.js
@@ -63,6 +63,22 @@ export const unshareApps = ({ appUnsharingRequest }) => {
     });
 };
 
+export const adminShareApps = ({ appSharingRequest }) => {
+    return callApi({
+        endpoint: `/api/admin/apps/sharing`,
+        method: "POST",
+        body: appSharingRequest,
+    });
+};
+
+export const adminUnshareApps = ({ appUnsharingRequest }) => {
+    return callApi({
+        endpoint: `/api/admin/apps/unsharing`,
+        method: "POST",
+        body: appUnsharingRequest,
+    });
+};
+
 export const shareAnalyses = ({ analysisSharingRequest }) => {
     return callApi({
         endpoint: `/api/analyses/sharing`,
@@ -151,6 +167,26 @@ export const doSharingUpdates = ({ sharing, unsharing }) => {
     return Promise.all(promises);
 };
 
+export const adminAppSharing = ({ sharing, unsharing }) => {
+    const { apps } = sharing;
+    const { apps: appsUnshare } = unsharing;
+    let promises = [];
+
+    if (apps && apps.length > 0) {
+        promises.push(adminShareApps({ appSharingRequest: { sharing: apps } }));
+    }
+
+    if (appsUnshare && appsUnshare.length > 0) {
+        promises.push(
+            adminUnshareApps({
+                appUnsharingRequest: { unsharing: appsUnshare },
+            })
+        );
+    }
+
+    return Promise.all(promises);
+};
+
 const getPaths = ({ paths }) => {
     return paths ? paths.map((resource) => resource.path) : null;
 };
@@ -174,7 +210,7 @@ const getToolIds = ({ tools }) => {
     return tools ? tools.map((resource) => resource.id) : null;
 };
 
-export const getPermissions = ({ resources }) => {
+export const getPermissions = ({ resources, appParams }) => {
     const paths = getPaths(resources);
     const apps = getAppIds(resources);
     const analyses = getAnalysisIds(resources);
@@ -185,7 +221,7 @@ export const getPermissions = ({ resources }) => {
         permissionPromises.push(getResourcePermissions({ paths }));
     }
     if (apps && apps.length > 0) {
-        permissionPromises.push(getAppPermissions({ apps }));
+        permissionPromises.push(getAppPermissions({ apps, params: appParams }));
     }
     if (analyses && analyses.length > 0) {
         permissionPromises.push(getAnalysisPermissions({ analyses }));

--- a/stories/apps/Listing.stories.js
+++ b/stories/apps/Listing.stories.js
@@ -12,6 +12,16 @@ import {
     appListing,
     categories,
 } from "./AppMocks";
+import {
+    appPermissionListResponse,
+    appShareResponse,
+    appUnshareResponse,
+} from "../sharing/SharingMocks";
+import {
+    collabListMemberResp,
+    userInfoMemberResp,
+    userInfoResp,
+} from "../UserInfoMocks";
 
 import constants from "../../src/constants";
 import appFields from "components/apps/appFields";
@@ -76,6 +86,34 @@ function ListingTest({ isAdminView }) {
         return [200];
     });
     mockAxios.onGet("/api/communities").reply(200, myCollectionList);
+
+    mockAxios.onGet(/\/api\/subjects.*/).reply(200, {
+        subjects: [
+            ...Object.values(userInfoResp),
+            { id: "test_user", email: "test@test.com", name: "Testy Test" },
+        ],
+    });
+    mockAxios
+        .onGet(/\/api\/user-info.*username=alfred.*/)
+        .reply(200, userInfoResp);
+    mockAxios
+        .onPost(/\/api\/apps\/permission-lister/)
+        .reply(200, appPermissionListResponse);
+    mockAxios.onPost(/\/api(\/admin)?\/apps\/sharing/).reply((config) => {
+        console.log("Sharing request", config.url, JSON.parse(config.data));
+        return [200, appShareResponse];
+    });
+    mockAxios.onPost(/\/api(\/admin)?\/apps\/unsharing/).reply((config) => {
+        console.log("Unshare request", config.url, JSON.parse(config.data));
+        return [200, appUnshareResponse];
+    });
+
+    mockAxios
+        .onGet("/api/collaborator-lists/default/members")
+        .reply(200, collabListMemberResp);
+    mockAxios
+        .onGet(/\/api\/user-info.*username=superman.*/)
+        .reply(200, userInfoMemberResp);
 
     const { t } = useTranslation("apps");
     const fields = appFields(t);


### PR DESCRIPTION
This PR will allow admins to open the apps sharing dialog from the admin apps listing, so they may grant any user (including themselves) `write` permissions on apps with the new admin apps (un)sharing endpoints.

This is required in order to create new versions for public apps.