### PR TITLE
CORE-1939 Add usage percentage to Data nav icon

### DIFF
--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -20,6 +20,7 @@
     "create": "Create",
     "cyverse": "CyVerse",
     "data": "Data",
+    "dataNavUsageTitle": "{{percentage}}% usage",
     "description": "Description",
     "deTitle": "Discovery Environment",
     "delete": "Delete",

--- a/src/components/dashboard/dashboardItem/CPUConsumption.js
+++ b/src/components/dashboard/dashboardItem/CPUConsumption.js
@@ -26,6 +26,7 @@ import { getErrorCode } from "components/error/errorCode";
 import { Typography, useTheme } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
 import { formatDateObject } from "components/utils/DateFormatter";
+import { formatUsagePercentage } from "components/subscriptions/utils";
 
 import { getUserQuota } from "../../../common/resourceUsage";
 
@@ -64,7 +65,7 @@ const options = (usage, quota, timestamp, title, theme, t) => {
                 text: [
                     title,
                     t("consumptionChartSecondaryTitle", {
-                        percentage: ((usage / quota) * 100).toFixed(2),
+                        percentage: formatUsagePercentage(usage, quota),
                         timestamp,
                     }),
                 ],

--- a/src/components/dashboard/dashboardItem/DataConsumption.js
+++ b/src/components/dashboard/dashboardItem/DataConsumption.js
@@ -32,6 +32,7 @@ import {
     getFormattedDistance,
     formatDateObject,
 } from "components/utils/DateFormatter";
+import { formatUsagePercentage } from "components/subscriptions/utils";
 import ExternalLink from "components/utils/ExternalLink";
 
 import { getUserQuota } from "../../../common/resourceUsage";
@@ -71,7 +72,7 @@ const options = (usage, quota, date, distance, title, theme, t) => {
                 text: [
                     title,
                     t("consumptionChartSecondaryTitle", {
-                        percentage: ((usage / quota) * 100).toFixed(2),
+                        percentage: formatUsagePercentage(usage, quota),
                         timestamp: date,
                     }),
                 ],

--- a/src/components/layout/DrawerItems.js
+++ b/src/components/layout/DrawerItems.js
@@ -15,7 +15,7 @@ import AnalysesIcon from "components/icons/AnalysesIcon";
 import DataIcon from "components/icons/DataIcon";
 import { TeamIcon } from "components/teams/Icons";
 import AdminDrawerItems from "./AdminDrawerItems";
-import { Badge, Divider, Hidden, List } from "@material-ui/core";
+import { Badge, Divider, Hidden, List, Tooltip } from "@material-ui/core";
 import { useUserProfile } from "contexts/userProfile";
 import AppsIcon from "@material-ui/icons/Apps";
 import HelpIcon from "@material-ui/icons/Help";
@@ -24,6 +24,9 @@ import NestedIcon from "@material-ui/icons/LabelImportant";
 import InstantLaunchDefaultIcon from "@material-ui/icons/PlayCircleOutlineOutlined";
 import SearchIcon from "@material-ui/icons/Search";
 import SettingsIcon from "@material-ui/icons/Settings";
+import InfoIcon from "@material-ui/icons/Info";
+import ErrorIcon from "@material-ui/icons/Error";
+import WarningIcon from "@material-ui/icons/Warning";
 import { Web } from "@material-ui/icons";
 import { openInteractiveUrl } from "../analyses/utils";
 import { CollectionIcon } from "../collections/Icons";
@@ -36,6 +39,33 @@ function InstantLaunchIcon(props) {
         return <TerminalIcon width={35} height={35} />;
     }
     return <InstantLaunchDefaultIcon {...props} />;
+}
+
+function WrappedDataIcon(dataUsagePercentage, t) {
+    if (dataUsagePercentage >= 50) {
+        const usageTitle = t("dataNavUsageTitle", {
+            percentage: dataUsagePercentage,
+        });
+
+        const BadgeContent =
+            dataUsagePercentage >= 100 ? (
+                <ErrorIcon color="error" />
+            ) : dataUsagePercentage >= 75 ? (
+                <WarningIcon color="secondary" />
+            ) : (
+                <InfoIcon color="secondary" />
+            );
+
+        return (props) => (
+            <Tooltip title={usageTitle} placement="top-start">
+                <Badge badgeContent={BadgeContent}>
+                    <DataIcon {...props} />
+                </Badge>
+            </Tooltip>
+        );
+    }
+
+    return DataIcon;
 }
 
 function WrappedAnalysesIcon(analysesStats) {
@@ -65,6 +95,7 @@ function DrawerItems(props) {
         runningViceJobs,
         instantLaunches,
         computeLimitExceeded,
+        dataUsagePercentage,
     } = props;
     const { t } = useTranslation(["common"]);
     const [userProfile] = useUserProfile();
@@ -84,7 +115,7 @@ function DrawerItems(props) {
             <DrawerItem
                 title={t("data")}
                 id={ids.DATA_MI}
-                icon={DataIcon}
+                icon={WrappedDataIcon(dataUsagePercentage, t)}
                 thisView={NavigationConstants.DATA}
                 clsxBase={"data-intro"}
                 activeView={activeView}

--- a/src/components/layout/DrawerItems.js
+++ b/src/components/layout/DrawerItems.js
@@ -15,7 +15,14 @@ import AnalysesIcon from "components/icons/AnalysesIcon";
 import DataIcon from "components/icons/DataIcon";
 import { TeamIcon } from "components/teams/Icons";
 import AdminDrawerItems from "./AdminDrawerItems";
-import { Badge, Divider, Hidden, List, Tooltip } from "@material-ui/core";
+import {
+    Badge,
+    Divider,
+    Hidden,
+    List,
+    Tooltip,
+    useTheme,
+} from "@material-ui/core";
 import { useUserProfile } from "contexts/userProfile";
 import AppsIcon from "@material-ui/icons/Apps";
 import HelpIcon from "@material-ui/icons/Help";
@@ -41,31 +48,31 @@ function InstantLaunchIcon(props) {
     return <InstantLaunchDefaultIcon {...props} />;
 }
 
-function WrappedDataIcon(dataUsagePercentage, t) {
-    if (dataUsagePercentage >= 50) {
-        const usageTitle = t("dataNavUsageTitle", {
-            percentage: dataUsagePercentage,
-        });
-
-        const BadgeContent =
-            dataUsagePercentage >= 100 ? (
-                <ErrorIcon color="error" />
-            ) : dataUsagePercentage >= 75 ? (
-                <WarningIcon color="secondary" />
-            ) : (
-                <InfoIcon color="secondary" />
-            );
-
-        return (props) => (
-            <Tooltip title={usageTitle} placement="top-start">
-                <Badge badgeContent={BadgeContent}>
-                    <DataIcon {...props} />
-                </Badge>
-            </Tooltip>
-        );
+function WrappedDataIcon(dataUsagePercentage, t, theme) {
+    if (dataUsagePercentage < 50) {
+        return DataIcon;
     }
 
-    return DataIcon;
+    const usageTitle = t("dataNavUsageTitle", {
+        percentage: dataUsagePercentage,
+    });
+
+    const BadgeContent =
+        dataUsagePercentage >= 100 ? (
+            <ErrorIcon color="error" />
+        ) : dataUsagePercentage >= 75 ? (
+            <WarningIcon style={{ color: theme.palette.yellow }} />
+        ) : (
+            <InfoIcon color="secondary" />
+        );
+
+    return (props) => (
+        <Tooltip title={usageTitle} placement="top-start">
+            <Badge badgeContent={BadgeContent}>
+                <DataIcon {...props} />
+            </Badge>
+        </Tooltip>
+    );
 }
 
 function WrappedAnalysesIcon(analysesStats) {
@@ -98,6 +105,7 @@ function DrawerItems(props) {
         dataUsagePercentage,
     } = props;
     const { t } = useTranslation(["common"]);
+    const theme = useTheme();
     const [userProfile] = useUserProfile();
 
     return (
@@ -115,7 +123,7 @@ function DrawerItems(props) {
             <DrawerItem
                 title={t("data")}
                 id={ids.DATA_MI}
-                icon={WrappedDataIcon(dataUsagePercentage, t)}
+                icon={WrappedDataIcon(dataUsagePercentage, t, theme)}
                 thisView={NavigationConstants.DATA}
                 clsxBase={"data-intro"}
                 activeView={activeView}

--- a/src/components/subscriptions/utils.js
+++ b/src/components/subscriptions/utils.js
@@ -4,4 +4,7 @@ const bytesToGiB = (bytes) => {
     return parseFloat(bytes / bytesInGiB);
 };
 
-export { bytesInGiB, bytesToGiB };
+const formatUsagePercentage = (usage, quota) =>
+    quota ? ((usage / quota) * 100).toFixed(2) : 0;
+
+export { bytesInGiB, bytesToGiB, formatUsagePercentage };

--- a/stories/AppBar.stories.js
+++ b/stories/AppBar.stories.js
@@ -16,6 +16,9 @@ import { instantLaunchNavDrawerMock } from "./instantlaunches/admin/SavedLaunchL
 import {
     usageSummaryResponse,
     usageSummaryComputeLimitExceededResponse,
+    usageSummaryDiskUsage50percentResponse,
+    usageSummaryDiskUsage75percentResponse,
+    usageSummaryDiskUsage100percentResponse,
 } from "./usageSummaryMock";
 
 const mockUser = {
@@ -208,6 +211,39 @@ ComputeLimitExceeded.args = {
     mockRunningViceJobs: runningViceJobs,
     mockInstantLaunches: instantLaunchNavDrawerMock,
     mockUsageSummary: usageSummaryComputeLimitExceededResponse,
+};
+
+export const DataUsage50percent = appBarTestTemplate.bind({});
+DataUsage50percent.args = {
+    mockUserProfile: mockUser,
+    mockBootstrapResponse: bootStrap,
+    mockNotificationsData: notificationsData,
+    mockBagData: bag_data,
+    mockRunningViceJobs: runningViceJobs,
+    mockInstantLaunches: instantLaunchNavDrawerMock,
+    mockUsageSummary: usageSummaryDiskUsage50percentResponse,
+};
+
+export const DataUsage75percent = appBarTestTemplate.bind({});
+DataUsage75percent.args = {
+    mockUserProfile: mockUser,
+    mockBootstrapResponse: bootStrap,
+    mockNotificationsData: notificationsData,
+    mockBagData: bag_data,
+    mockRunningViceJobs: runningViceJobs,
+    mockInstantLaunches: instantLaunchNavDrawerMock,
+    mockUsageSummary: usageSummaryDiskUsage75percentResponse,
+};
+
+export const DataUsage100percent = appBarTestTemplate.bind({});
+DataUsage100percent.args = {
+    mockUserProfile: mockUser,
+    mockBootstrapResponse: bootStrap,
+    mockNotificationsData: notificationsData,
+    mockBagData: bag_data,
+    mockRunningViceJobs: runningViceJobs,
+    mockInstantLaunches: instantLaunchNavDrawerMock,
+    mockUsageSummary: usageSummaryDiskUsage100percentResponse,
 };
 
 export default {

--- a/stories/usageSummaryMock.js
+++ b/stories/usageSummaryMock.js
@@ -54,56 +54,24 @@ export const usageSummaryResponse = {
 };
 
 export const usageSummaryComputeLimitExceededResponse = {
+    ...usageSummaryResponse,
     cpu_usage: {
-        id: "daafc764-42bf-425d-83c6-dbdfed410e26",
-        user_id: "2ec78d4e-0dc3-11e8-a42f-008cfa5ae621",
-        username: "ipcdev@iplantcollaborative.org",
+        ...usageSummaryResponse.cpu_usage,
         total: "2919.5484124900004782",
-        effective_start: "2022-03-01T08:38:11.717336Z",
-        effective_end: "2023-03-01T08:38:11.717336Z",
-        last_modified: "2022-08-16T15:29:50.757566Z",
     },
-    data_usage: {
-        id: "580cbce3-c94f-4f7e-90de-f073d9088b89",
-        user_id: "2ec78d4e-0dc3-11e8-a42f-008cfa5ae621",
-        username: "ipcdev@iplantcollaborative.org",
-        total: 12612182209,
-        time: "2022-08-16T15:33:38.352429-07:00",
-        last_modified: "2022-08-16T15:33:38.348854-07:00",
-    },
-    subscription: {
-        id: "3ae507e4-07d5-11ed-b0ae-008cfa5ae621",
-        effective_start_date: "2022-07-19T19:39:51.58586-07:00",
-        effective_end_date: "2023-07-19T19:39:51.58586-07:00",
-        plan: {
-            id: "cdf7ac7a-98dc-11ec-bbe3-406c8f3e9cbb",
-            name: "Pro",
-            description: "Professional plan",
-        },
-        quotas: [
-            {
-                id: "3ae561c6-07d5-11ed-b0ae-008cfa5ae621",
-                quota: 2000,
-                resource_type: {
-                    id: "99e3bc7e-950a-11ec-84a4-406c8f3e9cbb",
-                    name: "cpu.hours",
-                    description: "",
-                },
-            },
-            {
-                id: "3ae56e78-07d5-11ed-b0ae-008cfa5ae621",
-                quota: 3298534883328,
-                resource_type: {
-                    id: "99e3f91e-950a-11ec-84a4-406c8f3e9cbb",
-                    name: "data.size",
-                    description: "",
-                },
-            },
-        ],
-        users: {
-            id: "",
-            username: "",
-        },
-    },
-    errors: [],
+};
+
+export const usageSummaryDiskUsage50percentResponse = {
+    ...usageSummaryResponse,
+    data_usage: { ...usageSummaryResponse.data_usage, total: 1649267441664 },
+};
+
+export const usageSummaryDiskUsage75percentResponse = {
+    ...usageSummaryResponse,
+    data_usage: { ...usageSummaryResponse.data_usage, total: 2473901162497 },
+};
+
+export const usageSummaryDiskUsage100percentResponse = {
+    ...usageSummaryResponse,
+    data_usage: { ...usageSummaryResponse.data_usage, total: 3298534883328 },
 };


### PR DESCRIPTION
This PR will add a badge to the Data nav icon, with the user's Data usage percentage in a tooltip, when the usage is 50% or higher.

The badge will be an info icon for usage percentages at or above 50%, a warning icon for usage at or above 75%, and an error icon for usage at or above 100%.

![50 percent usage](https://github.com/cyverse-de/sonora/assets/996408/6555fc4d-edf1-4e9c-8cf2-93193bcef52a)
![50 percent usage with tooltip](https://github.com/cyverse-de/sonora/assets/996408/eb05b5eb-42dd-47cd-9077-246c17baaea5)
---
![75 percent usage](https://github.com/cyverse-de/sonora/assets/996408/9031f284-ca4f-465e-8268-5f2391a2993e)
![75 percent usage with tooltip](https://github.com/cyverse-de/sonora/assets/996408/ed82492d-9dbb-4a13-8b74-14a1473e940d)
---
![100 percent usage](https://github.com/cyverse-de/sonora/assets/996408/ff64c056-5ff8-46df-8b93-80cc6875ca3a)
![100 percent usage with tooltip](https://github.com/cyverse-de/sonora/assets/996408/e95de8a9-b80d-46b3-bfea-ca3ae27aafc7)
