### PR TITLE
CORE-1536 Update App Launch Version Select helper text

### DIFF
--- a/src/components/apps/launch/AppInfo.js
+++ b/src/components/apps/launch/AppInfo.js
@@ -215,6 +215,7 @@ const AppInfo = (props) => {
                         baseId={baseId}
                         version_id={app.deleted ? "" : app.version_id}
                         versions={app.versions}
+                        FormHelperTextProps={{ error: true }}
                         helperText={
                             app.deleted
                                 ? t("otherVersionsAvailable", {


### PR DESCRIPTION
This PR will update the `error` prop on the App Launch's `VersionSelection` help text, so that the other/newer-version-available text is more noticeable.

![Deleted App Version help text](https://user-images.githubusercontent.com/996408/199868322-1e5a9926-fb89-441d-9b46-fde071fe5863.png)

![Newer App Version Available help text](https://user-images.githubusercontent.com/996408/199868626-1a95deea-819c-4d0a-a368-c5e18576443a.png)
