### PR TITLE
CORE-1882 Fix duration display for cancelled analyses

### DIFF
--- a/src/components/analyses/useAnalysisRunTime.js
+++ b/src/components/analyses/useAnalysisRunTime.js
@@ -63,12 +63,15 @@ function useAnalysisRunTime(
         }
 
         const endDate = analysis?.enddate;
-        if (isComplete && runningStart && endDate) {
+        if (isComplete && runningStart) {
+            const startDate = new Date(runningStart);
+
+            // The analysis end date can be "0" if the user has just cancelled
+            // the analysis, but not refreshed the listing from the service.
             setTotalRunTime(
-                formatDistance(
-                    new Date(runningStart),
-                    new Date(parseInt(endDate))
-                )
+                endDate > 0
+                    ? formatDistance(startDate, new Date(parseInt(endDate)))
+                    : formatDistanceToNow(startDate)
             );
         }
 


### PR DESCRIPTION
This PR fixes the display bug in the Analyses Listing's "Duration" column, where analyses cancelled by the user will show a duration of "about 53 years".