### PR TITLE
Enable data sharing

### DIFF
--- a/public/static/locales/en/sharing.json
+++ b/public/static/locales/en/sharing.json
@@ -1,7 +1,6 @@
 {
     "addRecentContactError": "Failed to update recent contacts",
     "cannotAddSelf": "Cannot add yourself for sharing",
-    "dataGroupSharingDisabled": "Data and/or analyses resources cannot be shared with groups at this time",
     "fetchPermissionsError": "Failed to fetch resource permissions",
     "fetchRecentContactsError": "Failed to fetch recent contacts",
     "fetchUserInfoError": "Failed to fetch user information",

--- a/src/__tests__/sharing.js
+++ b/src/__tests__/sharing.js
@@ -345,7 +345,7 @@ it("tests sharing updates with data change", () => {
                         permission: "own",
                     },
                 ],
-                user: "alfred",
+                subject: { id: "alfred", source_id: "ldap" },
             },
         ],
     };
@@ -354,7 +354,7 @@ it("tests sharing updates with data change", () => {
         paths: [
             {
                 paths: ["/iplant/home/aramsey/CORE-9077-path.list"],
-                user: "alfred",
+                subject: { id: "alfred", source_id: "ldap" },
             },
         ],
     };

--- a/src/components/sharing/index.js
+++ b/src/components/sharing/index.js
@@ -7,8 +7,6 @@
 
 import React, { useEffect, useState } from "react";
 import buildID from "components/utils/DebugIDUtil";
-import { announce } from "components/announcer/CyVerseAnnouncer";
-import { INFO } from "components/announcer/AnnouncerConstants";
 import {
     Button,
     Dialog,
@@ -35,9 +33,7 @@ import {
     getUnsharingUpdates,
     getUserMap,
     getUserSet,
-    isGroup,
 } from "./util";
-import { TYPE } from "./constants";
 import { ADMIN_APPS_QUERY_KEY } from "serviceFacades/apps";
 import { getUserInfo } from "serviceFacades/users";
 import { USER_INFO_QUERY_KEY } from "serviceFacades/filesystem";
@@ -68,7 +64,6 @@ function Sharing(props) {
     const [permissions, setPermissions] = useState([]);
     const [originalUsers, setOriginalUsers] = useState({});
     const [userIdList, setUserIdList] = useState([]);
-    const [hasData, setHasData] = useState(false);
     const [userMap, setUserMap] = useState({});
     const [resourceTotal, setResourceTotal] = useState(0);
     const [errorDialogOpen, setErrorDialogOpen] = useState(false);
@@ -123,11 +118,6 @@ function Sharing(props) {
 
     useEffect(() => {
         if (resources) {
-            const data = resources[TYPE.DATA];
-            const analyses = resources[TYPE.ANALYSES];
-            setHasData(
-                (data && data.length > 0) || (analyses && analyses.length > 0)
-            );
             setResourceTotal(getResourceTotal(resources));
         }
     }, [resources]);
@@ -145,16 +135,6 @@ function Sharing(props) {
     const onPermissionChange = (user, permission) => {
         setErrorDetails(null);
         const userId = user.id;
-
-        // Cannot update permissions for groups if data (which also means
-        // analyses) are included
-        if (isGroup(user) && hasData) {
-            announce({
-                text: tSharing("dataGroupSharingDisabled"),
-                variant: INFO,
-            });
-            return;
-        }
 
         // Add any missing resources to the users resources list
         const updatedUser = addMissingResourcesToUser(user, resources);
@@ -176,10 +156,6 @@ function Sharing(props) {
             : userExist
             ? setErrorDetails({
                   message: tSharing("userAlreadyAdded"),
-              })
-            : isGroup(user) && hasData
-            ? setErrorDetails({
-                  message: tSharing("dataGroupSharingDisabled"),
               })
             : addUser(user, onUserAdded);
     };

--- a/src/components/sharing/index.js
+++ b/src/components/sharing/index.js
@@ -196,7 +196,17 @@ function Sharing(props) {
                         }
                     });
                 });
-                if (failures.length > 0) {
+                if (failures.length === 1) {
+                    const { error_code: code, ...rest } = failures[0].error;
+                    setErrorDetails({
+                        message: tSharing("sharingUnsuccessful"),
+                        error: {
+                            response: {
+                                data: { error_code: code, reason: rest },
+                            },
+                        },
+                    });
+                } else if (failures.length > 0) {
                     setErrorDetails({
                         message: tSharing("sharingUnsuccessful"),
                         error: failures,

--- a/src/components/sharing/util.js
+++ b/src/components/sharing/util.js
@@ -94,7 +94,8 @@ export const getSharingFns = (type) => {
             return {
                 getId: (sharing) => sharing.path,
                 getPermList: (sharing) => sharing["user-permissions"],
-                getUserId: (permission) => permission.user,
+                getUserId: (permission) =>
+                    irodsNameToSubject(permission.user).id,
                 formatSubject: (user) => {
                     let subject = {
                         source_id: "ldap",

--- a/src/components/sharing/util.js
+++ b/src/components/sharing/util.js
@@ -71,6 +71,17 @@ const allResourceTypes = [TYPE.DATA, TYPE.APPS, TYPE.ANALYSES, TYPE.TOOLS];
  */
 const getResponseType = (resp) => Object.keys(resp)[0];
 
+const irodsGrouperPrefix = "@grouper-";
+const irodsNameToSubject = (username) => {
+    let source_id = "ldap";
+    let user_id = username;
+    if (username.startsWith(irodsGrouperPrefix)) {
+        source_id = "g:gsa";
+        user_id = username.slice(irodsGrouperPrefix.length);
+    }
+    return { source_id: source_id, id: user_id };
+};
+
 /**
  * Helper functions for retrieving information across the different types of
  * permission-lister responses.
@@ -85,8 +96,17 @@ export const getSharingFns = (type) => {
                 getPermList: (sharing) => sharing["user-permissions"],
                 getUserId: (permission) => permission.user,
                 formatSubject: (user) => {
+                    let subject = {
+                        source_id: "ldap",
+                        id: user.id,
+                    };
+                    if (user.source_id) {
+                        subject.source_id = user.source_id;
+                    } else {
+                        subject = irodsNameToSubject(user.id);
+                    }
                     return {
-                        user: user.id,
+                        subject: subject,
                     };
                 },
                 formatSharing: (resource) => {

--- a/src/components/sharing/util.js
+++ b/src/components/sharing/util.js
@@ -106,7 +106,7 @@ export const getSharingFns = (type) => {
                         subject = irodsNameToSubject(user.id);
                     }
                     return {
-                        subject: subject,
+                        subject,
                     };
                 },
                 formatSharing: (resource) => {


### PR DESCRIPTION
This is not done but I wanted to get the start of it up.

Outstanding stuff:

- [x] Show groups properly in the sharing dialog (rather than showing '@grouper-....')
- [ ] Show group name properly in the popup that happens when sharing/unsharing (rather than '@grouper-')
- [ ] More gracefully handle the "group hasn't been propagated to irods yet" case somehow