### PR TITLE
Make periodic notifications work properly with instant launches

### DIFF
--- a/src/components/apps/launch/index.js
+++ b/src/components/apps/launch/index.js
@@ -80,7 +80,7 @@ const Launch = ({
     );
 
     const preferences = bootstrapInfo?.preferences;
-    const notify = preferences?.enableAnalysisEmailNotification || false;
+    const notify = !!preferences?.enableAnalysisEmailNotification;
     const notifyPeriodic = !!preferences?.enablePeriodicEmailNotification;
     const periodicPeriod = preferences?.periodicNotificationPeriod || 14400;
 

--- a/src/serviceFacades/instantlaunches.js
+++ b/src/serviceFacades/instantlaunches.js
@@ -325,7 +325,12 @@ export const deleteInstantLaunchHandler = async (id) => {
  * @param {Object} instantLaunch - The instant launch object returned by defaultInstantLaunch().
  * @param {Object} resource - An array of resources to use as inputs to the instantly launched app.
  */
-export const instantlyLaunch = ({ instantLaunch, resource, output_dir }) => {
+export const instantlyLaunch = ({
+    instantLaunch,
+    resource,
+    output_dir,
+    preferences,
+}) => {
     let savedLaunchId; // The saved launch ID, used to get app information.
     let savedLaunchPromise; // The promise used to get saved launch information.
 
@@ -434,6 +439,19 @@ export const instantlyLaunch = ({ instantLaunch, resource, output_dir }) => {
         })
         .then((submission) => {
             submission.output_dir = output_dir;
+            return submission;
+        })
+        .then((submission) => {
+            const notify =
+                preferences?.enableAnalysisEmailNotification || false;
+            submission.notify = notify;
+            const notifyPeriodic =
+                !!preferences?.enablePeriodicEmailNotification;
+            submission.notify_periodic = notifyPeriodic;
+            const periodicPeriod =
+                preferences?.periodicNotificationPeriod || 14400;
+            submission.periodic_period = periodicPeriod;
+
             return submission;
         })
         .then((submission) => submitAnalysis(submission)) // submit the analysis

--- a/src/serviceFacades/instantlaunches.js
+++ b/src/serviceFacades/instantlaunches.js
@@ -441,19 +441,12 @@ export const instantlyLaunch = ({
             submission.output_dir = output_dir;
             return submission;
         })
-        .then((submission) => {
-            const notify =
-                preferences?.enableAnalysisEmailNotification || false;
-            submission.notify = notify;
-            const notifyPeriodic =
-                !!preferences?.enablePeriodicEmailNotification;
-            submission.notify_periodic = notifyPeriodic;
-            const periodicPeriod =
-                preferences?.periodicNotificationPeriod || 14400;
-            submission.periodic_period = periodicPeriod;
-
-            return submission;
-        })
+        .then((submission) => ({
+            ...submission,
+            notify: !!preferences?.enableAnalysisEmailNotification,
+            notify_periodic: !!preferences?.enablePeriodicEmailNotification,
+            periodic_period: preferences?.periodicNotificationPeriod || 14400,
+        }))
         .then((submission) => submitAnalysis(submission)) // submit the analysis
         .then((analysisResp) => getAnalysis(analysisResp.id));
 };


### PR DESCRIPTION
This is the one place that calls to the `instantlyLaunch` helper function, so it should be the only place that needs to get preferences via bootstrap info to pass to it. This should also mean that anyone who's set up email notifications or not will have them behave correctly with respect to email (in the case where their preference doesn't match the saved launch).