### PR TITLE
CORE-1967 Initial Local Contexts label display

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -78,6 +78,8 @@ services:
         base: https://www.ebi.ac.uk/ols/api/select
     unified_astronomy_thesaurus:
         base: https://vocabs.ands.org.au/repository/api/lda/aas/the-unified-astronomy-thesaurus/current/concept.json
+    local_contexts:
+        base: https://sandbox.localcontextshub.org/api/v1
 
 grouper:
     allUsers: GrouperAll

--- a/public/static/locales/en/localcontexts.json
+++ b/public/static/locales/en/localcontexts.json
@@ -1,4 +1,5 @@
 {
+    "dataHasLocalContextsLabelsNotices": "This data has associated <ExternalLink href=\"https://localcontexts.org\">Local Contexts</ExternalLink> labels or notices.",
     "localContextsAttrDefaultValue": "The \"{{projectTitle}}\" project has Labels and/or Notices applied through the Local Contexts Hub. For more information, refer to the project page: {{projectPage}}",
     "localContextsHubError": "Error fetching Local Contexts Hub project information.",
     "localContextsHubProjectURI": "Local Contexts Hub Project URI",

--- a/public/static/locales/en/localcontexts.json
+++ b/public/static/locales/en/localcontexts.json
@@ -1,0 +1,3 @@
+{
+    "projectMoreInfoWithLink": "For more information on the <ExternalLink href=\"https://localcontexts.org\">Local Contexts</ExternalLink> project for this data, please visit the project's page: <ProjectLink>{{projectTitle}}</ProjectLink>"
+}

--- a/public/static/locales/en/localcontexts.json
+++ b/public/static/locales/en/localcontexts.json
@@ -1,3 +1,6 @@
 {
+    "localContextsAttrDefaultValue": "The \"{{projectTitle}}\" project has Labels and/or Notices applied through the Local Contexts Hub. For more information, refer to the project page: {{projectPage}}",
+    "localContextsHubError": "Error fetching Local Contexts Hub project information.",
+    "localContextsHubProjectURI": "Local Contexts Hub Project URI",
     "projectMoreInfoWithLink": "For more information on the <ExternalLink href=\"https://localcontexts.org\">Local Contexts</ExternalLink> project for this data, please visit the project's page: <ProjectLink>{{projectTitle}}</ProjectLink>"
 }

--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -280,7 +280,7 @@ function Listing(props) {
     const { data: localContextsProject } = useQuery({
         queryKey: [LOCAL_CONTEXTS_QUERY_KEY, projectID],
         queryFn: () => getLocalContextsProject({ projectID }),
-        enabled: URL.canParse(localContextsProjectURI),
+        enabled: !!localContextsProjectURI,
         onError: (error) =>
             console.log("Error fetching Local Contexts project.", {
                 localContextsProjectURI,

--- a/src/components/data/listing/TableView.js
+++ b/src/components/data/listing/TableView.js
@@ -102,7 +102,7 @@ function ResourceNameCell({
     const { data: project } = useQuery({
         queryKey: [LOCAL_CONTEXTS_QUERY_KEY, projectID],
         queryFn: () => getLocalContextsProject({ projectID }),
-        enabled: URL.canParse(localContextsProjectURI),
+        enabled: !!localContextsProjectURI,
         onError: (error) =>
             console.log("Error fetching Local Contexts project.", {
                 localContextsProjectURI,

--- a/src/components/forms/FormSearchField.js
+++ b/src/components/forms/FormSearchField.js
@@ -18,6 +18,7 @@ const FormSearchField = ({
     form: { setFieldValue, ...form },
     valueKey,
     labelKey,
+    readOnly,
     ...props
 }) => {
     const [searchValue, setSearchValue] = React.useState(value);
@@ -48,6 +49,7 @@ const FormSearchField = ({
     return (
         <Autocomplete
             id={id}
+            readOnly={readOnly}
             isOptionEqualToValue={(option, value) =>
                 option[labelKey] === value[labelKey]
             }

--- a/src/components/metadata/LocalContextsLabelDisplay.js
+++ b/src/components/metadata/LocalContextsLabelDisplay.js
@@ -12,7 +12,10 @@ import {
     useTheme,
 } from "@mui/material";
 
+import { Trans, useTranslation } from "i18n";
+
 import DEDialog from "components/utils/DEDialog";
+import ExternalLink from "components/utils/ExternalLink";
 
 import {
     LOCAL_CONTEXTS_QUERY_KEY,
@@ -26,7 +29,9 @@ const sizeToSpacing = (size, theme) =>
         ? theme.spacing(3)
         : theme.spacing(5);
 
-const LocalContextsLabel = ({ baseId, label, size = "medium" }) => {
+const LocalContextsLabel = ({ baseId, label, project, size = "medium" }) => {
+    const { t } = useTranslation("localcontexts");
+
     const [dialogOpen, setDialogOpen] = React.useState(false);
     const theme = useTheme();
     const labelURI = label.svg_url || label.img_url;
@@ -38,7 +43,8 @@ const LocalContextsLabel = ({ baseId, label, size = "medium" }) => {
                     <img
                         alt={label.name}
                         src={labelURI}
-                        width={sizeToSpacing(size, theme)}
+                        width="auto"
+                        height={sizeToSpacing(size, theme)}
                     />
                 </IconButton>
             </Tooltip>
@@ -48,19 +54,44 @@ const LocalContextsLabel = ({ baseId, label, size = "medium" }) => {
                 title={label.name}
                 onClose={() => setDialogOpen(false)}
             >
-                <Card sx={{ display: "flex" }}>
-                    <CardMedia
-                        component="img"
-                        title={label.name}
-                        image={labelURI}
-                        sx={{
-                            width: theme.spacing(16),
-                            height: theme.spacing(16),
-                        }}
-                    />
+                <Card>
+                    <Stack direction={"row"}>
+                        <CardMedia
+                            component="img"
+                            title={label.name}
+                            image={labelURI}
+                            sx={{
+                                width: "auto",
+                                height: theme.spacing(16),
+                            }}
+                        />
+                        <CardContent>
+                            <Typography
+                                sx={{
+                                    mb: theme.spacing(2),
+                                    textWrap: "balance",
+                                }}
+                            >
+                                {label.label_text || label.default_text}
+                            </Typography>
+                        </CardContent>
+                    </Stack>
+
                     <CardContent>
-                        <Typography sx={{ textWrap: "balance" }}>
-                            {label.default_text}
+                        <Typography>
+                            <Trans
+                                t={t}
+                                i18nKey="projectMoreInfoWithLink"
+                                values={{ projectTitle: project.title }}
+                                components={{
+                                    ExternalLink: <ExternalLink />,
+                                    ProjectLink: (
+                                        <ExternalLink
+                                            href={project.project_page}
+                                        />
+                                    ),
+                                }}
+                            />
                         </Typography>
                     </CardContent>
                 </Card>
@@ -113,6 +144,7 @@ const LocalContextsLabelDisplay = ({ rightsURI, size = "medium" }) => {
                     baseId={label.unique_id || label.img_url}
                     size={size}
                     label={label}
+                    project={project}
                 />
             ))}
         </Stack>

--- a/src/components/metadata/LocalContextsLabelDisplay.js
+++ b/src/components/metadata/LocalContextsLabelDisplay.js
@@ -87,7 +87,7 @@ const LocalContextsLabelDisplay = ({ rightsURI, size = "medium" }) => {
             }),
         enabled: !!projectID,
         onError: (error) => {
-            console.log("Error fetch Local Contexts project.", {
+            console.log("Error fetching Local Contexts project.", {
                 rightsURI,
                 error,
             });
@@ -96,9 +96,9 @@ const LocalContextsLabelDisplay = ({ rightsURI, size = "medium" }) => {
 
     const labels = [
         ...(project?.notice || []),
-        ...(project?.bclabels || []),
-        ...(project?.tklabels || []),
-    ].filter((url) => url);
+        ...(project?.bc_labels || []),
+        ...(project?.tk_labels || []),
+    ].filter((label) => label);
 
     return (
         <Stack

--- a/src/components/metadata/LocalContextsLabelDisplay.js
+++ b/src/components/metadata/LocalContextsLabelDisplay.js
@@ -1,6 +1,5 @@
 import React from "react";
 
-import { useQuery } from "react-query";
 import {
     Card,
     CardContent,
@@ -16,11 +15,6 @@ import { Trans, useTranslation } from "i18n";
 
 import DEDialog from "components/utils/DEDialog";
 import ExternalLink from "components/utils/ExternalLink";
-
-import {
-    LOCAL_CONTEXTS_QUERY_KEY,
-    getLocalContextsProject,
-} from "serviceFacades/metadata";
 
 const sizeToSpacing = (size, theme) =>
     size === "large"
@@ -100,31 +94,7 @@ const LocalContextsLabel = ({ baseId, label, project, size = "medium" }) => {
     );
 };
 
-const LocalContextsLabelDisplay = ({ rightsURI, size = "medium" }) => {
-    // Remove any trailing slash from the rightsURI
-    // and take the final part of the path as the project ID.
-    const projectID = rightsURI?.replace(/\/$/, "").split("/").at(-1);
-
-    const { data: project } = useQuery({
-        queryKey: [
-            LOCAL_CONTEXTS_QUERY_KEY,
-            projectID && {
-                projectID,
-            },
-        ],
-        queryFn: () =>
-            getLocalContextsProject({
-                projectID,
-            }),
-        enabled: !!projectID,
-        onError: (error) => {
-            console.log("Error fetching Local Contexts project.", {
-                rightsURI,
-                error,
-            });
-        },
-    });
-
+const LocalContextsLabelDisplay = ({ project, size = "medium" }) => {
     const labels = [
         ...(project?.notice || []),
         ...(project?.bc_labels || []),

--- a/src/components/metadata/LocalContextsLabelDisplay.js
+++ b/src/components/metadata/LocalContextsLabelDisplay.js
@@ -1,0 +1,104 @@
+import React from "react";
+
+import { useQuery } from "react-query";
+import {
+    IconButton,
+    Stack,
+    Tooltip,
+    Typography,
+    useTheme,
+} from "@mui/material";
+
+import DEDialog from "components/utils/DEDialog";
+
+import {
+    LOCAL_CONTEXTS_QUERY_KEY,
+    getLocalContextsProject,
+} from "serviceFacades/metadata";
+
+const sizeToSpacing = (size, theme) =>
+    size === "large"
+        ? theme.spacing(8)
+        : size === "small"
+        ? theme.spacing(3)
+        : theme.spacing(5);
+
+const LocalContextsLabel = ({ baseId, label, size = "medium" }) => {
+    const [dialogOpen, setDialogOpen] = React.useState(false);
+    const theme = useTheme();
+    const labelURI = label.svg_url || label.img_url;
+
+    return (
+        <>
+            <Tooltip title={label.name}>
+                <IconButton color="primary" onClick={() => setDialogOpen(true)}>
+                    <img
+                        alt={label.name}
+                        src={labelURI}
+                        width={sizeToSpacing(size, theme)}
+                    />
+                </IconButton>
+            </Tooltip>
+            <DEDialog
+                baseId={baseId}
+                open={dialogOpen}
+                title={label.name}
+                onClose={() => setDialogOpen(false)}
+            >
+                <Typography>{label.default_text}</Typography>
+            </DEDialog>
+        </>
+    );
+};
+
+const LocalContextsLabelDisplay = ({ rightsURI, size = "medium" }) => {
+    // Remove any trailing slash from the rightsURI
+    // and take the final part of the path as the project ID.
+    const projectID = rightsURI?.replace(/\/$/, "").split("/").at(-1);
+
+    const { data: project } = useQuery({
+        queryKey: [
+            LOCAL_CONTEXTS_QUERY_KEY,
+            projectID && {
+                projectID,
+            },
+        ],
+        queryFn: () =>
+            getLocalContextsProject({
+                projectID,
+            }),
+        enabled: !!projectID,
+        onError: (error) => {
+            console.log("Error fetch Local Contexts project.", {
+                rightsURI,
+                error,
+            });
+        },
+    });
+
+    const labels = [
+        ...(project?.notice || []),
+        ...(project?.bclabels || []),
+        ...(project?.tklabels || []),
+    ].filter((url) => url);
+
+    return (
+        <Stack
+            direction="row"
+            spacing={{ xs: 1, sm: 2 }}
+            useFlexGap
+            flexWrap="wrap"
+        >
+            {labels.map((label) => (
+                <LocalContextsLabel
+                    key={label.unique_id || label.img_url}
+                    baseId={label.unique_id || label.img_url}
+                    size={size}
+                    label={label}
+                />
+            ))}
+        </Stack>
+    );
+};
+
+export default LocalContextsLabelDisplay;

--- a/src/components/metadata/LocalContextsLabelDisplay.js
+++ b/src/components/metadata/LocalContextsLabelDisplay.js
@@ -2,6 +2,9 @@ import React from "react";
 
 import { useQuery } from "react-query";
 import {
+    Card,
+    CardContent,
+    CardMedia,
     IconButton,
     Stack,
     Tooltip,
@@ -45,7 +48,22 @@ const LocalContextsLabel = ({ baseId, label, size = "medium" }) => {
                 title={label.name}
                 onClose={() => setDialogOpen(false)}
             >
-                <Typography>{label.default_text}</Typography>
+                <Card sx={{ display: "flex" }}>
+                    <CardMedia
+                        component="img"
+                        title={label.name}
+                        image={labelURI}
+                        sx={{
+                            width: theme.spacing(16),
+                            height: theme.spacing(16),
+                        }}
+                    />
+                    <CardContent>
+                        <Typography sx={{ textWrap: "balance" }}>
+                            {label.default_text}
+                        </Typography>
+                    </CardContent>
+                </Card>
             </DEDialog>
         </>
     );

--- a/src/components/metadata/form/MetadataFormToolbar.js
+++ b/src/components/metadata/form/MetadataFormToolbar.js
@@ -38,6 +38,7 @@ const MetadataFormToolbar = (props) => {
     const {
         baseId,
         title,
+        dirty,
         saveDisabled,
         showSave,
         onSave,
@@ -59,7 +60,7 @@ const MetadataFormToolbar = (props) => {
 
     return (
         <Toolbar variant="dense" className={classes.metadataFormToolbar}>
-            <BackButton />
+            <BackButton dirty={dirty} />
             <Typography
                 id={buildID(baseId, ids.TITLE)}
                 variant="h6"

--- a/src/components/metadata/form/index.js
+++ b/src/components/metadata/form/index.js
@@ -198,6 +198,7 @@ const MetadataFormListing = (props) => {
                     setShowImportConfirmationDialog(true)
                 }
                 targetResource={targetResource}
+                dirty={dirty}
             />
 
             {irodsAVUs?.length > 0 && (

--- a/src/components/metadata/templates/LocalContextsField.js
+++ b/src/components/metadata/templates/LocalContextsField.js
@@ -87,6 +87,8 @@ const LocalContextsField = ({
         return schemeURI;
     });
 
+    const { touched, errors } = form;
+    const fieldError = getFormError(field.name, touched, errors);
     const projectID = parseProjectID(projectHubURI);
 
     const { data: project, isFetching } = useQuery({
@@ -95,7 +97,7 @@ const LocalContextsField = ({
             getLocalContextsProject({
                 projectID,
             }),
-        enabled: URL.canParse(projectHubURI),
+        enabled: projectHubURI && !fieldError,
         onSuccess: (project) => {
             let newValue = avu.value || "";
 
@@ -206,9 +208,7 @@ const LocalContextsField = ({
         }
     };
 
-    const { touched, errors } = form;
-    const errorMsg =
-        getFormError(field.name, touched, errors) || projectHubError;
+    const errorMsg = fieldError || projectHubError;
 
     return (
         <>

--- a/src/components/metadata/templates/LocalContextsField.js
+++ b/src/components/metadata/templates/LocalContextsField.js
@@ -1,0 +1,241 @@
+/**
+ * This custom metadata template field displays only a Local Contexts Hub
+ * project URL field, and auto-populates DataCite metadata and child AVUs using
+ * the project ID parsed from the URL and the Local Contexts Hub API response.
+ *
+ * @author psarando
+ */
+import React from "react";
+
+import { useQuery } from "react-query";
+
+import { useTranslation } from "i18n";
+
+import LocalContextsLabelDisplay from "../LocalContextsLabelDisplay";
+
+import ErrorTypographyWithDialog from "components/error/ErrorTypographyWithDialog";
+import getFormError from "components/forms/getFormError";
+import {
+    LocalContextsAttrs,
+    parseProjectID,
+} from "components/models/metadata/LocalContexts";
+
+import {
+    LOCAL_CONTEXTS_QUERY_KEY,
+    getLocalContextsProject,
+} from "serviceFacades/metadata";
+
+import { Skeleton, TextField } from "@mui/material";
+
+const findAVU = (avus, attr) => avus?.find((avu) => avu.attr === attr);
+
+const LocalContextsField = ({
+    avu,
+    onUpdate,
+    helperText,
+    form: { setFieldValue, ...form },
+    field: { value, onChange, ...field },
+    ...props
+}) => {
+    const { t } = useTranslation("localcontexts");
+
+    const [rightsURIAVU, setRightsURIAVU] = React.useState(
+        () =>
+            findAVU(avu.avus, LocalContextsAttrs.RIGHTS_URI) || {
+                attr: LocalContextsAttrs.RIGHTS_URI,
+                value: "",
+                unit: "",
+            }
+    );
+
+    const [projectHubURI, setProjectHubURI] = React.useState(
+        rightsURIAVU.value
+    );
+
+    const [projectHubError, setProjectHubError] = React.useState();
+
+    const [rightsIDSchemeURIAVU] = React.useState(() => {
+        let rightsIDScheme = findAVU(
+            avu.avus,
+            LocalContextsAttrs.RIGHTS_ID_SCHEME
+        );
+
+        if (
+            rightsIDScheme?.value !== LocalContextsAttrs.RIGHTS_ID_SCHEME_VALUE
+        ) {
+            rightsIDScheme = {
+                attr: LocalContextsAttrs.RIGHTS_ID_SCHEME,
+                value: LocalContextsAttrs.RIGHTS_ID_SCHEME_VALUE,
+                unit: "",
+            };
+        }
+
+        return rightsIDScheme;
+    });
+
+    const [schemeURIAVU] = React.useState(() => {
+        let schemeURI = findAVU(avu.avus, LocalContextsAttrs.SCHEME_URI);
+
+        if (schemeURI?.value !== LocalContextsAttrs.SCHEME_URI_VALUE) {
+            schemeURI = {
+                attr: LocalContextsAttrs.SCHEME_URI,
+                value: LocalContextsAttrs.SCHEME_URI_VALUE,
+                unit: "",
+            };
+        }
+
+        return schemeURI;
+    });
+
+    const projectID = parseProjectID(projectHubURI);
+
+    const { data: project, isFetching } = useQuery({
+        queryKey: [LOCAL_CONTEXTS_QUERY_KEY, projectID],
+        queryFn: () =>
+            getLocalContextsProject({
+                projectID,
+            }),
+        enabled: URL.canParse(projectHubURI),
+        onSuccess: (project) => {
+            let newValue = avu.value || "";
+
+            const projectLabels = [
+                ...(project?.notice?.filter((label) => label?.name) || []),
+                ...(project?.bc_labels?.filter((label) => label?.name) || []),
+                ...(project?.tk_labels?.filter((label) => label?.name) || []),
+            ];
+
+            if (projectLabels.length === 1) {
+                newValue =
+                    projectLabels[0].label_text ||
+                    projectLabels[0].default_text;
+            } else {
+                newValue = t("localContextsAttrDefaultValue", {
+                    projectTitle: project?.title,
+                    projectPage: project?.project_page,
+                });
+            }
+
+            const newLabels = projectLabels.map((label) => label.name);
+
+            let newAVUs = avu.avus || [];
+
+            const currentLabels = newAVUs
+                .filter(
+                    (childAVU) => childAVU.attr === LocalContextsAttrs.RIGHTS_ID
+                )
+                ?.map((childAVU) => childAVU.value);
+
+            const missingLabels = newLabels.filter(
+                (label) => !currentLabels.includes(label)
+            );
+
+            const extraLabels = currentLabels.filter(
+                (label) => !newLabels.includes(label)
+            );
+
+            const requiresUpdate =
+                avu.value !== newValue ||
+                missingLabels.length > 0 ||
+                extraLabels.length > 0;
+
+            if (requiresUpdate) {
+                newAVUs = newAVUs.filter(
+                    (childAVU) =>
+                        childAVU.attr !== LocalContextsAttrs.RIGHTS_URI &&
+                        childAVU.attr !== LocalContextsAttrs.RIGHTS_ID_SCHEME &&
+                        childAVU.attr !== LocalContextsAttrs.SCHEME_URI &&
+                        (childAVU.attr !== LocalContextsAttrs.RIGHTS_ID ||
+                            newLabels.includes(childAVU.value))
+                );
+
+                newAVUs = [
+                    ...newAVUs,
+                    rightsURIAVU,
+                    schemeURIAVU,
+                    rightsIDSchemeURIAVU,
+                    ...missingLabels.map((label) => ({
+                        attr: LocalContextsAttrs.RIGHTS_ID,
+                        value: label,
+                        unit: "",
+                    })),
+                ];
+
+                onUpdate({ ...avu, value: newValue, avus: newAVUs });
+            }
+        },
+        onError: (error) => {
+            setProjectHubError(
+                <ErrorTypographyWithDialog
+                    errorMessage={t("localContextsHubError")}
+                    errorObject={error}
+                />
+            );
+        },
+    });
+
+    const updateProjectHubURI = (uri) => {
+        setProjectHubURI(uri);
+        setProjectHubError(null);
+
+        let newAVUs = avu.avus || [];
+
+        if (rightsURIAVU.value !== uri) {
+            const newRightsURIAVU = {
+                attr: LocalContextsAttrs.RIGHTS_URI,
+                value: uri,
+                unit: "",
+            };
+            setRightsURIAVU(newRightsURIAVU);
+
+            newAVUs = newAVUs.filter(
+                (childAVU) =>
+                    childAVU.attr !== LocalContextsAttrs.RIGHTS_URI &&
+                    childAVU.attr !== LocalContextsAttrs.RIGHTS_ID_SCHEME &&
+                    childAVU.attr !== LocalContextsAttrs.SCHEME_URI
+            );
+
+            newAVUs = [
+                ...newAVUs,
+                newRightsURIAVU,
+                schemeURIAVU,
+                rightsIDSchemeURIAVU,
+            ];
+
+            onUpdate({ ...avu, avus: newAVUs });
+        }
+    };
+
+    const { touched, errors } = form;
+    const errorMsg =
+        getFormError(field.name, touched, errors) || projectHubError;
+
+    return (
+        <>
+            <TextField
+                error={!!errorMsg}
+                helperText={errorMsg || helperText}
+                variant="outlined"
+                margin="dense"
+                size="small"
+                fullWidth
+                placeholder="https://localcontextshub.org/projects/adcbca87-081a-4e2c-b6af-bff12fe3b7b0/"
+                {...field}
+                {...props}
+                label={t("localContextsHubProjectURI")}
+                required
+                value={projectHubURI}
+                onChange={(event) => updateProjectHubURI(event?.target?.value)}
+            />
+            {isFetching ? (
+                <Skeleton variant="rectangular">
+                    <LocalContextsLabelDisplay project={project} />
+                </Skeleton>
+            ) : (
+                <LocalContextsLabelDisplay project={project} />
+            )}
+        </>
+    );
+};
+
+export default LocalContextsField;

--- a/src/components/metadata/templates/index.js
+++ b/src/components/metadata/templates/index.js
@@ -680,10 +680,7 @@ const MetadataTemplateView = (props) => {
                 attributes
                     .filter((attribute) => attribute.required)
                     .forEach((attribute) => {
-                        if (
-                            avus.filter((avu) => avu.attr === attribute.name)
-                                .length < 1
-                        ) {
+                        if (!avus.find((avu) => avu.attr === attribute.name)) {
                             avus.push(newAVU(attribute));
                         }
 
@@ -825,12 +822,11 @@ const MetadataTemplateView = (props) => {
             const attrTemplate = attributeMap[avu.attr];
 
             const isNumberAttr =
-                attrTemplate &&
-                (attrTemplate.type === AttributeTypes.NUMBER ||
-                    attrTemplate.type === AttributeTypes.INTEGER);
+                attrTemplate?.type === AttributeTypes.NUMBER ||
+                attrTemplate?.type === AttributeTypes.INTEGER;
 
             const isGroupingAttr =
-                attrTemplate && attrTemplate.type === AttributeTypes.GROUPING;
+                attrTemplate?.type === AttributeTypes.GROUPING;
 
             const hasChildAVUs = avu.avus && avu.avus.length > 0;
 

--- a/src/components/metadata/templates/index.js
+++ b/src/components/metadata/templates/index.js
@@ -241,7 +241,7 @@ const MetadataTemplateAttributeForm = (props) => {
                             fieldProps = {
                                 ...fieldProps,
                                 searchAstroThesaurusTerms,
-                                isDisabled: !writable,
+                                readOnly: !writable,
                             };
                             break;
 
@@ -251,7 +251,7 @@ const MetadataTemplateAttributeForm = (props) => {
                                 ...fieldProps,
                                 searchOLSTerms,
                                 attribute,
-                                isDisabled: !writable,
+                                readOnly: !writable,
                             };
                             break;
 

--- a/src/components/metadata/templates/index.js
+++ b/src/components/metadata/templates/index.js
@@ -43,6 +43,8 @@ import FormCheckboxStringValue from "components/forms/FormCheckboxStringValue";
 
 import AstroThesaurusSearchField from "./AstroThesaurusSearchField";
 import OntologyLookupServiceSearchField from "./OntologyLookupServiceSearchField";
+
+import LocalContextsLabelDisplay from "../LocalContextsLabelDisplay";
 import SlideUpTransition from "../SlideUpTransition";
 
 import {
@@ -316,6 +318,17 @@ const MetadataTemplateAttributeForm = (props) => {
 
                             const avuField = (
                                 <Fragment key={avuFieldName}>
+                                    {attribute.name === "LocalContexts" && (
+                                        <LocalContextsLabelDisplay
+                                            rightsURI={
+                                                avu.avus?.find(
+                                                    (childAVU) =>
+                                                        childAVU.attr ===
+                                                        "rightsURI"
+                                                )?.value
+                                            }
+                                        />
+                                    )}
                                     <Grid
                                         item
                                         container

--- a/src/components/models/metadata/LocalContexts.js
+++ b/src/components/models/metadata/LocalContexts.js
@@ -1,0 +1,14 @@
+// Remove any trailing slash from the rightsURI
+// and take the final part of the path as the project ID.
+export const parseProjectID = (projectHubURI) =>
+    projectHubURI?.replace(/\/$/, "").split("/").at(-1);
+
+export const LocalContextsAttrs = {
+    LOCAL_CONTEXTS: "LocalContexts",
+    RIGHTS_URI: "rightsURI",
+    RIGHTS_ID: "rightsIdentifier",
+    RIGHTS_ID_SCHEME: "rightsIdentifierScheme",
+    RIGHTS_ID_SCHEME_VALUE: "Local Contexts",
+    SCHEME_URI: "schemeURI",
+    SCHEME_URI_VALUE: "https://localcontexts.org",
+};

--- a/src/pages/data/ds/[...pathItems].js
+++ b/src/pages/data/ds/[...pathItems].js
@@ -205,6 +205,7 @@ export async function getServerSideProps(context) {
             title,
             ...(await serverSideTranslations(locale, [
                 "data",
+                "localcontexts",
                 "metadata",
                 "upload",
                 "urlImport",

--- a/src/server/api/metadata.js
+++ b/src/server/api/metadata.js
@@ -7,7 +7,7 @@
 import express from "express";
 
 import * as auth from "../auth";
-import { olsURL, uatURL } from "../configuration";
+import { localContextsURL, olsURL, uatURL } from "../configuration";
 import logger from "../logging";
 
 import { handler as externalHandler } from "./external";
@@ -118,6 +118,16 @@ export default function metadataRouter() {
             url: uatURL,
         })
     );
+
+    logger.info("adding the GET /api/local-contexts/projects/:id handler");
+    api.get("/local-contexts/projects/:id", async (req, res) => {
+        const localContextsHandler = externalHandler({
+            method: "GET",
+            url: `${localContextsURL}/projects/${req.params.id}`,
+        });
+
+        return localContextsHandler(req, res);
+    });
 
     return api;
 }

--- a/src/server/configuration.js
+++ b/src/server/configuration.js
@@ -290,6 +290,14 @@ export const olsURL = config.get("services.ontology_lookup_service.base");
 export const uatURL = config.get("services.unified_astronomy_thesaurus.base");
 
 /**
+ * The Local Contexts Hub API.
+ * https://github.com/localcontexts/localcontextshub/wiki/API-Documentation
+ *
+ * @type {string}
+ */
+export const localContextsURL = config.get("services.local_contexts.base");
+
+/**
  * The base URL for the User Portal's API
  */
 export const userPortalAPIURL = `${config.get("user_portal_url")}/api`;

--- a/src/serviceFacades/metadata.js
+++ b/src/serviceFacades/metadata.js
@@ -12,6 +12,7 @@ const FILESYSTEM_METADATA_TEMPLATE_LISTING_QUERY_KEY =
     "fetchFilesystemMetadataTemplateListingKey";
 const SEARCH_OLS_QUERY_KEY = "searchOntologyLookupServiceKey";
 const SEARCH_UAT_QUERY_KEY = "searchUnifiedAstronomyThesaurusKey";
+const LOCAL_CONTEXTS_QUERY_KEY = "localContextsKey";
 
 function getFilesystemMetadataTemplateListing() {
     return callApi({
@@ -138,10 +139,20 @@ function searchUnifiedAstronomyThesaurus({ searchTerm, orderBy }) {
         .then((apiResponse) => apiResponse.data);
 }
 
+function getLocalContextsProject({ projectID }) {
+    return axiosInstance
+        .request({
+            url: `/api/local-contexts/projects/${projectID}`,
+            method: "GET",
+        })
+        .then((apiResponse) => apiResponse.data);
+}
+
 export {
     FILESYSTEM_METADATA_QUERY_KEY,
     FILESYSTEM_METADATA_TEMPLATE_QUERY_KEY,
     FILESYSTEM_METADATA_TEMPLATE_LISTING_QUERY_KEY,
+    LOCAL_CONTEXTS_QUERY_KEY,
     SEARCH_OLS_QUERY_KEY,
     SEARCH_UAT_QUERY_KEY,
     getFilesystemMetadata,
@@ -150,6 +161,7 @@ export {
     saveFilesystemMetadata,
     setFilesystemMetadata,
     applyBulkMetadataFromFile,
+    getLocalContextsProject,
     searchOntologyLookupService,
     searchUnifiedAstronomyThesaurus,
 };


### PR DESCRIPTION
This PR will add the initial Local Contexts label display to Data Listings and Metadata Templates.

When the metadata for a folder contains a `LocalContexts` attribute, and a `rightsURI` sub-attribute with a valid Local Contexts project URI as its value, then the Local Contexts labels for that project will be displayed in the data listing, as well as in metadata templates (such as the DataCite 4.2 template) that have a `LocalContexts` attribute field.

Each label is also an icon button that opens a dialog which displays the label or notice's descriptive text, along with a larger image of the label, and a link to the Local Contexts project page.

This PR also adds a custom `LocalContexts` attribute field for metadata templates (such as the DataCite 4.2 template) which displays only a Local Contexts Hub project URI field for the user, and will auto-populate DataCite metadata and child AVUs using the project ID parsed from the URI and the Local Contexts Hub API response (which is also used to display the project's labels below the field). 

---

![DataCite Metadata Template](https://github.com/cyverse-de/sonora/assets/996408/f058a6f5-ad7c-4875-a4ba-06959d9ce3ff)

---

![Data Listing](https://github.com/cyverse-de/sonora/assets/996408/8c593a58-f7c7-4455-a70c-3c97c2065d95)

---

It's also possible for Local Contexts Hub projects to have sub-projects.

This can also be supported in the DE if the user adds the sub-project's URI to the associated data in the main project's folder:

![Data Listing folder contents](https://github.com/cyverse-de/sonora/assets/996408/aae6700f-527c-42c0-954a-52753df98efa)

---

Finally, this is an example Dialog displaying a project's TK Label and associated text:
![TK Label Dialog](https://github.com/cyverse-de/sonora/assets/996408/ed9d5c61-4dc9-4222-a5a0-e4966f691d4c)

---