### PR TITLE
CORE 1961

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -94,3 +94,6 @@ username:
 subscriptions:
     checkout_url: https://cyverse-subscription-sandbox.phoenixbioinformatics.org
     enforce: true
+
+elastic:
+    enabled: true

--- a/next.config.js
+++ b/next.config.js
@@ -97,5 +97,6 @@ module.exports = withBundleAnalyzer({
         SUPPORT_EMAIL: config.get("support_email"),
         DE_FAQ: config.get("de_faq"),
         CYVERSE_URL: config.get("cyverse_url"),
+        ELASTIC_ENABLED: config.get("elastic.enabled"),
     },
 });

--- a/src/components/layout/AppBar.js
+++ b/src/components/layout/AppBar.js
@@ -135,7 +135,10 @@ function DEAppBar(props) {
         filter = searchConstants.APPS;
     } else if (activeView === NavigationConstants.ANALYSES) {
         filter = searchConstants.ANALYSES;
-    } else if (activeView === NavigationConstants.DATA) {
+    } else if (
+        activeView === NavigationConstants.DATA &&
+        config?.elasticEnabled
+    ) {
         filter = searchConstants.DATA;
     } else {
         filter = searchConstants.ALL;

--- a/src/components/search/GlobalSearchField.js
+++ b/src/components/search/GlobalSearchField.js
@@ -362,6 +362,8 @@ function GlobalSearchField(props) {
     const [bootstrapQueryEnabled, setBootstrapQueryEnabled] = useState(false);
     const [userHomeDir, setUserHomeDir] = useState(null);
 
+    const [defaultTab, setDefaultTab] = useState(null);
+
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down("xs"));
 
@@ -433,6 +435,14 @@ function GlobalSearchField(props) {
     useEffect(() => {
         setFilter(selectedFilter);
     }, [selectedFilter]);
+
+    useEffect(() => {
+        setDefaultTab(
+            config?.elasticEnabled
+                ? SEARCH_RESULTS_TABS.data
+                : SEARCH_RESULTS_TABS.apps
+        );
+    }, [config]);
 
     const { isFetching: searchingAnalyses, error: analysesSearchError } =
         useAnalysesSearch(
@@ -825,7 +835,7 @@ function GlobalSearchField(props) {
                         selectedTab:
                             filter && filter !== searchConstants.ALL
                                 ? filter.toUpperCase()
-                                : SEARCH_RESULTS_TABS.data,
+                                : defaultTab,
                     });
                 }
             }}

--- a/src/components/search/GlobalSearchField.js
+++ b/src/components/search/GlobalSearchField.js
@@ -407,6 +407,7 @@ function GlobalSearchField(props) {
         },
     };
 
+    // Return 'view all data' option if data search is enabled; otherwise, return false. False values are filtered out from the options array.
     const viewAllDataOptions = () => {
         return config?.elasticEnabled
             ? {

--- a/src/components/search/GlobalSearchField.js
+++ b/src/components/search/GlobalSearchField.js
@@ -407,10 +407,14 @@ function GlobalSearchField(props) {
         },
     };
 
-    const viewAllDataOptions = {
-        id: searchConstants.VIEW_ALL_DATA_ID,
-        name: searchTerm,
-        resultType: { type: t("data"), id: searchConstants.DATA },
+    const viewAllDataOptions = () => {
+        return config?.elasticEnabled
+            ? {
+                  id: searchConstants.VIEW_ALL_DATA_ID,
+                  name: searchTerm,
+                  resultType: { type: t("data"), id: searchConstants.DATA },
+              }
+            : false;
     };
 
     const viewAllAppOptions = {
@@ -447,14 +451,16 @@ function GlobalSearchField(props) {
                         filter === searchConstants.ANALYSES &&
                         !singleSearchOption
                     ) {
-                        setOptions([
-                            ...options,
-                            ...analyses,
-                            viewAllAnalysesOptions,
-                            viewAllAppOptions,
-                            viewAllDataOptions,
-                            viewAllTeamOptions,
-                        ]);
+                        setOptions(
+                            [
+                                ...options,
+                                ...analyses,
+                                viewAllAnalysesOptions,
+                                viewAllAppOptions,
+                                viewAllDataOptions(),
+                                viewAllTeamOptions,
+                            ].filter(Boolean)
+                        );
                     } else {
                         setOptions([
                             ...options,
@@ -479,14 +485,16 @@ function GlobalSearchField(props) {
                     };
                 });
                 if (filter === searchConstants.APPS && !singleSearchOption) {
-                    setOptions([
-                        ...options,
-                        ...apps,
-                        viewAllAppOptions,
-                        viewAllAnalysesOptions,
-                        viewAllDataOptions,
-                        viewAllTeamOptions,
-                    ]);
+                    setOptions(
+                        [
+                            ...options,
+                            ...apps,
+                            viewAllAppOptions,
+                            viewAllAnalysesOptions,
+                            viewAllDataOptions(),
+                            viewAllTeamOptions,
+                        ].filter(Boolean)
+                    );
                 } else {
                     setOptions([...options, ...apps, viewAllAppOptions]);
                 }
@@ -508,19 +516,25 @@ function GlobalSearchField(props) {
                     };
                 });
                 if (filter === searchConstants.DATA && !singleSearchOption) {
-                    setOptions([
-                        ...options,
-                        ...data,
-                        viewAllDataOptions,
-                        viewAllAnalysesOptions,
-                        viewAllAppOptions,
-                        viewAllTeamOptions,
-                    ]);
+                    setOptions(
+                        [
+                            ...options,
+                            ...data,
+                            viewAllDataOptions(),
+                            viewAllAnalysesOptions,
+                            viewAllAppOptions,
+                            viewAllTeamOptions,
+                        ].filter(Boolean)
+                    );
                 } else {
-                    setOptions([...options, ...data, viewAllDataOptions]);
+                    setOptions(
+                        [...options, ...data, viewAllDataOptions()].filter(
+                            Boolean
+                        )
+                    );
                 }
             } else {
-                setOptions([...options, viewAllDataOptions]);
+                setOptions([...options, viewAllDataOptions()].filter(Boolean));
             }
         }
     );
