### PR TITLE
CORE-1889 Tapis v3 Migration

### DIFF
--- a/src/components/analyses/landing/AnalysisSubmissionLanding.js
+++ b/src/components/analyses/landing/AnalysisSubmissionLanding.js
@@ -3,6 +3,7 @@ import React from "react";
 import { useTranslation } from "i18n";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import {
+    ANALYSIS_HISTORY_QUERY_KEY,
     ANALYSES_LISTING_QUERY_KEY,
     cancelAnalysis,
     extendVICEAnalysisTimeLimit,
@@ -162,6 +163,7 @@ export default function AnalysisSubmissionLanding(props) {
 
     const refreshAnalysis = () => {
         queryClient.invalidateQueries([ANALYSES_LISTING_QUERY_KEY, id]);
+        queryClient.invalidateQueries([ANALYSIS_HISTORY_QUERY_KEY, id]);
     };
 
     const { isFetching, error: analysisFetchError } = useQuery({

--- a/src/components/analyses/toolbar/Toolbar.js
+++ b/src/components/analyses/toolbar/Toolbar.js
@@ -14,7 +14,7 @@ import { allowAnalysesCancel } from "../utils";
 
 import { useConfig } from "contexts/config";
 
-import AppsTypeFilter from "components/apps/AppsTypeFilter";
+import AppsTypeFilter, { getFilters } from "components/apps/AppsTypeFilter";
 
 import buildID from "components/utils/DebugIDUtil";
 
@@ -171,6 +171,17 @@ function AnalysesToolbar(props) {
         hasSelection && allowAnalysesCancel(selectedAnalyses, username, config);
     const { isSmDown, isMdDown } = useBreakpoints();
 
+    const typeFilter = (
+        <AppsTypeFilter
+            baseId={analysesNavId}
+            filter={appTypeFilter}
+            classes={classes}
+            handleFilterChange={handleAppTypeFilterChange}
+            options={getFilters(true)}
+            disabled={false}
+        />
+    );
+
     return (
         <>
             <Toolbar variant="dense" id={analysesNavId} style={{ padding: 0 }}>
@@ -182,13 +193,7 @@ function AnalysesToolbar(props) {
                             classes={classes}
                             handleFilterChange={handleOwnershipFilterChange}
                         />
-                        <AppsTypeFilter
-                            baseId={analysesNavId}
-                            filter={appTypeFilter}
-                            classes={classes}
-                            handleFilterChange={handleAppTypeFilterChange}
-                            disabled={false}
-                        />
+                        {typeFilter}
                     </>
                 )}
                 {viewFiltered && (
@@ -300,13 +305,7 @@ function AnalysesToolbar(props) {
                         handleFilterChange={handleOwnershipFilterChange}
                     />
                     <br />
-                    <AppsTypeFilter
-                        baseId={analysesNavId}
-                        filter={appTypeFilter}
-                        classes={classes}
-                        handleFilterChange={handleAppTypeFilterChange}
-                        disabled={false}
-                    />
+                    {typeFilter}
                 </DialogContent>
                 <DialogActions>
                     <Button onClick={() => setOpenFilterDialog(false)}>

--- a/src/components/apps/AppsTypeFilter.js
+++ b/src/components/apps/AppsTypeFilter.js
@@ -6,12 +6,21 @@ import buildID from "components/utils/DebugIDUtil";
 import Autocomplete from "@mui/material/Autocomplete";
 import { TextField } from "@mui/material";
 
-function getFilters() {
-    return Object.values(appType);
+function getFilters(includeDeprecated = false) {
+    const filters = Object.values(appType);
+
+    return includeDeprecated ? filters : filters.filter((f) => !f.deprecated);
 }
 
 export default function AppsTypeFilter(props) {
-    const { baseId, filter, handleFilterChange, classes, disabled } = props;
+    const {
+        baseId,
+        filter,
+        handleFilterChange,
+        classes,
+        disabled,
+        options = getFilters(),
+    } = props;
     const { t } = useTranslation("apps");
 
     return (
@@ -19,7 +28,7 @@ export default function AppsTypeFilter(props) {
             id={buildID(baseId, ids.APPS_FILTER)}
             disabled={disabled}
             value={filter}
-            options={getFilters()}
+            options={options}
             size="small"
             onChange={(event, newValue) => {
                 handleFilterChange(newValue);

--- a/src/components/apps/launch/formatters.js
+++ b/src/components/apps/launch/formatters.js
@@ -144,7 +144,13 @@ const initGroupValues = (groups) =>
 
             if (paramArgs?.length > 0) {
                 const defaultArg =
-                    paramArgs.find((arg) => defaultValue?.id === arg.id) ||
+                    (defaultValue &&
+                        paramArgs.find((arg) => defaultValue.id === arg.id)) ||
+                    // param arg IDs can change between jobs
+                    (defaultValue &&
+                        paramArgs.find(
+                            (arg) => defaultValue.value === arg.value
+                        )) ||
                     paramArgs.find((arg) => arg.isDefault);
 
                 value = defaultArg || "";

--- a/src/components/apps/listing/Listing.js
+++ b/src/components/apps/listing/Listing.js
@@ -17,7 +17,7 @@ import buildID from "components/utils/DebugIDUtil";
 import { announce } from "components/announcer/CyVerseAnnouncer";
 import { SUCCESS } from "components/announcer/AnnouncerConstants";
 
-import appType from "components/models/AppType";
+import SystemIds from "components/models/systemId";
 
 import ConfirmationDialog from "components/utils/ConfirmationDialog";
 import DEPagination from "components/utils/DEPagination";
@@ -485,7 +485,7 @@ function Listing(props) {
                 let toFilter = filter;
                 if (
                     category.system_id?.toLowerCase() ===
-                    appType.agave.value.toLowerCase()
+                    SystemIds.tapis.toLowerCase()
                 ) {
                     toFilter = null;
                 }

--- a/src/components/apps/savedLaunch/SavedLaunchListing.js
+++ b/src/components/apps/savedLaunch/SavedLaunchListing.js
@@ -318,7 +318,7 @@ function ListSavedLaunches(props) {
     }
 
     if (!savedLaunches || savedLaunches.length === 0) {
-        if (systemId !== SystemIds.agave) {
+        if (systemId !== SystemIds.tapis) {
             const href = `/${NavigationConstants.APPS}/[systemId]/[appId]/launch`;
             const as = `/${NavigationConstants.APPS}/${systemId}/${appId}/launch`;
             return (

--- a/src/components/apps/toolbar/AppNavigation.js
+++ b/src/components/apps/toolbar/AppNavigation.js
@@ -127,7 +127,7 @@ function AppNavigation(props) {
                 (cat) => cat.system_id === systemId.de
             );
             const hpcCat = data.categories.find(
-                (cat) => cat.system_id === systemId.agave
+                (cat) => cat.system_id === systemId.tapis
             );
 
             let categoryList = privateCat.categories;

--- a/src/components/apps/toolbar/Toolbar.js
+++ b/src/components/apps/toolbar/Toolbar.js
@@ -10,7 +10,7 @@ import AppNavigation from "./AppNavigation";
 import CreateAppMenuItem from "../menuItems/CreateAppMenuItem";
 import CreateWorkflowMenuItem from "../menuItems/CreateWorkflowMenuItem";
 
-import appType from "components/models/AppType";
+import SystemIds from "components/models/systemId";
 import AppsTypeFilter from "components/apps/AppsTypeFilter";
 
 import NavigationConstants from "common/NavigationConstants";
@@ -197,7 +197,7 @@ function AppsToolbar(props) {
                             handleFilterChange={handleFilterChange}
                             disabled={
                                 selectedCategory?.system_id?.toLowerCase() ===
-                                appType.agave.value.toLowerCase()
+                                SystemIds.tapis.toLowerCase()
                             }
                         />
                     )}
@@ -324,7 +324,7 @@ function AppsToolbar(props) {
                         handleFilterChange={handleFilterChange}
                         disabled={
                             selectedCategory?.system_id?.toLowerCase() ===
-                            appType.agave.value.toLowerCase()
+                            SystemIds.tapis.toLowerCase()
                         }
                     />
                 </DialogContent>

--- a/src/components/apps/utils.js
+++ b/src/components/apps/utils.js
@@ -21,6 +21,7 @@ import ReferenceGenomeSelect from "components/apps/launch/ReferenceGenomeSelect"
 
 import AppParamTypes from "components/models/AppParamTypes";
 import AppType from "components/models/AppType";
+import SystemIds from "components/models/systemId";
 import ToolTypes from "components/models/ToolTypes";
 import Permissions, {
     permissionHierarchy,
@@ -292,8 +293,8 @@ export const appUnavailable = (
 };
 
 export const getAppTypeDisplay = (app) => {
-    if (app?.system_id?.toLowerCase() === AppType.agave.value.toLowerCase()) {
-        return AppType.agave.display;
+    if (app?.system_id?.toLowerCase() === SystemIds.tapis.toLowerCase()) {
+        return AppType.tapis.display;
     }
 
     if (app?.step_count === 1) {

--- a/src/components/models/AppType.js
+++ b/src/components/models/AppType.js
@@ -1,7 +1,9 @@
 const appType = {
-    agave: { value: "Agave", display: "HPC" },
     de: { value: "DE", display: "DE" },
     interactive: { value: "Interactive", display: "VICE" },
+    tapis: { value: "Tapis", display: "HPC" },
     osg: { value: "OSG", display: "OSG" },
+    agave: { value: "Agave", display: "Agave (deprecated)", deprecated: true },
 };
+
 export default appType;

--- a/src/components/models/systemId.js
+++ b/src/components/models/systemId.js
@@ -1,5 +1,5 @@
 const systemId = {
-    agave: "agave",
+    tapis: "tapis",
     de: "de",
 };
 export default systemId;

--- a/src/components/oauth/OAuthCodeHandler.js
+++ b/src/components/oauth/OAuthCodeHandler.js
@@ -37,7 +37,7 @@ function OAuthCodeHandler(props) {
     const determineListingUrl = useCallback(
         (data) => {
             const hpcCategory = data.categories.find(
-                (cat) => cat.system_id === systemId.agave
+                (cat) => cat.system_id === systemId.tapis
             );
             setListingUrl(
                 getListingPath(

--- a/src/serviceFacades/apps.js
+++ b/src/serviceFacades/apps.js
@@ -3,7 +3,6 @@
  *
  */
 import callApi from "../common/callApi";
-import appType from "../components/models/AppType";
 import constants from "../constants";
 import {
     betaAVU,
@@ -32,10 +31,7 @@ const ADMIN_APP_DETAILS_QUERY_KEY = "fetchAppDetailsForAdmin";
 const ADMIN_APP_AVU_QUERY_KEY = "fetchAppAVUs";
 
 const getAppTypeFilter = (appTypeFilter) => {
-    const typeFilter =
-        appTypeFilter && appTypeFilter !== appType.all
-            ? "&app-type=" + appTypeFilter
-            : "";
+    const typeFilter = appTypeFilter ? "&app-type=" + appTypeFilter : "";
     return typeFilter;
 };
 
@@ -370,11 +366,7 @@ function getAppsForAdmin({
         params["search"] = searchTerm;
     }
 
-    if (appTypeFilter && appTypeFilter !== appType.all) {
-        params["app-type"] = appTypeFilter;
-    } else {
-        params["app-type"] = "";
-    }
+    params["app-type"] = appTypeFilter || "";
 
     if (adminOwnershipFilter) {
         params["app-subset"] = adminOwnershipFilter;


### PR DESCRIPTION
This PR will rename `Agave` to `Tapis` just about everywhere, except there is still an `AppsTypeFilter` for `Agave`, only for the `Analyses` listing, so users can still list their old `Agave` jobs, even if they can't relaunch them anymore.

This PR also includes fixes for listing enum param default values in relaunch forms, and for refreshing the job history in the Analysis Landing page.