### PR TITLE
CORE-1971: Add the include-defaults flag to the endpoint for 'getToolDetails'.

### DIFF
--- a/src/serviceFacades/tools.js
+++ b/src/serviceFacades/tools.js
@@ -81,9 +81,11 @@ function getToolPermissions({ tools }) {
     });
 }
 
-function getToolDetails({ id, isAdmin = false }) {
+function getToolDetails({ id, isAdmin = false, includeDefaults = false }) {
     return callApi({
-        endpoint: isAdmin ? `/api/admin/tools/${id}` : `/api/tools/${id}`,
+        endpoint: isAdmin
+            ? `/api/admin/tools/${id}?include-defaults=${includeDefaults}`
+            : `/api/tools/${id}?include-defaults=${includeDefaults}`,
         method: "GET",
     });
 }


### PR DESCRIPTION
defaults to include-defaults=false since most places that should include them aren't via this endpoint.

I'm not sure if there's more I'll need to do in this service, but it depends on cyverse-de/apps#266 and the corresponding common-swagger-api and terrain PRs anyway.