### PR TITLE
CORE-1809 Add app version labels to Admin Instant Launch List

### DIFF
--- a/src/components/instantlaunches/admin/InstantLaunchList.js
+++ b/src/components/instantlaunches/admin/InstantLaunchList.js
@@ -333,6 +333,7 @@ const InstantLaunchList = ({ showErrorAnnouncer }) => {
             {
                 Header: "",
                 accessor: "quick_launch_id",
+                disableSortBy: true,
                 Cell: ({ row }) => {
                     const il = row.original;
 
@@ -391,6 +392,7 @@ const InstantLaunchList = ({ showErrorAnnouncer }) => {
             {
                 Header: "",
                 accessor: "id",
+                disableSortBy: true,
                 Cell: ({ row }) => {
                     const il = row.original;
 

--- a/src/components/instantlaunches/admin/RowDotMenu.js
+++ b/src/components/instantlaunches/admin/RowDotMenu.js
@@ -1,0 +1,91 @@
+import React from "react";
+
+import DotMenu from "components/dotMenu/DotMenu";
+
+import { ListItemIcon, ListItemText, MenuItem } from "@material-ui/core";
+import {
+    Delete as DeleteIcon,
+    Home as HomeIcon,
+    LabelImportant as NestedIcon,
+    MenuOutlined,
+} from "@material-ui/icons";
+
+const RowDotMenu = (props) => {
+    const {
+        baseId,
+        dashboardActionId,
+        dashboardAction,
+        dashboardLabel,
+        navDrawerActionId,
+        navDrawerAction,
+        navDrawerLabel,
+        listingActionId,
+        listingAction,
+        listingLabel,
+        deleteActionId,
+        deleteAction,
+        deleteLabel,
+    } = props;
+
+    return (
+        <DotMenu
+            baseId={baseId}
+            render={(onClose) => [
+                <MenuItem
+                    key={listingActionId}
+                    id={listingActionId}
+                    onClick={() => {
+                        onClose();
+                        listingAction();
+                    }}
+                >
+                    <ListItemIcon>
+                        <NestedIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText primary={listingLabel} />
+                </MenuItem>,
+                <MenuItem
+                    key={dashboardActionId}
+                    id={dashboardActionId}
+                    onClick={() => {
+                        onClose();
+                        dashboardAction();
+                    }}
+                >
+                    <ListItemIcon>
+                        <HomeIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText primary={dashboardLabel} />
+                </MenuItem>,
+                <MenuItem
+                    key={navDrawerActionId}
+                    id={navDrawerActionId}
+                    onClick={() => {
+                        onClose();
+                        navDrawerAction();
+                    }}
+                >
+                    <ListItemIcon>
+                        <MenuOutlined fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText primary={navDrawerLabel} />
+                </MenuItem>,
+                <MenuItem
+                    key={deleteActionId}
+                    id={deleteActionId}
+                    onClick={() => {
+                        onClose();
+                        deleteAction();
+                    }}
+                >
+                    <ListItemIcon>
+                        <DeleteIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText primary={deleteLabel} />
+                </MenuItem>,
+            ]}
+        />
+    );
+};
+
+export default RowDotMenu;

--- a/src/components/table/BasicTable.js
+++ b/src/components/table/BasicTable.js
@@ -63,7 +63,7 @@ function BasicTable(props) {
                                     )}
                                 >
                                     {column.render("Header")}
-                                    {sortable && (
+                                    {sortable && column.canSort && (
                                         <TableSortLabel
                                             active={column.isSorted}
                                             direction={


### PR DESCRIPTION
This PR will add app version labels to the Admin Instant Launch List, which required some refactoring to allow space for the app name and version labels, replacing row action buttons with a `RowDotMenu`, and also to use the `BasicTable` component for consistency with the user instant launch listing.

Icons were also added in an initial column to indicate where instant launches are currently displayed to users.

![Admin Instant Launch List - Row Menu - Add to Nav](https://user-images.githubusercontent.com/996408/204951724-a796d3a0-1643-42c1-9e3a-6b1fea6e959a.png)

![Admin Instant Launch List - Row Menu - Add to all](https://user-images.githubusercontent.com/996408/204951907-91e4d480-edae-4485-898e-554f0257453b.png)
