### PR TITLE
CORE-1968 Add page titles in each DE page

### DIFF
--- a/public/static/locales/en/apps.json
+++ b/public/static/locales/en/apps.json
@@ -29,6 +29,7 @@
     "appListingError": "Unable to get Apps. Please try again.",
     "appPubRequestsFetchError": "Unable to fetch publication requests. Please try again.",
     "appPublicationError": "Unable to publish {{appName}}. Please check the details.",
+    "appsAdmin": "Apps Admin",
     "appType": "Type",
     "appVersion": "Version",
     "apps_under_development": "Apps Under Development",

--- a/public/static/locales/en/collections.json
+++ b/public/static/locales/en/collections.json
@@ -27,6 +27,7 @@
     "noCollections": "No $t(featureName_plural)",
     "noExternalApps": "Adding Agave/HPC apps is not currently supported",
     "noExternalAppsNote": "NOTE: $t(noExternalApps).",
+    "pageTitle": "Collection - {{name}}",
     "remove": "Remove",
     "retagApps": "Re-tag Apps",
     "retagAppsMessage": "{{name}} currently has apps associated with it. Renaming the $t(featureName) will cause all the currently tagged apps to be re-tagged with the new $t(featureName) name.  Do you wish to continue?",

--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -23,6 +23,7 @@
     "dataNavUsageTitle": "{{percentage}}% usage",
     "description": "Description",
     "deTitle": "Discovery Environment",
+    "dePageTitle": "{{title}} - Discovery Environment",
     "delete": "Delete",
     "disable": "Disable",
     "discard": "Discard",

--- a/public/static/locales/en/data.json
+++ b/public/static/locales/en/data.json
@@ -100,6 +100,7 @@
     "noContent": "No content to display.",
     "ok": "OK",
     "own": "Own",
+    "pageTitle": "Data - {{path}}",
     "path": "Path",
     "pathCopied": "Path copied.",
     "pathCopyError": "Unable to copy path.",

--- a/public/static/locales/en/referenceGenomes.json
+++ b/public/static/locales/en/referenceGenomes.json
@@ -14,6 +14,7 @@
     "createdOn": "Created On",
     "lastModifiedBy": "Last Modified By",
     "lastModifiedOn": "Last Modified On",
+    "referenceGenomes": "Reference Genomes",
     "search": "Search",
     "updateSuccess": "Reference Genome updated successfully.",
     "updateFailed": "Unable to update the Reference Genome"

--- a/public/static/locales/en/search.json
+++ b/public/static/locales/en/search.json
@@ -21,6 +21,7 @@
     "noResults": "No results to display.",
     "own": "Own",
     "owner": "Owner",
+    "pageTitle": "Search - {{searchTerm}}",
     "path": "Path",
     "pathPlaceholder": "/iplant/home/me",
     "permissions": "Permissions",

--- a/public/static/locales/en/subscriptions.json
+++ b/public/static/locales/en/subscriptions.json
@@ -38,6 +38,7 @@
     "noSubscriptions": "No subscriptions",
     "noUsages": "No usages",
     "paid": "Paid",
+    "pageTitle": "Subscriptions - {{searchTerm}}",
     "planName": "Plan Name",
     "quota": "Quota",
     "quotas": "Quotas",

--- a/public/static/locales/en/teams.json
+++ b/public/static/locales/en/teams.json
@@ -2,6 +2,7 @@
     "admin": "Admin",
     "allTeams": "All Teams",
     "ariaTeamFilter": "Team Filter",
+    "createTeam": "Create Team",
     "createTeamFail": "Failed to create team name or description. Please try again.",
     "creator": "Creator Name",
     "deleteTeamFail": "Failed to delete team.  Please try again.",

--- a/public/static/locales/en/teams.json
+++ b/public/static/locales/en/teams.json
@@ -27,6 +27,7 @@
     "myTeams": "My Teams",
     "name": "Name",
     "noTeams": "No teams",
+    "pageTitle": "Team - {{name}}",
     "privilege": "Privilege",
     "publicTeam": "Public Team",
     "publicTeamHelp": "Making your team public allows your team to be discoverable to other CyVerse users who are not members of your team. Allowing users to discover your team will enable them to view the team and request to join. A team can be updated from public to private and vice versa any time.",

