### PR TITLE
CORE-1999: fix the matching file count when no matching files are found

### DIFF
--- a/src/components/search/utils.js
+++ b/src/components/search/utils.js
@@ -11,5 +11,7 @@ export const getSearchLink = ({ searchTerm = "", advancedDataQuery = "" }) => {
 };
 
 export const extractTotal = (result) => {
-    return result?.total?.value || result?.total;
+    return typeof result?.total === "object"
+        ? result?.total?.value
+        : result?.total;
 };


### PR DESCRIPTION
Prior to this change search results when there were no matches showed the wrong result count:

<img width="754" alt="image" src="https://github.com/cyverse-de/sonora/assets/415143/f0d2394a-b422-4159-85e8-560f48df17ea">

After this change, the results display the correct count:

<img width="733" alt="image" src="https://github.com/cyverse-de/sonora/assets/415143/ebdce1aa-5443-43f0-b4c6-4c92bf4ed85a">