@@ -536,14 +550,16 @@ function GlobalSearchField(props) {
                     };
                 });
                 if (filter === searchConstants.TEAMS && !singleSearchOption) {
-                    setOptions([
-                        ...options,
-                        ...teams,
-                        viewAllTeamOptions,
-                        viewAllDataOptions,
-                        viewAllAppOptions,
-                        viewAllAnalysesOptions,
-                    ]);
+                    setOptions(
+                        [
+                            ...options,
+                            ...teams,
+                            viewAllTeamOptions,
+                            viewAllDataOptions(),
+                            viewAllAppOptions,
+                            viewAllAnalysesOptions,
+                        ].filter(Boolean)
+                    );
                 } else {
                     setOptions([...options, ...teams, viewAllTeamOptions]);
                 }

--- a/src/components/search/GlobalSearchField.js
+++ b/src/components/search/GlobalSearchField.js
@@ -339,6 +339,9 @@ function GlobalSearchField(props) {
     const { t: analysesI18n } = useTranslation("analyses");
     const { t: i18NSearch } = useTranslation("search");
     const appRecordFields = appFields(appsI18n);
+    const defaultTab = config?.elasticEnabled
+        ? SEARCH_RESULTS_TABS.data
+        : SEARCH_RESULTS_TABS.apps;
 
     const [searchTerm, setSearchTerm] = useState(search);
     const [filter, setFilter] = useState(selectedFilter || searchConstants.ALL);
@@ -361,8 +364,6 @@ function GlobalSearchField(props) {
 
     const [bootstrapQueryEnabled, setBootstrapQueryEnabled] = useState(false);
     const [userHomeDir, setUserHomeDir] = useState(null);
-
-    const [defaultTab, setDefaultTab] = useState(null);
 
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down("xs"));
@@ -435,14 +436,6 @@ function GlobalSearchField(props) {
     useEffect(() => {
         setFilter(selectedFilter);
     }, [selectedFilter]);
-
-    useEffect(() => {
-        setDefaultTab(
-            config?.elasticEnabled
-                ? SEARCH_RESULTS_TABS.data
-                : SEARCH_RESULTS_TABS.apps
-        );
-    }, [config]);
 
     const { isFetching: searchingAnalyses, error: analysesSearchError } =
         useAnalysesSearch(

--- a/src/components/search/GlobalSearchField.js
+++ b/src/components/search/GlobalSearchField.js
@@ -614,7 +614,7 @@ function GlobalSearchField(props) {
         const isLoggedIn = !!userProfile?.id;
         switch (filter) {
             case searchConstants.DATA:
-                setDataSearchQueryEnabled(true);
+                setDataSearchQueryEnabled(config?.elasticEnabled);
                 setAppsSearchQueryEnabled(false);
                 setAnalysesSearchQueryEnabled(false);
                 setTeamSearchQueryEnabled(false);
@@ -642,7 +642,7 @@ function GlobalSearchField(props) {
                 break;
 
             default:
-                setDataSearchQueryEnabled(true);
+                setDataSearchQueryEnabled(config?.elasticEnabled);
                 setAppsSearchQueryEnabled(true);
                 setAnalysesSearchQueryEnabled(isLoggedIn);
                 setTeamSearchQueryEnabled(isLoggedIn);
@@ -816,14 +816,17 @@ function GlobalSearchField(props) {
     );
 
     const searchFilterId = buildID(ids.SEARCH, ids.SEARCH_FILTER_MENU);
+    const allFilterOptions = [
+        searchConstants.ALL,
+        searchConstants.DATA,
+        searchConstants.APPS,
+        searchConstants.ANALYSES,
+    ];
     const filterOptions = singleSearchOption
         ? [selectedFilter]
-        : [
-              searchConstants.ALL,
-              searchConstants.DATA,
-              searchConstants.APPS,
-              searchConstants.ANALYSES,
-          ];
+        : config?.elasticEnabled
+        ? allFilterOptions
+        : allFilterOptions.filter((option) => option !== searchConstants.DATA);
 
     return (
         <>

--- a/src/components/search/detailed/DataSearchResults.js
+++ b/src/components/search/detailed/DataSearchResults.js
@@ -324,7 +324,7 @@ function DataSearchResults(props) {
     }
     if (
         status !== constants.LOADING &&
-        (!data || data.pages.length === 0 || data.pages[0]?.hits.length === 0)
+        (!data || data.pages.length === 0 || data.pages[0]?.hits?.length === 0)
     ) {
         return (
             <>
@@ -335,7 +335,7 @@ function DataSearchResults(props) {
     }
 
     let flatData = [];
-    if (data && data.pages[0].hits.length > 0) {
+    if (data && data.pages[0].hits?.length > 0) {
         data.pages.forEach((page) => {
             flatData = [...flatData, ...page.hits];
         });

--- a/src/components/search/detailed/DetailedSearchResults.js
+++ b/src/components/search/detailed/DetailedSearchResults.js
@@ -39,6 +39,8 @@ import {
 import AppsIcon from "@material-ui/icons/Apps";
 import SearchIcon from "@material-ui/icons/Search";
 
+import { useConfig } from "contexts/config";
+
 const useStyles = makeStyles((theme) => ({
     root: {
         flexGrow: 1,
@@ -91,6 +93,8 @@ function DetailedSearchResults(props) {
     const appsTabId = buildID(baseId, ids.APPS_SEARCH_RESULTS_TAB);
     const analysesTabId = buildID(baseId, ids.ANALYSES_SEARCH_RESULTS_TAB);
     const teamTabId = buildID(baseId, ids.TEAM_SEARCH_RESULTS_TAB);
+
+    const [config] = useConfig();
 
     const dataTabIcon =
         selectedTab === SEARCH_RESULTS_TABS.data ? (
@@ -153,17 +157,21 @@ function DetailedSearchResults(props) {
                 centered={!isMobile}
                 variant={isMobile ? "fullWidth" : "standard"}
             >
-                <DETab
-                    value={SEARCH_RESULTS_TABS.data}
-                    key={dataTabId}
-                    id={dataTabId}
-                    label={
-                        isMobile
-                            ? `(${dataCount})`
-                            : t("search:dataSearchTab", { count: dataCount })
-                    }
-                    icon={dataTabIcon}
-                />
+                {config?.elasticEnabled && (
+                    <DETab
+                        value={SEARCH_RESULTS_TABS.data}
+                        key={dataTabId}
+                        id={dataTabId}
+                        label={
+                            isMobile
+                                ? `(${dataCount})`
+                                : t("search:dataSearchTab", {
+                                      count: dataCount,
+                                  })
+                        }
+                        icon={dataTabIcon}
+                    />
+                )}
                 <DETab
                     value={SEARCH_RESULTS_TABS.apps}
                     key={appsTabId}
@@ -202,19 +210,20 @@ function DetailedSearchResults(props) {
                     icon={<TeamIcon />}
                 />
             </Tabs>
-
-            <DETabPanel
-                tabId={dataTabId}
-                value={SEARCH_RESULTS_TABS.data}
-                selectedTab={selectedTab}
-            >
-                <DataSearchResults
-                    searchTerm={searchTerm}
-                    advancedDataQuery={advancedDataQuery}
-                    updateResultCount={(count) => setDataCount(count)}
-                    baseId={dataTabId}
-                />
-            </DETabPanel>
+            {config?.elasticEnabled && (
+                <DETabPanel
+                    tabId={dataTabId}
+                    value={SEARCH_RESULTS_TABS.data}
+                    selectedTab={selectedTab}
+                >
+                    <DataSearchResults
+                        searchTerm={searchTerm}
+                        advancedDataQuery={advancedDataQuery}
+                        updateResultCount={(count) => setDataCount(count)}
+                        baseId={dataTabId}
+                    />
+                </DETabPanel>
+            )}
             <DETabPanel
                 tabId={appsTabId}
                 value={SEARCH_RESULTS_TABS.apps}

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -213,6 +213,7 @@ function MyApp({ Component, pageProps }) {
         const supportEmail = publicRuntimeConfig.SUPPORT_EMAIL;
         const deFaq = publicRuntimeConfig.DE_FAQ;
         const cyverseURL = publicRuntimeConfig.CYVERSE_URL;
+        const elasticEnabled = publicRuntimeConfig.ELASTIC_ENABLED;
 
         setConfig({
             intercom,
@@ -230,6 +231,7 @@ function MyApp({ Component, pageProps }) {
             supportEmail,
             deFaq,
             cyverseURL,
+            elasticEnabled,
         });
 
         const jssStyles = document.querySelector("#jss-server-side");

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { Hidden } from "@material-ui/core";
@@ -12,16 +12,12 @@ import { useConfig } from "contexts/config";
 export default function Search() {
     const [config] = useConfig();
     const router = useRouter();
-    const [defaultTab, setDefaultTab] = useState(null);
+    const defaultTab = config?.elasticEnabled
+        ? SEARCH_RESULTS_TABS.data
+        : SEARCH_RESULTS_TABS.apps;
     const { searchTerm, filter, selectedTab, advancedDataQuery } =
         router?.query;
-    useEffect(() => {
-        setDefaultTab(
-            config?.elasticEnabled
-                ? SEARCH_RESULTS_TABS.data
-                : SEARCH_RESULTS_TABS.apps
-        );
-    }, [config]);
+
     let tab = selectedTab || defaultTab;
     const onShowDetailedSearch = (query) => {
         router.push({

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -43,7 +43,7 @@ export default function Search() {
                 baseId="search"
                 searchTerm={searchTerm}
                 advancedDataQuery={advancedDataQuery}
-                //filter={filter}
+                filter={filter}
                 selectedTab={tab}
                 onTabSelectionChange={(event, selection) => {
                     router.push({

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { Hidden } from "@material-ui/core";
@@ -7,12 +7,22 @@ import GlobalSearchField from "components/search/GlobalSearchField";
 import DetailedSearchResults from "components/search/detailed/DetailedSearchResults";
 import SEARCH_RESULTS_TABS from "components/search/detailed/tabs";
 import NavigationConstants from "common/NavigationConstants";
+import { useConfig } from "contexts/config";
 
 export default function Search() {
+    const [config] = useConfig();
     const router = useRouter();
+    const [defaultTab, setDefaultTab] = useState(null);
     const { searchTerm, filter, selectedTab, advancedDataQuery } =
         router?.query;
-    let tab = selectedTab || SEARCH_RESULTS_TABS.data;
+    useEffect(() => {
+        setDefaultTab(
+            config?.elasticEnabled
+                ? SEARCH_RESULTS_TABS.data
+                : SEARCH_RESULTS_TABS.apps
+        );
+    }, [config]);
+    let tab = selectedTab || defaultTab;
     const onShowDetailedSearch = (query) => {
         router.push({
             pathname: `/${NavigationConstants.SEARCH}`,
@@ -33,7 +43,7 @@ export default function Search() {
                 baseId="search"
                 searchTerm={searchTerm}
                 advancedDataQuery={advancedDataQuery}
-                filter={filter}
+                //filter={filter}
                 selectedTab={tab}
                 onTabSelectionChange={(event, selection) => {
                     router.push({

--- a/stories/configMock.js
+++ b/stories/configMock.js
@@ -47,4 +47,5 @@ export default {
             "https://cyverse-subscription-sandbox.phoenixbioinformatics.org",
         enforce: true,
     },
+    elasticEnabled: true,
 };


### PR DESCRIPTION
Add configuration setting that can be used to disable data search in the DE
Remove data search features from the DE when data search is disabled
-Remove data filter
-Remove data tab and data tab panel
-Disable data search queries
-Set default tab to 'apps' when clicking enter to search on globalsearchfield