--- a/public/static/locales/en/tools.json
+++ b/public/static/locales/en/tools.json
@@ -126,6 +126,7 @@
     "toolRequests": "Tool Requests",
     "toolRequestSuccess": "Request submitted successfully. You will receive notifications about the progress.",
     "tools": "Tools",
+    "toolsAdmin": "Tools Admin",
     "toolSrcLinkLabel": "Provide a link for your tool's source (GitHub, BitBucket, DockerHub etc...)",
     "toolsUsed": "Tools used by {{appName}}",
     "toolTestDataLabel": "Provide a link for your tool's test data",

--- a/public/static/locales/en/vice-admin.json
+++ b/public/static/locales/en/vice-admin.json
@@ -104,5 +104,6 @@
     "userIDColumn": "User ID",
     "username": "Username",
     "usernameColumn": "Username",
-    "value": "Value"
+    "value": "Value",
+    "viceAdmin": "VICE Admin"
 }

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -123,6 +123,8 @@ function MyApp({ Component, pageProps }) {
             })
     );
 
+    const { title } = pageProps;
+
     useEffect(() => {
         const analytics_id = publicRuntimeConfig.ANALYTICS_ID;
         const handleRouteChange = (url) => {
@@ -271,7 +273,13 @@ function MyApp({ Component, pageProps }) {
                                             clientConfig={config}
                                         >
                                             <Head>
-                                                <title>{t("deTitle")}</title>
+                                                <title>
+                                                    {title
+                                                        ? t("dePageTitle", {
+                                                              title,
+                                                          })
+                                                        : t("deTitle")}
+                                                </title>
                                             </Head>
                                             <ReactQueryDevtools
                                                 initialIsOpen={false}

--- a/src/pages/admin/apps.js
+++ b/src/pages/admin/apps.js
@@ -11,7 +11,7 @@ import React, { useCallback } from "react";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces, useTranslation } from "i18n";
+import { i18n, RequiredNamespaces, useTranslation } from "i18n";
 
 import { getLocalStorage } from "components/utils/localStorage";
 
@@ -145,8 +145,11 @@ export default function Apps() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("apps:appsAdmin");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "collections",
                 "tools",

--- a/src/pages/admin/doi.js
+++ b/src/pages/admin/doi.js
@@ -9,7 +9,7 @@
 import React, { useCallback } from "react";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 import Listing from "components/doi/Listing";
 import NotAuthorized from "components/error/NotAuthorized";
 import { useUserProfile } from "contexts/userProfile";
@@ -73,8 +73,11 @@ export default function Doi() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("doiRequests");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "doi",
                 "data",

--- a/src/pages/admin/refgenomes.js
+++ b/src/pages/admin/refgenomes.js
@@ -2,7 +2,7 @@ import React from "react";
 
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 import ReferenceGenomes from "../../components/apps/admin/referenceGenomes/ReferenceGenomes";
 import { useUserProfile } from "contexts/userProfile";
 import NotAuthorized from "components/error/NotAuthorized";
@@ -17,8 +17,11 @@ export default function RefGenome() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("referenceGenomes:referenceGenomes");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "referenceGenomes",
                 ...RequiredNamespaces,

--- a/src/pages/admin/subscriptions.js
+++ b/src/pages/admin/subscriptions.js
@@ -11,7 +11,7 @@ import { useQuery, useQueryClient } from "react-query";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces, useTranslation } from "i18n";
+import { i18n, RequiredNamespaces, useTranslation } from "i18n";
 
 import Listing from "components/subscriptions/listing/Listing";
 import AddOnsListing from "components/subscriptions/addons/listing/Listing";
@@ -158,8 +158,11 @@ export default function Subscriptions() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("subscriptions");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "subscriptions",
                 ...RequiredNamespaces,

--- a/src/pages/admin/subscriptions.js
+++ b/src/pages/admin/subscriptions.js
@@ -157,8 +157,16 @@ export default function Subscriptions() {
     }
 }
 
-export async function getServerSideProps({ locale }) {
-    const title = i18n.t("subscriptions");
+export async function getServerSideProps(context) {
+    const {
+        locale,
+        query: { searchTerm },
+    } = context;
+
+    let title = i18n.t("subscriptions");
+    if (searchTerm) {
+        title = i18n.t("subscriptions:pageTitle", { searchTerm });
+    }
 
     return {
         props: {

--- a/src/pages/admin/tools.js
+++ b/src/pages/admin/tools.js
@@ -11,7 +11,7 @@ import React, { useCallback } from "react";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces, useTranslation } from "i18n";
+import { i18n, RequiredNamespaces, useTranslation } from "i18n";
 
 import constants from "../../constants";
 import { getLocalStorage } from "components/utils/localStorage";
@@ -139,8 +139,11 @@ export default function Tools() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("tools:toolsAdmin");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "tools",
                 ...RequiredNamespaces,

--- a/src/pages/admin/vice.js
+++ b/src/pages/admin/vice.js
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 import { useUserProfile } from "contexts/userProfile";
 import NotAuthorized from "components/error/NotAuthorized";
 
-import { RequiredNamespaces, useTranslation } from "i18n";
+import { i18n, RequiredNamespaces, useTranslation } from "i18n";
 
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
@@ -221,8 +221,11 @@ export default function VICEAdminPage() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("vice-admin:viceAdmin");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "vice-admin",
                 ...RequiredNamespaces,

--- a/src/pages/analyses.js
+++ b/src/pages/analyses.js
@@ -10,7 +10,7 @@ import React, { useCallback } from "react";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces, useTranslation } from "i18n";
+import { i18n, RequiredNamespaces, useTranslation } from "i18n";
 
 import constants from "../constants";
 
@@ -86,8 +86,11 @@ export default function Analyses() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("analyses");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "data",
                 // "analyses" already included by RequiredNamespaces

--- a/src/pages/analyses/[analysisId]/index.js
+++ b/src/pages/analyses/[analysisId]/index.js
@@ -9,7 +9,7 @@ import React from "react";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 import AnalysisSubmissionLanding from "components/analyses/landing/AnalysisSubmissionLanding";
 
 /**
@@ -32,8 +32,11 @@ export default function Analysis() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("analyses:analysis");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 // "analyses" already included by RequiredNamespaces
                 "dashboard",

--- a/src/pages/analyses/[analysisId]/relaunch.js
+++ b/src/pages/analyses/[analysisId]/relaunch.js
@@ -10,7 +10,7 @@ import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useQuery } from "react-query";
 
-import { RequiredNamespaces, useTranslation } from "i18n";
+import { i18n, RequiredNamespaces, useTranslation } from "i18n";
 
 import constants from "../../../constants";
 import {
@@ -122,14 +122,17 @@ const Relaunch = ({ showErrorAnnouncer }) => {
 };
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("analyses:relaunch");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "data",
                 "launch",
                 "upload",
                 "urlImport",
-                // "apps" already included by RequiredNamespaces
+                // "apps" and "analyses" already included by RequiredNamespaces
                 ...RequiredNamespaces,
             ])),
         },

--- a/src/pages/apps.js
+++ b/src/pages/apps.js
@@ -79,8 +79,14 @@ export default function Apps() {
 }
 
 export async function getServerSideProps(context) {
-    const { locale } = context;
-    const title = i18n.t("apps");
+    const { locale, query } = context;
+
+    let selectedCategory;
+    if (query.selectedCategory) {
+        selectedCategory = JSON.parse(query.selectedCategory).name;
+    }
+
+    const title = selectedCategory || i18n.t("apps");
 
     return {
         props: {

--- a/src/pages/apps.js
+++ b/src/pages/apps.js
@@ -11,7 +11,7 @@ import React, { useCallback } from "react";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces, useTranslation } from "i18n";
+import { i18n, RequiredNamespaces, useTranslation } from "i18n";
 
 import { getLocalStorage } from "components/utils/localStorage";
 
@@ -80,8 +80,11 @@ export default function Apps() {
 
 export async function getServerSideProps(context) {
     const { locale } = context;
+    const title = i18n.t("apps");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "collections",
                 // "apps" already included by RequiredNamespaces

--- a/src/pages/apps/[systemId]/[appId]/index.js
+++ b/src/pages/apps/[systemId]/[appId]/index.js
@@ -9,7 +9,7 @@ import React, { useCallback } from "react";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces, useTranslation } from "i18n";
+import { i18n, RequiredNamespaces, useTranslation } from "i18n";
 
 import { getLocalStorage } from "components/utils/localStorage";
 
@@ -76,8 +76,11 @@ export default function App() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("apps");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "collections",
                 // "apps" already included by RequiredNamespaces

--- a/src/pages/apps/[systemId]/[appId]/launch.js
+++ b/src/pages/apps/[systemId]/[appId]/launch.js
@@ -10,7 +10,7 @@ import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useQuery } from "react-query";
 
-import { RequiredNamespaces, useTranslation } from "i18n";
+import { i18n, RequiredNamespaces, useTranslation } from "i18n";
 
 import {
     getAppDescription,
@@ -120,8 +120,11 @@ function Launch({ showErrorAnnouncer }) {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("launch:launchAnalysis");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "data",
                 "upload",

--- a/src/pages/apps/[systemId]/[appId]/versions/[versionId]/create.js
+++ b/src/pages/apps/[systemId]/[appId]/versions/[versionId]/create.js
@@ -9,7 +9,7 @@ import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useQuery } from "react-query";
 
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 
 import AppEditor from "components/apps/editor";
 import ids from "components/apps/editor/ids";
@@ -156,8 +156,11 @@ export default function AppVersionCreate() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("apps:createAppVersion");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "app_editor",
                 "app_editor_help",

--- a/src/pages/apps/[systemId]/[appId]/versions/[versionId]/edit.js
+++ b/src/pages/apps/[systemId]/[appId]/versions/[versionId]/edit.js
@@ -10,7 +10,7 @@ import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useQuery } from "react-query";
 
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 
 import AppEditor from "components/apps/editor";
 import ids from "components/apps/editor/ids";
@@ -109,8 +109,11 @@ export default function AppEdit() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("apps:editApp");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "app_editor",
                 "app_editor_help",

--- a/src/pages/apps/[systemId]/[appId]/versions/[versionId]/launch.js
+++ b/src/pages/apps/[systemId]/[appId]/versions/[versionId]/launch.js
@@ -9,7 +9,7 @@ import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useQuery } from "react-query";
 
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 
 import {
     getAppDescription,
@@ -76,8 +76,11 @@ export default function Launch() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("launch:launchAnalysis");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "data",
                 "upload",

--- a/src/pages/apps/create.js
+++ b/src/pages/apps/create.js
@@ -7,7 +7,7 @@ import React from "react";
 
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 
 import AppEditor from "components/apps/editor";
 import NewAppDefaults from "components/apps/editor/NewAppDefaults";
@@ -39,8 +39,11 @@ export default function AppCreate() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("apps:createApp");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "app_editor",
                 "app_editor_help",

--- a/src/pages/collections/[collectionName].js
+++ b/src/pages/collections/[collectionName].js
@@ -31,8 +31,15 @@ export default function EditCollection() {
     );
 }
 
-export async function getServerSideProps({ locale }) {
-    const title = i18n.t("collections:featureName");
+export async function getServerSideProps(context) {
+    const {
+        locale,
+        params: { collectionName },
+    } = context;
+
+    const title = i18n.t("collections:pageTitle", {
+        name: collectionName,
+    });
 
     return {
         props: {

--- a/src/pages/collections/[collectionName].js
+++ b/src/pages/collections/[collectionName].js
@@ -9,7 +9,7 @@ import React from "react";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 
 import CollectionForm from "components/collections/form";
 import NavigationConstants from "common/NavigationConstants";
@@ -32,8 +32,11 @@ export default function EditCollection() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("collections:featureName");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "collections",
                 ...RequiredNamespaces,

--- a/src/pages/collections/create.js
+++ b/src/pages/collections/create.js
@@ -9,7 +9,7 @@ import React from "react";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 import CollectionForm from "components/collections/form";
 import NavigationConstants from "common/NavigationConstants";
 
@@ -29,8 +29,11 @@ export default function CreateCollection() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("collections:featureName");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "collections",
                 ...RequiredNamespaces,

--- a/src/pages/collections/index.js
+++ b/src/pages/collections/index.js
@@ -8,7 +8,7 @@ import React from "react";
 import CollectionsView from "components/collections";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 import NavigationConstants from "../../common/NavigationConstants";
 
 export default function Collections() {
@@ -37,8 +37,11 @@ export default function Collections() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("collections:featureName_plural");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "collections",
                 ...RequiredNamespaces,

--- a/src/pages/data/ds/[...pathItems].js
+++ b/src/pages/data/ds/[...pathItems].js
@@ -9,7 +9,7 @@ import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useQuery } from "react-query";
 
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 import constants from "../../../constants";
 import { NavigationParams } from "common/NavigationConstants";
 
@@ -189,8 +189,11 @@ export default function DataStore() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("data");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "data",
                 "metadata",

--- a/src/pages/data/ds/[...pathItems].js
+++ b/src/pages/data/ds/[...pathItems].js
@@ -188,8 +188,17 @@ export default function DataStore() {
     );
 }
 
-export async function getServerSideProps({ locale }) {
-    const title = i18n.t("data");
+export async function getServerSideProps(context) {
+    const {
+        locale,
+        params: { pathItems },
+    } = context;
+
+    // Display the full path up to 3 items deep, otherwise only the last item.
+    const path =
+        pathItems.length <= 3 ? "/" + pathItems.join("/") : pathItems.at(-1);
+
+    const title = i18n.t("data:pageTitle", { path });
 
     return {
         props: {

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -7,7 +7,7 @@ import React, { Fragment, useEffect } from "react";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 
 import constants from "../../constants";
 import {
@@ -51,8 +51,11 @@ export default function Data() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("data");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "data",
                 ...RequiredNamespaces,

--- a/src/pages/error.js
+++ b/src/pages/error.js
@@ -10,7 +10,7 @@ import React from "react";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 import ErrorHandler from "components/error/ErrorHandler";
 
 export default function Error() {
@@ -21,8 +21,11 @@ export default function Error() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("util:error");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, RequiredNamespaces)),
         },
     };

--- a/src/pages/help.js
+++ b/src/pages/help.js
@@ -10,7 +10,7 @@ import React from "react";
 
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 import HelpTopics from "components/help/HelpTopics";
 
 export default function Help() {
@@ -18,8 +18,11 @@ export default function Help() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("help");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "help",
                 "intro",

--- a/src/pages/instantlaunches.js
+++ b/src/pages/instantlaunches.js
@@ -7,7 +7,7 @@ import React from "react";
 
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 import Listing from "components/instantlaunches/listing";
 
 export default function InstantLaunches() {
@@ -15,8 +15,11 @@ export default function InstantLaunches() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("instantLaunches");
+
     return {
         props: {
+            title,
             // "instantlaunches" already included by RequiredNamespaces
             ...(await serverSideTranslations(locale, RequiredNamespaces)),
         },

--- a/src/pages/notifications.js
+++ b/src/pages/notifications.js
@@ -7,7 +7,7 @@ import React from "react";
 
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 import NotificationsListing from "components/notifications/listing";
 
 export default function Notifications() {
@@ -15,8 +15,11 @@ export default function Notifications() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("notifications");
+
     return {
         props: {
+            title,
             // "notifications" already included by RequiredNamespaces
             ...(await serverSideTranslations(locale, RequiredNamespaces)),
         },

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -2,7 +2,7 @@ import React from "react";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { Hidden } from "@material-ui/core";
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 import GlobalSearchField from "components/search/GlobalSearchField";
 import DetailedSearchResults from "components/search/detailed/DetailedSearchResults";
 import SEARCH_RESULTS_TABS from "components/search/detailed/tabs";
@@ -58,8 +58,11 @@ export default function Search() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("search");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "data",
                 "teams",

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -57,8 +57,16 @@ export default function Search() {
     );
 }
 
-export async function getServerSideProps({ locale }) {
-    const title = i18n.t("search");
+export async function getServerSideProps(context) {
+    const {
+        locale,
+        query: { searchTerm },
+    } = context;
+
+    let title = i18n.t("search");
+    if (searchTerm) {
+        title = i18n.t("search:pageTitle", { searchTerm });
+    }
 
     return {
         props: {

--- a/src/pages/settings.js
+++ b/src/pages/settings.js
@@ -2,15 +2,18 @@ import React from "react";
 
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 import Preferences from "../components/preferences/Preferences";
 
 export default function Settings() {
     return <Preferences baseId="preferences" />;
 }
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("settings");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "preferences",
                 ...RequiredNamespaces,

--- a/src/pages/teams/[teamName].js
+++ b/src/pages/teams/[teamName].js
@@ -31,8 +31,13 @@ export default function EditTeam() {
     );
 }
 
-export async function getServerSideProps({ locale }) {
-    const title = i18n.t("teams");
+export async function getServerSideProps(context) {
+    const {
+        locale,
+        params: { teamName },
+    } = context;
+
+    const title = i18n.t("teams:pageTitle", { name: teamName });
 
     return {
         props: {

--- a/src/pages/teams/[teamName].js
+++ b/src/pages/teams/[teamName].js
@@ -9,7 +9,7 @@ import React from "react";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 
 import NavigationConstants from "common/NavigationConstants";
 import TeamForm from "components/teams/form";
@@ -32,8 +32,11 @@ export default function EditTeam() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("teams");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "teams",
                 ...RequiredNamespaces,

--- a/src/pages/teams/create.js
+++ b/src/pages/teams/create.js
@@ -9,7 +9,7 @@ import React from "react";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 
 import NavigationConstants from "common/NavigationConstants";
 import TeamForm from "components/teams/form/";
@@ -26,8 +26,11 @@ export default function CreateTeam() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("teams:createTeam");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "teams",
                 ...RequiredNamespaces,

--- a/src/pages/teams/index.js
+++ b/src/pages/teams/index.js
@@ -9,7 +9,7 @@ import React from "react";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 
 import NavigationConstants from "common/NavigationConstants";
 import TeamsView from "components/teams";
@@ -37,8 +37,11 @@ export default function Teams() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("teams");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "teams",
                 ...RequiredNamespaces,

--- a/src/pages/tools.js
+++ b/src/pages/tools.js
@@ -11,7 +11,7 @@ import React, { useCallback } from "react";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 import constants from "../constants";
 import { getLocalStorage } from "components/utils/localStorage";
 import Listing from "components/tools/listing/Listing";
@@ -63,8 +63,11 @@ export default function Tools() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("tools");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "tools",
                 ...RequiredNamespaces,

--- a/src/pages/vice/[accessUrl].js
+++ b/src/pages/vice/[accessUrl].js
@@ -9,7 +9,7 @@ import React from "react";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 import ViceLoading from "components/vice/loading";
 
 export default function Loading() {
@@ -20,8 +20,11 @@ export default function Loading() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("vice-loading:initializingVice");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "vice-loading",
                 ...RequiredNamespaces,

--- a/src/pages/workflows/create.js
+++ b/src/pages/workflows/create.js
@@ -7,7 +7,7 @@ import React from "react";
 
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { RequiredNamespaces } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 
 import WorkflowEditor from "components/apps/workflows/Editor";
 import NewWorkflowDefaults from "components/apps/workflows/NewWorkflowDefaults";
@@ -39,8 +39,11 @@ export default function AppCreate() {
 }
 
 export async function getServerSideProps({ locale }) {
+    const title = i18n.t("apps:createWorkflow");
+
     return {
         props: {
+            title,
             ...(await serverSideTranslations(locale, [
                 "launch",
                 "workflows",


### PR DESCRIPTION
This PR will add a basic page title to each DE page.

For example, the home page will still be titled `Discovery Environment`, but this PR will update the page title for the `/data` page to `Data - Discovery Environment`, the `/apps` listing page to `Apps - Discovery Environment`, the `/help` page to `Help - Discovery Environment`, etc.

Some pages will add additional info to the page title, if available.

For example, when viewing the details of a collection or team, the collection or team name will also display in the title, as `Collection - name - Discovery Environment` or `Team - name - Discovery Environment`; and when a user navigates to their home folder under `/data/ds/cyverse/home/user`, then the page title will display as `Data - /cyverse/home/user - Discovery Environment`.

When viewing subfolders of a user's home folder, then only the name of the current file or folder will display in the title (e.g. `Data - current_folder - Discovery Environment`).

App categories will also display in the page title when viewing the different app listings, but because the category names usually also contain the word "App", then the title will not have `App - ` prepended to it (e.g. just `Favorite Apps - Discovery Environment`).