### PR TITLE
CORE-1893 Update data nav to use paths from data info service

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -45,7 +45,7 @@ analysis:
 
 irods:
     home_path: /iplant/home
-    trash_path: /iplant/trash/home/de-irods
+    trash_path: /iplant/trash/home
     community_path: /iplant/home/shared
     web_dav:
         anon_uri: https://data.cyverse.org/dav-anon  

--- a/src/components/data/listing/TableView.js
+++ b/src/components/data/listing/TableView.js
@@ -19,8 +19,7 @@ import { getLocalStorage, setLocalStorage } from "../../utils/localStorage";
 import WrappedErrorHandler from "../../error/WrappedErrorHandler";
 import { DERow } from "components/table/DERow";
 import DETableHead from "components/table/DETableHead";
-import { isPathInTrash, formatFileSize } from "../utils";
-import { useConfig } from "contexts/config";
+import { isPathInTrash, formatFileSize, useBaseTrashPath } from "../utils";
 
 import buildID from "components/utils/DebugIDUtil";
 import DECheckbox from "components/utils/DECheckbox";
@@ -158,7 +157,7 @@ function TableView(props) {
     const { t } = useTranslation("data");
     const dataRecordFields = dataFields(t);
     const tableId = buildID(baseId, ids.LISTING_TABLE);
-    const [config] = useConfig();
+    const trashPath = useBaseTrashPath();
 
     const [displayColumns, setDisplayColumns] = useState(
         getLocalStorageCols(rowDotMenuVisibility, dataRecordFields) ||
@@ -170,7 +169,7 @@ function TableView(props) {
         setDisplayColumns(columns);
     };
 
-    const inTrash = isPathInTrash(path, config?.irods?.trash_path);
+    const inTrash = isPathInTrash(path, trashPath);
 
     const optionalColumns = () => {
         return [

--- a/src/components/data/toolbar/Toolbar.js
+++ b/src/components/data/toolbar/Toolbar.js
@@ -14,12 +14,10 @@ import DataDotMenu from "./DataDotMenu";
 import UploadMenuBtn from "./UploadMenuBtn";
 import Navigation from "./Navigation";
 
-import { useConfig } from "contexts/config";
-
 import ids from "../ids";
 import styles from "../styles";
 import CreateFolderDialog from "../CreateFolderDialog";
-import { isOwner, isWritable, isPathInTrash } from "../utils";
+import { isOwner, isWritable, isPathInTrash, useBaseTrashPath } from "../utils";
 import SharingButton from "components/sharing/SharingButton";
 
 import buildID from "components/utils/DebugIDUtil";
@@ -80,7 +78,7 @@ function DataToolbar(props) {
     } = props;
 
     const { t } = useTranslation("data");
-    const [config] = useConfig();
+    const baseTrashPath = useBaseTrashPath();
     const [createFolderDlgOpen, setCreateFolderDlgOpen] = useState(false);
     const onCreateFolderDlgClose = () => setCreateFolderDlgOpen(false);
     const onCreateFolderClicked = () => setCreateFolderDlgOpen(true);
@@ -91,7 +89,7 @@ function DataToolbar(props) {
     const theme = useTheme();
     const isSmall = useMediaQuery(theme.breakpoints.down("sm"));
 
-    const inTrash = isPathInTrash(path, config?.irods?.trash_path);
+    const inTrash = isPathInTrash(path, baseTrashPath);
     const uploadEnabled = !inTrash && isWritable(permission);
     const sharingEnabled = !inTrash && canShare;
     const bagEnabled = !inTrash && selected && selected.length > 0;

--- a/src/components/data/utils.js
+++ b/src/components/data/utils.js
@@ -144,19 +144,34 @@ const containsFolders = (resources) => {
     return false;
 };
 
-const useHomePath = () => {
-    const [config] = useConfig();
-    const [userProfile] = useUserProfile();
+const useBaseHomePath = () => {
     const [bootstrapInfo] = useBootstrapInfo();
+    const [config] = useConfig();
+
+    const userHomeFromDataInfo = bootstrapInfo?.data_info?.user_home_path;
+    if (userHomeFromDataInfo) {
+        return userHomeFromDataInfo.split("/").slice(0, -1).join("/");
+    }
+
+    const irodsHomePath = config?.irods?.home_path;
+    if (irodsHomePath) {
+        return irodsHomePath;
+    }
+
+    return "";
+};
+
+const useUserHomePath = () => {
+    const [bootstrapInfo] = useBootstrapInfo();
+    const [userProfile] = useUserProfile();
+    const irodsHomePath = useBaseHomePath();
 
     const userHomeFromDataInfo = bootstrapInfo?.data_info?.user_home_path;
     if (userHomeFromDataInfo) {
         return userHomeFromDataInfo;
     }
 
-    const irodsHomePath = config?.irods?.home_path;
     const username = userProfile?.id;
-
     if (irodsHomePath && username) {
         return `${irodsHomePath}/${username}`;
     }
@@ -164,8 +179,43 @@ const useHomePath = () => {
     return "";
 };
 
+const useBaseTrashPath = () => {
+    const [bootstrapInfo] = useBootstrapInfo();
+    const [config] = useConfig();
+
+    const baseTrashFromDataInfo = bootstrapInfo?.data_info?.base_trash_path;
+    if (baseTrashFromDataInfo) {
+        return baseTrashFromDataInfo;
+    }
+
+    const irodsTrashPath = config?.irods?.trash_path;
+    if (irodsTrashPath) {
+        return irodsTrashPath;
+    }
+
+    return "";
+};
+
+const useTrashPath = () => {
+    const [bootstrapInfo] = useBootstrapInfo();
+    const [userProfile] = useUserProfile();
+    const irodsTrashPath = useBaseTrashPath();
+
+    const userTrashFromDataInfo = bootstrapInfo?.data_info?.user_trash_path;
+    if (userTrashFromDataInfo) {
+        return userTrashFromDataInfo;
+    }
+
+    const username = userProfile?.id;
+    if (irodsTrashPath && username) {
+        return `${irodsTrashPath}/${username}`;
+    }
+
+    return "";
+};
+
 const useSelectorDefaultFolderPath = () => {
-    const homePath = useHomePath();
+    const homePath = useUserHomePath();
     const [bootstrapInfo] = useBootstrapInfo();
 
     const preferences = bootstrapInfo?.preferences;
@@ -176,7 +226,7 @@ const useSelectorDefaultFolderPath = () => {
 };
 
 const useDefaultOutputDir = () => {
-    const homePath = useHomePath();
+    const homePath = useUserHomePath();
     const [bootstrapInfo] = useBootstrapInfo();
     const preferences = bootstrapInfo?.preferences;
 
@@ -215,7 +265,10 @@ export {
     parseNameFromPath,
     getParentPath,
     useDataNavigationLink,
-    useHomePath,
+    useBaseHomePath,
+    useUserHomePath,
+    useBaseTrashPath,
+    useTrashPath,
     useSelectorDefaultFolderPath,
     useDefaultOutputDir,
     containsFolders,


### PR DESCRIPTION
Updated `components/data/toolbar/Navigation` to use the trash and home paths returned by the data info service, rather than relying solely on config values.

Added some hook functions to `components/data/utils` to assist with looking up the home and trash paths, but falling back to config values if the `bootstrap` or `roots` endpoints have not yet populated these paths (for logged out users, for example).