### PR TITLE
Small update to use the _first_ @ rather than the last for username truncation

### DIFF
--- a/src/components/instantlaunches/functions.js
+++ b/src/components/instantlaunches/functions.js
@@ -1,11 +1,11 @@
 /**
- * Removes a suffix from the username. Everything after the last '@' will be removed.
+ * Removes a suffix from the username. Everything starting from the first '@' will be removed.
  *
  * @param {string} username - The username that will be shortened
  * @returns {string} - The shortened username
  */
 export const shortenUsername = (username) => {
-    const atIndex = username.lastIndexOf("@");
+    const atIndex = username.indexOf("@");
     if (atIndex > -1) {
         return username.slice(0, atIndex);
     }


### PR DESCRIPTION
There's one other spot we're using the suffix, but it already removes all `@` signs (it splits on `@` and then takes the first returned component). I guess it won't do exactly what it should if for some reason the username suffix differs from the configured value, but I'm just not that worried about that. This change is (I think) only relevant to display, but still seemed better to be consistent.