### PR TITLE
Core 1919 highlight running analyses

### DIFF
--- a/src/components/analyses/listing/TableView.js
+++ b/src/components/analyses/listing/TableView.js
@@ -46,6 +46,23 @@ const useStyles = makeStyles((theme) => ({
         maxWidth: "12rem",
         overflowWrap: "break-word",
     },
+    backdrop: {
+        backgroundColor: theme.palette.leaf,
+        animation: "$strobe 3.5s infinite",
+    },
+    "@keyframes strobe": {
+        "0%": { backgroundColor: "rgba(55, 143, 67, 0.25)" },
+        "10%": { backgroundColor: "rgba(55, 143, 67, 0.23)" },
+        "20%": { backgroundColor: "rgba(55, 143, 67, 0.2)" },
+        "30%": { backgroundColor: "rgba(55, 143, 67, 0.15)" },
+        "40%": { backgroundColor: "rgba(55, 143, 67, 0.1)" },
+        "50%": { backgroundColor: "rgba(55, 143, 67, 0.07)" },
+        "60%": { backgroundColor: "rgba(55, 143, 67, 0.1)" },
+        "70%": { backgroundColor: "rgba(55, 143, 67, 0.15)" },
+        "80%": { backgroundColor: "rgba(55, 143, 67, 0.2)" },
+        "90%": { backgroundColor: "rgba(55, 143, 67, 0.23)" },
+        "100%": { backgroundColor: "rgba(55, 143, 67, .25)" },
+    },
 }));
 
 function AnalysisName(props) {
@@ -235,6 +252,12 @@ function TableView(props) {
                                     <DERow
                                         onClick={(event) =>
                                             handleClick(event, id, index)
+                                        }
+                                        className={
+                                            !isSelected &&
+                                            analysis.status ===
+                                                analysisStatus.RUNNING &&
+                                            classes.backdrop
                                         }
                                         role="checkbox"
                                         aria-checked={isSelected}

--- a/src/components/analyses/listing/TableView.js
+++ b/src/components/analyses/listing/TableView.js
@@ -41,29 +41,16 @@ import {
     useTheme,
 } from "@material-ui/core";
 
+import styles from "components/utils/runningAnimation";
+
 const useStyles = makeStyles((theme) => ({
     name: {
         maxWidth: "12rem",
         overflowWrap: "break-word",
     },
-    backdrop: {
-        backgroundColor: theme.palette.leaf,
-        animation: "$strobe 3.5s infinite",
-    },
-    "@keyframes strobe": {
-        "0%": { backgroundColor: "rgba(55, 143, 67, 0.25)" },
-        "10%": { backgroundColor: "rgba(55, 143, 67, 0.23)" },
-        "20%": { backgroundColor: "rgba(55, 143, 67, 0.2)" },
-        "30%": { backgroundColor: "rgba(55, 143, 67, 0.15)" },
-        "40%": { backgroundColor: "rgba(55, 143, 67, 0.1)" },
-        "50%": { backgroundColor: "rgba(55, 143, 67, 0.07)" },
-        "60%": { backgroundColor: "rgba(55, 143, 67, 0.1)" },
-        "70%": { backgroundColor: "rgba(55, 143, 67, 0.15)" },
-        "80%": { backgroundColor: "rgba(55, 143, 67, 0.2)" },
-        "90%": { backgroundColor: "rgba(55, 143, 67, 0.23)" },
-        "100%": { backgroundColor: "rgba(55, 143, 67, .25)" },
-    },
 }));
+
+const useRunningAnalysesStyles = makeStyles(styles);
 
 function AnalysisName(props) {
     const analysis = props.analysis;
@@ -191,6 +178,7 @@ function TableView(props) {
 
     const theme = useTheme();
     const classes = useStyles();
+    const running = useRunningAnalysesStyles();
     const { t } = useTranslation("analyses");
 
     const isSmall = useMediaQuery(theme.breakpoints.down("sm"));
@@ -257,7 +245,7 @@ function TableView(props) {
                                             !isSelected &&
                                             analysis.status ===
                                                 analysisStatus.RUNNING &&
-                                            classes.backdrop
+                                            running.backdrop
                                         }
                                         role="checkbox"
                                         aria-checked={isSelected}

--- a/src/components/dashboard/dashboardItem/ItemBase.js
+++ b/src/components/dashboard/dashboardItem/ItemBase.js
@@ -5,6 +5,7 @@ import { useTranslation } from "i18n";
 
 import AnalysisSubheader from "./AnalysisSubheader";
 import buildID from "components/utils/DebugIDUtil";
+import analysisStatus from "components/models/analysisStatus";
 
 import {
     Avatar,
@@ -75,6 +76,9 @@ const DashboardItem = ({ item }) => {
     const description = fns.cleanDescription(item.content.description);
     const [origination, date] = item.getOrigination(t);
 
+    const isRunningAnalysis =
+        item.kind === "analyses" &&
+        item.content.status === analysisStatus.RUNNING;
     return (
         <Card
             classes={{ root: classes.dashboardCard }}
@@ -82,6 +86,7 @@ const DashboardItem = ({ item }) => {
             elevation={4}
         >
             <CardHeader
+                className={isRunningAnalysis && classes.backdrop}
                 avatar={
                     isMediumOrLarger && (
                         <Avatar className={classes.avatar}>

--- a/src/components/dashboard/dashboardItem/ItemBase.js
+++ b/src/components/dashboard/dashboardItem/ItemBase.js
@@ -13,11 +13,14 @@ import {
     CardContent,
     CardHeader,
     Link,
+    makeStyles,
     Tooltip,
     Typography,
     useMediaQuery,
     useTheme,
 } from "@material-ui/core";
+
+import styles from "components/utils/runningAnimation";
 
 import ids from "../ids";
 import * as constants from "../constants";
@@ -27,6 +30,8 @@ import useStyles from "./styles";
 import { useConfig } from "contexts/config";
 
 import { getUserName } from "../../utils/getUserName";
+
+const useRunningAnalysesStyles = makeStyles(styles);
 
 const DashboardLink = ({ target, kind, children }) => {
     const isNewTab =
@@ -65,6 +70,7 @@ const DashboardItem = ({ item }) => {
         height: item.height,
         color,
     });
+    const running = useRunningAnalysesStyles();
 
     const { t } = useTranslation(["dashboard", "apps"]);
 
@@ -86,7 +92,7 @@ const DashboardItem = ({ item }) => {
             elevation={4}
         >
             <CardHeader
-                className={isRunningAnalysis && classes.backdrop}
+                className={isRunningAnalysis && running.backdrop}
                 avatar={
                     isMediumOrLarger && (
                         <Avatar className={classes.avatar}>

--- a/src/components/dashboard/dashboardItem/styles.js
+++ b/src/components/dashboard/dashboardItem/styles.js
@@ -76,21 +76,4 @@ export default makeStyles((theme) => ({
         marginTop: theme.spacing(2),
         marginBottom: theme.spacing(2),
     },
-    backdrop: {
-        backgroundColor: theme.palette.leaf,
-        animation: "$strobe 3.5s infinite",
-    },
-    "@keyframes strobe": {
-        "0%": { backgroundColor: "rgba(55, 143, 67, 0.25)" },
-        "10%": { backgroundColor: "rgba(55, 143, 67, 0.23)" },
-        "20%": { backgroundColor: "rgba(55, 143, 67, 0.2)" },
-        "30%": { backgroundColor: "rgba(55, 143, 67, 0.15)" },
-        "40%": { backgroundColor: "rgba(55, 143, 67, 0.1)" },
-        "50%": { backgroundColor: "rgba(55, 143, 67, 0.07)" },
-        "60%": { backgroundColor: "rgba(55, 143, 67, 0.1)" },
-        "70%": { backgroundColor: "rgba(55, 143, 67, 0.15)" },
-        "80%": { backgroundColor: "rgba(55, 143, 67, 0.2)" },
-        "90%": { backgroundColor: "rgba(55, 143, 67, 0.23)" },
-        "100%": { backgroundColor: "rgba(55, 143, 67, .25)" },
-    },
 }));

--- a/src/components/dashboard/dashboardItem/styles.js
+++ b/src/components/dashboard/dashboardItem/styles.js
@@ -76,4 +76,21 @@ export default makeStyles((theme) => ({
         marginTop: theme.spacing(2),
         marginBottom: theme.spacing(2),
     },
+    backdrop: {
+        backgroundColor: theme.palette.leaf,
+        animation: "$strobe 3.5s infinite",
+    },
+    "@keyframes strobe": {
+        "0%": { backgroundColor: "rgba(55, 143, 67, 0.25)" },
+        "10%": { backgroundColor: "rgba(55, 143, 67, 0.23)" },
+        "20%": { backgroundColor: "rgba(55, 143, 67, 0.2)" },
+        "30%": { backgroundColor: "rgba(55, 143, 67, 0.15)" },
+        "40%": { backgroundColor: "rgba(55, 143, 67, 0.1)" },
+        "50%": { backgroundColor: "rgba(55, 143, 67, 0.07)" },
+        "60%": { backgroundColor: "rgba(55, 143, 67, 0.1)" },
+        "70%": { backgroundColor: "rgba(55, 143, 67, 0.15)" },
+        "80%": { backgroundColor: "rgba(55, 143, 67, 0.2)" },
+        "90%": { backgroundColor: "rgba(55, 143, 67, 0.23)" },
+        "100%": { backgroundColor: "rgba(55, 143, 67, .25)" },
+    },
 }));

--- a/src/components/utils/runningAnimation.js
+++ b/src/components/utils/runningAnimation.js
@@ -1,0 +1,28 @@
+/**
+ * A light-green and strobing backdrop that indicates a running analysis.
+ *
+ * @author sboleyn
+ *
+ */
+
+const styles = (theme) => ({
+    backdrop: {
+        backgroundColor: theme.palette.leaf,
+        animation: "$strobe 3.5s infinite",
+    },
+    "@keyframes strobe": {
+        "0%": { backgroundColor: "rgba(55, 143, 67, 0.25)" },
+        "10%": { backgroundColor: "rgba(55, 143, 67, 0.23)" },
+        "20%": { backgroundColor: "rgba(55, 143, 67, 0.2)" },
+        "30%": { backgroundColor: "rgba(55, 143, 67, 0.15)" },
+        "40%": { backgroundColor: "rgba(55, 143, 67, 0.1)" },
+        "50%": { backgroundColor: "rgba(55, 143, 67, 0.07)" },
+        "60%": { backgroundColor: "rgba(55, 143, 67, 0.1)" },
+        "70%": { backgroundColor: "rgba(55, 143, 67, 0.15)" },
+        "80%": { backgroundColor: "rgba(55, 143, 67, 0.2)" },
+        "90%": { backgroundColor: "rgba(55, 143, 67, 0.23)" },
+        "100%": { backgroundColor: "rgba(55, 143, 67, .25)" },
+    },
+});
+
+export default styles;


### PR DESCRIPTION
Add a light-green and strobing background for running analyses in the analyses listing and in recent analyses on the dashboard. This strobe uses the CyVerse palette and leaf color. 

https://github.com/cyverse-de/sonora/assets/12879073/4307cc9c-658a-495d-b2d8-bf6ada71efc8


https://github.com/cyverse-de/sonora/assets/12879073/bdd82e7d-34b7-4d50-b4b3-88341a61123d


https://github.com/cyverse-de/sonora/assets/12879073/fe4f0fae-6044-4bd9-aae5-b2001fd2de3e


https://github.com/cyverse-de/sonora/assets/12879073/44db0b1f-dd3e-4ce5-beae-161f5c8b9727
