### PR TITLE
CORE-1913 Add running count to Analyses nav icon

### DIFF
--- a/src/components/dashboard/dashboardItem/AnalysesStats.js
+++ b/src/components/dashboard/dashboardItem/AnalysesStats.js
@@ -156,9 +156,11 @@ const getFormattedData = (data, theme) => {
 export default function AnalysesStats() {
     const { t } = useTranslation("dashboard");
     const theme = useTheme();
-    const { status, data, error } = useQuery([ANALYSES_STATS_QUERY_KEY], () =>
-        getAnalysesStats()
+    const { status, data, error } = useQuery(
+        [ANALYSES_STATS_QUERY_KEY],
+        getAnalysesStats
     );
+
     if (status === "error") {
         return (
             <div style={{ padding: theme.spacing(1) }}>

--- a/src/components/layout/DrawerItems.js
+++ b/src/components/layout/DrawerItems.js
@@ -10,11 +10,12 @@ import { useTranslation } from "i18n";
 import DrawerItem from "./DrawerItem";
 import ids from "./ids";
 import NavigationConstants from "common/NavigationConstants";
+import analysisStatus from "components/models/analysisStatus";
 import AnalysesIcon from "components/icons/AnalysesIcon";
 import DataIcon from "components/icons/DataIcon";
 import { TeamIcon } from "components/teams/Icons";
 import AdminDrawerItems from "./AdminDrawerItems";
-import { Divider, Hidden, List } from "@material-ui/core";
+import { Badge, Divider, Hidden, List } from "@material-ui/core";
 import { useUserProfile } from "contexts/userProfile";
 import AppsIcon from "@material-ui/icons/Apps";
 import HelpIcon from "@material-ui/icons/Help";
@@ -37,6 +38,22 @@ function InstantLaunchIcon(props) {
     return <InstantLaunchDefaultIcon {...props} />;
 }
 
+function WrappedAnalysesIcon(analysesStats) {
+    const runningStats =
+        analysesStats &&
+        analysesStats["status-count"].find(
+            (stat) => stat.status === analysisStatus.RUNNING
+        );
+
+    return runningStats?.count > 0
+        ? (props) => (
+              <Badge badgeContent={runningStats.count} color="error">
+                  <AnalysesIcon {...props} />
+              </Badge>
+          )
+        : AnalysesIcon;
+}
+
 function DrawerItems(props) {
     const {
         open,
@@ -44,6 +61,7 @@ function DrawerItems(props) {
         toggleDrawer,
         isXsDown,
         adminUser,
+        analysesStats,
         runningViceJobs,
         instantLaunches,
         computeLimitExceeded,
@@ -110,7 +128,7 @@ function DrawerItems(props) {
             <DrawerItem
                 title={t("analyses")}
                 id={ids.ANALYSES_MI}
-                icon={AnalysesIcon}
+                icon={WrappedAnalysesIcon(analysesStats)}
                 thisView={NavigationConstants.ANALYSES}
                 clsxBase={"analyses-intro"}
                 activeView={activeView}

--- a/src/components/notifications/utils.js
+++ b/src/components/notifications/utils.js
@@ -25,11 +25,16 @@ export function getDisplayMessage(notification) {
     }
 }
 
-export function isViceNotification(notification) {
-    const message = notification?.message;
-
+export function isAnalysisNotification(notification) {
     return (
-        NotificationCategory.ANALYSIS.toLowerCase() === message?.type &&
-        message?.payload?.interactive_urls?.length > 0
+        NotificationCategory.ANALYSIS.toLowerCase() ===
+        notification?.message?.type
+    );
+}
+
+export function isViceNotification(notification) {
+    return (
+        isAnalysisNotification(notification) &&
+        notification.message.payload?.interactive_urls?.length > 0
     );
 }

--- a/stories/AppBar.stories.js
+++ b/stories/AppBar.stories.js
@@ -154,6 +154,30 @@ const appBarTestTemplate = (args) => {
     mockAxios
         .onGet(/\/api\/resource-usage\/summary.*/)
         .reply(200, mockUsageSummary);
+    mockAxios.onGet("/api/analyses/stats").reply(200, {
+        "status-count": [
+            {
+                count: 32,
+                status: "Canceled",
+            },
+            {
+                count: 703,
+                status: "Completed",
+            },
+            {
+                count: 296,
+                status: "Failed",
+            },
+            {
+                count: 150,
+                status: "Submitted",
+            },
+            {
+                count: 2,
+                status: "Running",
+            },
+        ],
+    });
 
     return (
         <UserProfileProvider>

--- a/stories/AppBar.stories.js
+++ b/stories/AppBar.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { UserProfileProvider } from "../src/contexts/userProfile";
 import DEAppBar from "../src/components/layout/AppBar";
-import { AXIOS_DELAY, mockAxios } from "./axiosMock";
+import { mockAxios } from "./axiosMock";
 import { NotificationsProvider } from "../src/contexts/pushNotifications";
 import notificationsData from "./notifications/notificationsData";
 import testConfig from "./configMock";
@@ -198,7 +198,6 @@ NormalView.args = {
     mockInstantLaunches: instantLaunchNavDrawerMock,
     mockUsageSummary: usageSummaryResponse,
 };
-NormalView.parameters = { chromatic: { delay: AXIOS_DELAY * 2 } };
 
 export const ComputeLimitExceeded = appBarTestTemplate.bind({});
 ComputeLimitExceeded.args = {
@@ -210,9 +209,12 @@ ComputeLimitExceeded.args = {
     mockInstantLaunches: instantLaunchNavDrawerMock,
     mockUsageSummary: usageSummaryComputeLimitExceededResponse,
 };
-ComputeLimitExceeded.parameters = { chromatic: { delay: AXIOS_DELAY * 2 } };
 
 export default {
     title: "AppBar",
     component: DEAppBar,
+    parameters: {
+        // This is the max delay allowed.
+        chromatic: { delay: 15000 },
+    },
 };

--- a/stories/UserPortalProfile.stories.js
+++ b/stories/UserPortalProfile.stories.js
@@ -5,7 +5,12 @@ import DEAppBar from "../src/components/layout/AppBar";
 import { UserProfileProvider } from "../src/contexts/userProfile";
 import testConfig from "./configMock";
 
-export default { title: "User Portal Status" };
+export default {
+    title: "User Portal Status",
+    parameters: {
+        chromatic: { delay: AXIOS_DELAY * 2 },
+    },
+};
 
 const mockUser = {
     id: "mockUser",
@@ -30,7 +35,6 @@ export function GracePeriod() {
         </UserProfileProvider>
     );
 }
-GracePeriod.parameters = { chromatic: { delay: AXIOS_DELAY * 2 } };
 
 export function Expired() {
     mockAxios.onGet("/api/profile").reply(200, mockUser);
@@ -43,4 +47,3 @@ export function Expired() {
         </UserProfileProvider>
     );
 }
-Expired.parameters = { chromatic: { delay: AXIOS_DELAY * 2 } };


### PR DESCRIPTION
This PR will add a running analyses count to the Analyses nav icon in the App Bar's Drawer items.

It also updates the AppBar to use the analyses stats query, which becomes invalidated when notifications arrive for running, canceled, or completed analyses, so that the running analyses count automatically updates based on these notifications.

![Dashboard - 1 Running Analysis](https://github.com/cyverse-de/sonora/assets/996408/a062c7e9-defd-4a1d-9f7e-601bf0c10c79)

![Analyses Listing - 2 Running Analyses](https://github.com/cyverse-de/sonora/assets/996408/84f4f678-2e45-4758-bc8b-b94c48c2eaa9)

---

With the App Bar Drawer expanded to display the icon labels:
![App Bar Drawer expanded](https://github.com/cyverse-de/sonora/assets/996408/f9ec30dd-ebfb-4e5e-92f6-c76e016b003b)

