### PR TITLE
CORE-1936 MUI v5 fixes

### DIFF
--- a/src/components/analyses/AnalysisCommentDialog.js
+++ b/src/components/analyses/AnalysisCommentDialog.js
@@ -105,7 +105,7 @@ function AnalysisCommentDialog(props) {
                                 </Button>
                                 <Button
                                     id={buildID(baseId, UtilIds.DIALOG.CONFIRM)}
-                                    color="primary"
+                                    variant="contained"
                                     type="submit"
                                     onClick={handleSubmit}
                                 >

--- a/src/components/analyses/RenameAnalysisDialog.js
+++ b/src/components/analyses/RenameAnalysisDialog.js
@@ -122,7 +122,7 @@ function RenameAnalysisDialog(props) {
                                 </Button>
                                 <Button
                                     id={buildID(baseId, UtilIds.DIALOG.CONFIRM)}
-                                    color="primary"
+                                    variant="contained"
                                     type="submit"
                                     onClick={handleSubmit}
                                 >

--- a/src/components/analyses/details/InfoPanel.js
+++ b/src/components/analyses/details/InfoPanel.js
@@ -109,7 +109,7 @@ function InfoPanel(props) {
         return <GridLoading rows={2} baseId={baseId} />;
     }
 
-    if (!info && !isInfoFetching && !infoFetchError) {
+    if (!(info?.steps || isInfoFetching || infoFetchError)) {
         return null;
     }
 

--- a/src/components/apps/AgaveAuthPromptDialog.js
+++ b/src/components/apps/AgaveAuthPromptDialog.js
@@ -62,7 +62,7 @@ function AgaveAuthPromptDialog(props) {
                 </Button>
                 <Button
                     onClick={redirectUser}
-                    color="primary"
+                    variant="contained"
                     id={buildID(
                         baseId,
                         ids.AGAVE_AUTH_PROMPT_DIALOG,

--- a/src/components/apps/PublishAppDialog.js
+++ b/src/components/apps/PublishAppDialog.js
@@ -249,7 +249,7 @@ export default function PublishAppDialog(props) {
                                     <Button
                                         id={buildID(parentId, ids.SUBMIT_BTN)}
                                         type="submit"
-                                        color="primary"
+                                        variant="contained"
                                         onClick={handleSubmit}
                                     >
                                         {i18nCommon("submit")}

--- a/src/components/apps/admin/details/AdminAppDetails.js
+++ b/src/components/apps/admin/details/AdminAppDetails.js
@@ -209,7 +209,7 @@ function AdminAppDetailsForm(props) {
                         <Button
                             id={buildID(parentId, ids.SAVE_BTN)}
                             type="submit"
-                            color="primary"
+                            variant="contained"
                             onClick={handleSubmit}
                         >
                             {i18nCommon("save")}

--- a/src/components/apps/admin/referenceGenomes/Edit.js
+++ b/src/components/apps/admin/referenceGenomes/Edit.js
@@ -167,7 +167,7 @@ function Edit(props) {
                             <Button
                                 id={buildID(baseId, ids.OK_BUTTON)}
                                 className={classes.actionButton}
-                                color="primary"
+                                variant="contained"
                                 type="submit"
                             >
                                 {t("ok")}

--- a/src/components/dashboard/DashboardSection.js
+++ b/src/components/dashboard/DashboardSection.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import clsx from "clsx";
 
-import { Typography, Collapse, Button, useTheme, Divider } from "@mui/material";
+import { Typography, Collapse, Button, Divider } from "@mui/material";
 
 import getItem from "./dashboardItem";
 
@@ -9,9 +9,10 @@ import useStyles from "./styles";
 import * as fns from "./functions";
 import * as constants from "./constants";
 import ids from "./ids";
-import { useTranslation } from "i18n";
 
 const DashboardSection = ({
+    t,
+    theme,
     name,
     kind,
     items,
@@ -29,9 +30,7 @@ const DashboardSection = ({
     computeLimitExceeded,
 }) => {
     const classes = useStyles();
-    const { t } = useTranslation("dashboard");
     const [expanded, setExpanded] = useState(false);
-    const theme = useTheme();
 
     const isNewsSection = section === constants.SECTION_NEWS;
     const isEventsSection = section === constants.SECTION_EVENTS;
@@ -115,6 +114,7 @@ class SectionBase {
 
     getComponent({
         t,
+        theme,
         cardWidth,
         cardHeight,
         data,
@@ -169,6 +169,8 @@ class SectionBase {
                 setPendingAnalysis={setPendingAnalysis}
                 setTerminateAnalysis={setTerminateAnalysis}
                 computeLimitExceeded={computeLimitExceeded}
+                t={t}
+                theme={theme}
             />
         );
     }

--- a/src/components/dashboard/dashboardItem/AnalysisItem.js
+++ b/src/components/dashboard/dashboardItem/AnalysisItem.js
@@ -8,7 +8,7 @@ import {
     Cancel,
     Launch,
 } from "@mui/icons-material";
-import { IconButton, useTheme } from "@mui/material";
+import { IconButton } from "@mui/material";
 
 import { formatDate } from "components/utils/DateFormatter";
 
@@ -20,7 +20,6 @@ import { getFolderPage } from "../../data/utils";
 
 import NavConstants from "../../../common/NavigationConstants";
 import { isTerminated } from "components/analyses/utils";
-import { useTranslation } from "i18n";
 import { isInteractive, openInteractiveUrl } from "components/analyses/utils";
 
 class AnalysisItem extends ItemBase {
@@ -36,11 +35,14 @@ class AnalysisItem extends ItemBase {
 
     static create(props) {
         const analysis = props.content;
-        const { setDetailsAnalysis, setPendingAnalysis, setTerminateAnalysis } =
-            props;
+        const {
+            setDetailsAnalysis,
+            setPendingAnalysis,
+            setTerminateAnalysis,
+            t,
+            theme,
+        } = props;
         const item = new AnalysisItem(props);
-        const { t } = useTranslation("dashboard");
-        const theme = useTheme();
         const isTerminatedAnalysis = isTerminated(analysis);
         const isVICE = isInteractive(analysis);
         const interactiveUrls = analysis?.interactive_urls;

--- a/src/components/dashboard/dashboardItem/AppItem.js
+++ b/src/components/dashboard/dashboardItem/AppItem.js
@@ -12,10 +12,8 @@ import { appFavorite, APP_BY_ID_QUERY_KEY } from "serviceFacades/apps";
 
 import * as constants from "../constants";
 import ItemBase, { ItemAction } from "./ItemBase";
-import { useTranslation } from "i18n";
 import AppFavorite from "components/apps/AppFavorite";
 import { useAppLaunchLink } from "components/apps/utils";
-import { useTheme } from "@mui/material";
 
 class AppItem extends ItemBase {
     constructor(props) {
@@ -30,9 +28,7 @@ class AppItem extends ItemBase {
 
     static create(props) {
         const item = new AppItem(props);
-        const { showErrorAnnouncer, setDetailsApp } = props;
-        const { t } = useTranslation("dashboard");
-        const theme = useTheme();
+        const { showErrorAnnouncer, setDetailsApp, t, theme } = props;
 
         // Extract app details. Note: dashboard-aggregator only queries the DE database.
         const app = props.content;

--- a/src/components/dashboard/dashboardItem/EventItem.js
+++ b/src/components/dashboard/dashboardItem/EventItem.js
@@ -13,7 +13,6 @@ import * as fns from "../functions";
 import * as constants from "../constants";
 
 import ItemBase, { ItemAction, DashboardFeedItem } from "./ItemBase";
-import { useTranslation } from "i18n";
 
 class EventItem extends ItemBase {
     constructor({ section, content, height, width }) {
@@ -28,7 +27,7 @@ class EventItem extends ItemBase {
 
     static create(props) {
         const item = new EventItem(props);
-        const { t } = useTranslation("dashboard");
+        const { t } = props;
         return item.addActions([
             <ItemAction
                 ariaLabel={t("tweetAria")}

--- a/src/components/dashboard/dashboardItem/InstantLaunchItems.js
+++ b/src/components/dashboard/dashboardItem/InstantLaunchItems.js
@@ -54,6 +54,10 @@ class InstantLaunchItem extends ItemBase {
                     instantLaunch={instantLaunch}
                     showErrorAnnouncer={showErrorAnnouncer}
                     computeLimitExceeded={computeLimitExceeded}
+                    style={{
+                        margin: theme.spacing(1),
+                    }}
+                    size="small"
                 />
             </ItemAction>,
 

--- a/src/components/dashboard/dashboardItem/NewsItem.js
+++ b/src/components/dashboard/dashboardItem/NewsItem.js
@@ -12,7 +12,6 @@ import * as fns from "../functions";
 import * as constants from "../constants";
 
 import ItemBase, { ItemAction, DashboardFeedItem } from "./ItemBase";
-import { useTranslation } from "i18n";
 
 class NewsItem extends ItemBase {
     constructor({ section, content, height, width }) {
@@ -27,7 +26,7 @@ class NewsItem extends ItemBase {
 
     static create(props) {
         const item = new NewsItem(props);
-        const { t } = useTranslation("dashboard");
+        const { t } = props;
 
         return item.addActions([
             <ItemAction

--- a/src/components/dashboard/dashboardItem/Tour.js
+++ b/src/components/dashboard/dashboardItem/Tour.js
@@ -64,7 +64,7 @@ export default function Tour(props) {
                         <Button
                             id={buildID(baseId, ids.TOUR_BTN)}
                             size="small"
-                            color="primary"
+                            variant="contained"
                             onClick={() => setRunTour(true)}
                         >
                             {t("startTour")}

--- a/src/components/dashboard/index.js
+++ b/src/components/dashboard/index.js
@@ -12,7 +12,7 @@ import clsx from "clsx";
 import { useQueryClient, useQuery, useMutation } from "react-query";
 import { useTranslation } from "i18n";
 
-import { Typography } from "@mui/material";
+import { Typography, useTheme } from "@mui/material";
 
 import { Skeleton } from "@mui/material";
 
@@ -118,6 +118,7 @@ const Dashboard = (props) => {
     const [userProfile] = useUserProfile();
     const [config] = useConfig();
     const queryClient = useQueryClient();
+    const theme = useTheme();
 
     const [resourceUsageSummary, setResourceUsageSummary] = useState(null);
     const [resourceUsageError, setResourceUsageError] = useState(null);
@@ -261,6 +262,7 @@ const Dashboard = (props) => {
               .map((section) =>
                   section.getComponent({
                       t,
+                      theme,
                       data,
                       cardWidth,
                       cardHeight,

--- a/src/components/data/CreateFolderDialog.js
+++ b/src/components/data/CreateFolderDialog.js
@@ -151,7 +151,7 @@ function CreateFolderDialog(props) {
                                 </Button>
                                 <Button
                                     id={buildID(baseId, ids.CREATE_BTN)}
-                                    color="primary"
+                                    variant="contained"
                                     type="submit"
                                     onClick={handleSubmit}
                                 >

--- a/src/components/data/MoveDialog.js
+++ b/src/components/data/MoveDialog.js
@@ -88,7 +88,7 @@ function MoveDialog(props) {
                                     </Button>
                                     <Button
                                         id={buildID(baseId, ids.MOVE_BTN)}
-                                        color="primary"
+                                        variant="contained"
                                         type="submit"
                                         onClick={handleSubmit}
                                     >

--- a/src/components/data/PathListAutomation.js
+++ b/src/components/data/PathListAutomation.js
@@ -459,7 +459,7 @@ export default function PathListAutomation(props) {
                                                 baseId,
                                                 ids.PATH_LIST_AUTO_DONE_BTN
                                             )}
-                                            color="primary"
+                                            variant="contained"
                                             type="submit"
                                             onClick={handleSubmit}
                                         >

--- a/src/components/data/RenameDialog.js
+++ b/src/components/data/RenameDialog.js
@@ -107,7 +107,7 @@ function RenameDialog(props) {
                                     </Button>
                                     <Button
                                         id={buildID(baseId, ids.RENAME_BTN)}
-                                        color="primary"
+                                        variant="contained"
                                         type="submit"
                                         onClick={handleSubmit}
                                     >

--- a/src/components/data/SaveAsDialog.js
+++ b/src/components/data/SaveAsDialog.js
@@ -69,7 +69,7 @@ function SaveAsDialog(props) {
                                     </Button>
                                     <Button
                                         id={buildID(baseId, ids.CREATE_BTN)}
-                                        color="primary"
+                                        variant="contained"
                                         type="submit"
                                         onClick={handleSubmit}
                                     >

--- a/src/components/data/SelectionDrawer.js
+++ b/src/components/data/SelectionDrawer.js
@@ -337,10 +337,12 @@ function SelectionDrawer(props) {
             onClose={onClose}
             open={open}
             anchor="right"
+            elevation={0}
             PaperProps={{
                 variant: "outlined",
                 classes: { root: classes.selectionDrawer },
             }}
+            sx={{ zIndex: "modal" }}
         >
             <div
                 style={{

--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -773,7 +773,7 @@ function Listing(props) {
                             {t("cancel")}
                         </Button>
                         <Button
-                            color="primary"
+                            variant="contained"
                             onClick={() => {
                                 setConfirmDOIRequestDialogOpen(false);
                                 requestDOI({

--- a/src/components/data/listing/TableView.js
+++ b/src/components/data/listing/TableView.js
@@ -36,6 +36,7 @@ import {
     TableBody,
     TableCell,
     TableContainer,
+    useTheme,
 } from "@mui/material";
 
 import makeStyles from "@mui/styles/makeStyles";
@@ -154,11 +155,13 @@ function TableView(props) {
         instantLaunchDefaultsMapping,
         computeLimitExceeded,
     } = props;
+
     const invalidRowClass = invalidRowStyles();
     const { t } = useTranslation("data");
     const dataRecordFields = dataFields(t);
     const tableId = buildID(baseId, ids.LISTING_TABLE);
     const trashPath = useBaseTrashPath();
+    const theme = useTheme();
 
     const [displayColumns, setDisplayColumns] = useState(
         getLocalStorageCols(rowDotMenuVisibility, dataRecordFields) ||
@@ -403,7 +406,10 @@ function TableView(props) {
                                                     resource={resource}
                                                     size="small"
                                                     color="default"
-                                                    themeSpacing={3}
+                                                    style={{
+                                                        marginLeft:
+                                                            theme.spacing(3),
+                                                    }}
                                                     computeLimitExceeded={
                                                         computeLimitExceeded
                                                     }

--- a/src/components/data/viewers/FileTypeSelectionDialog.js
+++ b/src/components/data/viewers/FileTypeSelectionDialog.js
@@ -50,7 +50,7 @@ export default function FileTypeSelectionDialog(props) {
                     </Button>
                     <Button
                         id={buildID(baseId, ids.CREATE_BTN)}
-                        color="primary"
+                        variant="contained"
                         onClick={() => onFileTypeSelected(type)}
                     >
                         {i18nCommon("create")}

--- a/src/components/data/viewers/PathListViewer.js
+++ b/src/components/data/viewers/PathListViewer.js
@@ -23,6 +23,7 @@ import Toolbar from "./Toolbar";
 import { getColumns, LINE_NUMBER_ACCESSOR } from "./utils";
 
 import DataSelectionDrawer from "components/data/SelectionDrawer";
+import { useSelectorDefaultFolderPath } from "components/data/utils";
 import PageWrapper from "components/layout/PageWrapper";
 
 import withErrorAnnouncer from "components/error/withErrorAnnouncer";
@@ -67,6 +68,7 @@ function PathListViewer(props) {
         fileName,
         data,
         editable,
+        startingPath,
     } = props;
 
     const { t } = useTranslation("data");
@@ -75,6 +77,8 @@ function PathListViewer(props) {
     const [dirty, setDirty] = useState(false);
     const [editorData, setEditorData] = useState([]);
     const [fileSaveStatus, setFileSaveStatus] = useState();
+
+    const defaultStartingPath = useSelectorDefaultFolderPath();
 
     const columns = useMemo(
         () => getColumns(data, false, t("path")),
@@ -266,6 +270,7 @@ function PathListViewer(props) {
                         }
                     }}
                     multiSelect={true}
+                    startingPath={startingPath || defaultStartingPath}
                 />
             </UploadTrackingProvider>
         </PageWrapper>

--- a/src/components/help/Feedback.js
+++ b/src/components/help/Feedback.js
@@ -98,7 +98,7 @@ export default function Feedback(props) {
                                     </Button>
                                     <Button
                                         type="submit"
-                                        color="primary"
+                                        variant="contained"
                                         onClick={handleSubmit}
                                     >
                                         {i18nHelp("submit_feedback")}

--- a/src/components/instantlaunches/index.js
+++ b/src/components/instantlaunches/index.js
@@ -7,7 +7,6 @@ import {
     IconButton,
     LinearProgress,
     Typography,
-    useTheme,
 } from "@mui/material";
 
 import makeStyles from "@mui/styles/makeStyles";
@@ -93,12 +92,11 @@ const InstantLaunchButton = ({
     instantLaunch,
     resource = {},
     size = "medium",
-    themeSpacing = 0,
+    style,
     color = "primary",
     computeLimitExceeded = false,
 }) => {
     const baseID = buildID(ids.BASE, ids.LAUNCH, ids.BUTTON);
-    const theme = useTheme();
 
     return (
         <InstantLaunchButtonWrapper
@@ -110,7 +108,7 @@ const InstantLaunchButton = ({
                     id={baseID}
                     variant="contained"
                     size={size}
-                    style={{ marginLeft: theme.spacing(themeSpacing) }}
+                    style={style}
                     color={color}
                     onClick={onClick}
                 >

--- a/src/components/metadata/ApplyBulkMetadataDialog.js
+++ b/src/components/metadata/ApplyBulkMetadataDialog.js
@@ -83,7 +83,7 @@ export default function ApplyBulkMetadataDialog(props) {
                                     <Button
                                         id={buildID(baseId, ids.COPY_BUTTON)}
                                         type="submit"
-                                        color="primary"
+                                        variant="contained"
                                         onClick={handleSubmit}
                                     >
                                         {i18nCommon("done")}

--- a/src/components/metadata/CopyMetadataDialog.js
+++ b/src/components/metadata/CopyMetadataDialog.js
@@ -62,7 +62,7 @@ export default function CopyMetadataDialog(props) {
                                     <Button
                                         id={buildID(baseId, ids.COPY_BUTTON)}
                                         type="submit"
-                                        color="primary"
+                                        variant="contained"
                                         onClick={handleSubmit}
                                     >
                                         {i18nCommon("copy")}

--- a/src/components/metadata/form/AVUFormList.js
+++ b/src/components/metadata/form/AVUFormList.js
@@ -99,7 +99,7 @@ const AVUFormDialog = (props) => {
                     <span>
                         <Button
                             id={buildID(formID, ids.BUTTONS.DONE)}
-                            color="primary"
+                            variant="contained"
                             onClick={onClose}
                         >
                             {t("done")}

--- a/src/components/metadata/templates/Listing.js
+++ b/src/components/metadata/templates/Listing.js
@@ -120,7 +120,7 @@ const MetadataTemplateListing = (props) => {
                 <Button
                     key={ids.BUTTONS.CONFIRM}
                     id={buildID(dialogID, ids.BUTTONS.CONFIRM)}
-                    color="primary"
+                    variant="contained"
                     onClick={() =>
                         selectedTemplateId &&
                         onSelectTemplate(selectedTemplateId)

--- a/src/components/metadata/templates/index.js
+++ b/src/components/metadata/templates/index.js
@@ -509,7 +509,7 @@ const MetadataTemplateForm = (props) => {
                         )}
                         disabled={loading || isSubmitting}
                         onClick={handleSubmitWrapper}
-                        color="primary"
+                        variant="contained"
                     >
                         {t("save")}
                     </Button>

--- a/src/components/notifications/dialogs/AdminJoinTeamRequestDialog.js
+++ b/src/components/notifications/dialogs/AdminJoinTeamRequestDialog.js
@@ -316,7 +316,7 @@ function AdminJoinTeamRequestDialog(props) {
                         {t("common:cancel")}
                     </Button>
                     <Button
-                        color="primary"
+                        variant="contained"
                         id={buildID(baseId, ids.ADMIN_JOIN_TEAM.SUBMIT_BTN)}
                         onClick={handleSubmit}
                     >

--- a/src/components/notifications/dialogs/JoinTeamDeniedDialog.js
+++ b/src/components/notifications/dialogs/JoinTeamDeniedDialog.js
@@ -35,7 +35,7 @@ function JoinTeamDeniedDialog(props) {
             title={t("denyDetailsHeader")}
             actions={
                 <Button
-                    color="primary"
+                    variant="contained"
                     id={buildID(baseId, ids.OK_BTN)}
                     onClick={handleClose}
                 >

--- a/src/components/preferences/Preferences.js
+++ b/src/components/preferences/Preferences.js
@@ -616,7 +616,7 @@ function Preferences(props) {
                                         onClick={restoreDefaults(
                                             props.setFieldValue
                                         )}
-                                        color="primary"
+                                        variant="contained"
                                     >
                                         {t("okBtnLbl")}
                                     </Button>

--- a/src/components/sharing/index.js
+++ b/src/components/sharing/index.js
@@ -359,7 +359,7 @@ function Sharing(props) {
                 </Button>
                 <Button
                     id={buildID(baseId, ids.BUTTONS.SAVE)}
-                    color="primary"
+                    variant="contained"
                     type="submit"
                     onClick={onSave}
                 >

--- a/src/components/subscriptions/edit/AddSubAddon.js
+++ b/src/components/subscriptions/edit/AddSubAddon.js
@@ -82,8 +82,7 @@ function AddSubAddonsDialog(props) {
                                 <Button
                                     id={buildID(parentId, ids.SUBMIT_BUTTON)}
                                     type="submit"
-                                    color="primary"
-                                    variant="outlined"
+                                    variant="contained"
                                     onClick={handleSubmit}
                                 >
                                     {t("submit")}

--- a/src/components/subscriptions/edit/EditQuotas.js
+++ b/src/components/subscriptions/edit/EditQuotas.js
@@ -93,8 +93,7 @@ function EditQuotasDialog(props) {
                                             ids.SUBMIT_BUTTON
                                         )}
                                         type="submit"
-                                        color="primary"
-                                        variant="outlined"
+                                        variant="contained"
                                         onClick={handleSubmit}
                                     >
                                         {t("submit")}

--- a/src/components/subscriptions/edit/EditSubAddons.js
+++ b/src/components/subscriptions/edit/EditSubAddons.js
@@ -152,9 +152,8 @@ function EditSubAddonsDialog(props) {
                                                         parentId,
                                                         ids.SUBMIT_BUTTON
                                                     )}
-                                                    variant="outlined"
                                                     type="submit"
-                                                    color="primary"
+                                                    variant="contained"
                                                     onClick={handleSubmit}
                                                 >
                                                     {t("submit")}

--- a/src/components/subscriptions/edit/EditSubscription.js
+++ b/src/components/subscriptions/edit/EditSubscription.js
@@ -154,8 +154,7 @@ function EditSubscriptionDialog(props) {
                                             ids.SUBMIT_BUTTON
                                         )}
                                         type="submit"
-                                        color="primary"
-                                        variant="outlined"
+                                        variant="contained"
                                         onClick={handleSubmit}
                                     >
                                         {t("submit")}

--- a/src/components/teams/dialogs/JoinTeamDialog.js
+++ b/src/components/teams/dialogs/JoinTeamDialog.js
@@ -78,7 +78,7 @@ function JoinTeamDialog(props) {
                                 </Button>
                                 <Button
                                     id={buildID(baseId, ids.BUTTONS.JOIN_BTN)}
-                                    color="primary"
+                                    variant="contained"
                                     type="submit"
                                     onClick={handleSubmit}
                                 >

--- a/src/components/tools/NewToolRequestDialog.js
+++ b/src/components/tools/NewToolRequestDialog.js
@@ -79,7 +79,7 @@ export default function NewToolRequestDialog(props) {
                             title={t("newToolRequestDialogHeading")}
                             actions={
                                 <Button
-                                    color="primary"
+                                    variant="contained"
                                     type="submit"
                                     id={buildID(baseId, ids.BUTTONS.SUBMIT)}
                                     aria-label={t("submit")}

--- a/src/components/tools/ToolSelectionDialog.js
+++ b/src/components/tools/ToolSelectionDialog.js
@@ -65,7 +65,7 @@ export default function ToolSelectionDialog(props) {
                 <>
                     <Button onClick={onClose}>{t("common:cancel")}</Button>
                     <Button
-                        color="primary"
+                        variant="contained"
                         onClick={() => {
                             onConfirm(selectedTool);
                         }}

--- a/src/components/tools/edit/EditTool.js
+++ b/src/components/tools/edit/EditTool.js
@@ -245,7 +245,7 @@ function EditToolDialog(props) {
                                                 ids.BUTTONS.SAVE
                                             )}
                                             type="submit"
-                                            color="primary"
+                                            variant="contained"
                                             onClick={handleSubmit}
                                         >
                                             {isAdminPublishing
@@ -394,7 +394,7 @@ function EditToolDialog(props) {
                                 setShowOverwriteWarningDialog(false);
                                 setOverwriteAppsAffectedByTool(true);
                             }}
-                            color="primary"
+                            variant="contained"
                         >
                             {t("overwrite")}
                         </Button>

--- a/src/components/tools/requests/Details.js
+++ b/src/components/tools/requests/Details.js
@@ -61,7 +61,7 @@ function DetailsDialog(props) {
                                 <Button
                                     id={buildID(parentId, ids.BUTTONS.OK)}
                                     type="submit"
-                                    color="primary"
+                                    variant="contained"
                                     onClick={onClose}
                                 >
                                     {i18nCommon("ok")}

--- a/src/components/uploads/dialog/index.js
+++ b/src/components/uploads/dialog/index.js
@@ -81,7 +81,7 @@ const UploadDialog = ({ open, handleClose = () => {} }) => {
                 <Button
                     id={buildID(ids.BASE, ids.CLOSE)}
                     onClick={handleClose}
-                    color="primary"
+                    variant="contained"
                     aria-label={t("closeAria")}
                 >
                     {t("close")}

--- a/src/components/utils/UpdateRequestDialog.js
+++ b/src/components/utils/UpdateRequestDialog.js
@@ -147,7 +147,7 @@ export default function UpdateRequestDialog(props) {
                                         {t("cancel")}
                                     </Button>
                                     <Button
-                                        color="primary"
+                                        variant="contained"
                                         type="submit"
                                         id={buildID(baseId, ids.SUBMIT_BTN)}
                                         aria-label={t("updateRequest")}

--- a/src/components/vice/AccessRequestDialog.js
+++ b/src/components/vice/AccessRequestDialog.js
@@ -90,7 +90,7 @@ export default function AccessRequestDialog(props) {
                                             ids.ACCESS_REQUEST_DLG.SUBMIT
                                         )}
                                         type="submit"
-                                        color="primary"
+                                        variant="contained"
                                         onClick={handleSubmit}
                                     >
                                         {i18nCommon("submit")}

--- a/src/components/vice/RunErrorDialog.js
+++ b/src/components/vice/RunErrorDialog.js
@@ -30,7 +30,7 @@ const RunErrorDialog = (props) => {
             title={title}
             open={open}
             actions={
-                <Button color="primary" onClick={onClose}>
+                <Button variant="contained" onClick={onClose}>
                     {t("common:ok")}
                 </Button>
             }

--- a/src/components/vice/admin/accessRequests/Listing.js
+++ b/src/components/vice/admin/accessRequests/Listing.js
@@ -208,7 +208,7 @@ function Listing(props) {
                         <Button onClick={() => setJobLimitDialogOpen(false)}>
                             {i18nCommon("cancel")}
                         </Button>
-                        <Button color="primary" onClick={onSetJobLimit}>
+                        <Button variant="contained" onClick={onSetJobLimit}>
                             {i18nCommon("done")}
                         </Button>
                     </>
@@ -255,7 +255,7 @@ function Listing(props) {
                         <Button onClick={() => setDeniedMsgDialogOpen(false)}>
                             {i18nCommon("cancel")}
                         </Button>
-                        <Button color="primary" onClick={onRejectRequest}>
+                        <Button variant="contained" onClick={onRejectRequest}>
                             {i18nCommon("done")}
                         </Button>
                     </>

--- a/src/components/vice/loading/ContactSupportDialog.js
+++ b/src/components/vice/loading/ContactSupportDialog.js
@@ -136,7 +136,7 @@ function ContactSupportDialog(props) {
                         {t("common:cancel")}
                     </Button>
                     <Button
-                        color="primary"
+                        variant="contained"
                         id={buildID(baseId, ids.CONTACT_SUPPORT_BTN)}
                         onClick={onContactSupport}
                     >

--- a/stories/analyses/Listing.stories.js
+++ b/stories/analyses/Listing.stories.js
@@ -6,7 +6,7 @@ import constants from "../../src/constants";
 
 import { mockAxios } from "../axiosMock";
 
-import { listing } from "./AnalysesMocks";
+import { info, listing } from "./AnalysesMocks";
 
 import Listing from "components/analyses/listing/Listing";
 import analysisFields from "components/analyses/analysisFields";
@@ -71,7 +71,8 @@ const errorResponse = {
 };
 
 export const AnalysesListingTest = () => {
-    mockAxios.onGet(/\/api\/analyses*/).reply(200, listing);
+    mockAxios.onGet(new RegExp("/api/analyses/.*/history")).reply(200, info);
+    mockAxios.onGet("/api/analyses").reply(200, listing);
 
     mockAxios.onPost("/api/analyses/relauncher").replyOnce(500, errorResponse);
     mockAxios.onPost("/api/analyses/relauncher").reply((config) => {


### PR DESCRIPTION
This PR will add some fixes for changes introduced by MUI v5 added in #554.

* Updated dialog action buttons to `contained` variants, since the `Button` component now uses the `primary` color by default, and most of our dialog primary action buttons now looked the same as "cancel" buttons. The `contained` variant should also help the primary action to stand out more.
* Updated data selection drawer `zIndex` to `modal`.
  * The data selection drawer `zIndex` was less than the `zIndex` for dialogs in MUI v5, so it was hidden behind dialogs like the data move or copy metadata dialogs.

This PR also includes some fixes not related to the MUI v5 upgrade, but are for bugs that I came across during testing; such as a `startingPath` warning in the `PathListViewer`, and a `client-side exception has occurred` error that can display after launching analyses and navigating away and then back to the dashboard.

See visual changes in [Chromatic](https://www.chromatic.com/build?appId=5ebad5c6b991d60022b1e72e&number=2653).