### PR TITLE
CORE-2011 Update setting max CPUs in app launch form

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -41,6 +41,11 @@ module.exports = withBundleAnalyzer({
         SESSION_POLL_INTERVAL_MS: config.has("sessions.poll_interval_ms")
             ? config.get("sessions.poll_interval_ms")
             : 5000,
+        TOOLS_DEFAULT_SELECTED_MAX_CPUS: config.has(
+            "tools.default_selected_max_cpus"
+        )
+            ? config.get("tools.default_selected_max_cpus")
+            : 4,
         TOOLS_ADMIN_MAX_CPU_LIMIT: config.has("tools.admin.max_cpu_limit")
             ? config.get("tools.admin.max_cpu_limit")
             : 8,

--- a/src/components/apps/launch/formatters.js
+++ b/src/components/apps/launch/formatters.js
@@ -35,14 +35,15 @@ const initAppLaunchValues = (
         notify,
         notifyPeriodic,
         periodicPeriod,
-        defaultMaxCpuCores = 4,
+        defaultSelectedMaxCpus,
+        defaultMaxCpuCores = defaultSelectedMaxCpus,
         defaultOutputDir,
         app: { id, version_id, system_id, name, requirements, groups },
     }
 ) => {
     // If no default_max_cpu_cores is returned from the API,
-    // then use the default from params (if it's less than the actual max)
-    // so the max is not automatically selected in the launch form.
+    // then use the default from configs (if it's less than the actual max)
+    // so the max is not automatically submitted by the services.
     const reqInitValues = requirements?.map(
         ({
             step_number,

--- a/src/components/apps/launch/formatters.js
+++ b/src/components/apps/launch/formatters.js
@@ -35,21 +35,27 @@ const initAppLaunchValues = (
         notify,
         notifyPeriodic,
         periodicPeriod,
+        defaultMaxCpuCores = 4,
         defaultOutputDir,
         app: { id, version_id, system_id, name, requirements, groups },
     }
 ) => {
+    // If no default_max_cpu_cores is returned from the API,
+    // then use the default from params (if it's less than the actual max)
+    // so the max is not automatically selected in the launch form.
     const reqInitValues = requirements?.map(
         ({
             step_number,
             max_cpu_cores,
-            default_max_cpu_cores = 0,
+            default_max_cpu_cores = max_cpu_cores < defaultMaxCpuCores
+                ? max_cpu_cores
+                : defaultMaxCpuCores,
             default_cpu_cores = 0,
             default_memory = 0,
             default_disk_space = 0,
         }) => ({
             step_number,
-            max_cpu_cores: default_max_cpu_cores || max_cpu_cores,
+            max_cpu_cores: default_max_cpu_cores,
             min_cpu_cores: default_cpu_cores,
             min_memory_limit: default_memory,
             min_disk_space: default_disk_space,

--- a/src/components/apps/launch/index.js
+++ b/src/components/apps/launch/index.js
@@ -84,6 +84,7 @@ const Launch = ({
     const notifyPeriodic = !!preferences?.enablePeriodicEmailNotification;
     const periodicPeriod = preferences?.periodicNotificationPeriod || 14400;
 
+    const defaultSelectedMaxCpus = config?.tools?.default_selected_max_cpus;
     const defaultMaxCPUCores = config?.tools?.private.max_cpu_limit;
     const defaultMaxMemory = config?.tools?.private.max_memory_limit;
     const defaultMaxDiskSpace = config?.tools?.private.max_disk_limit;
@@ -148,6 +149,7 @@ const Launch = ({
             defaultMaxCPUCores={defaultMaxCPUCores}
             defaultMaxMemory={defaultMaxMemory}
             defaultMaxDiskSpace={defaultMaxDiskSpace}
+            defaultSelectedMaxCpus={defaultSelectedMaxCpus}
             app={app}
             appError={submissionError}
             loading={loading}

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -164,6 +164,8 @@ function MyApp({ Component, pageProps }) {
             poll_interval_ms: publicRuntimeConfig.SESSION_POLL_INTERVAL_MS,
         };
         const tools = {
+            default_selected_max_cpus:
+                publicRuntimeConfig.TOOLS_DEFAULT_SELECTED_MAX_CPUS,
             admin: {
                 max_cpu_limit: publicRuntimeConfig.TOOLS_ADMIN_MAX_CPU_LIMIT,
                 max_memory_limit:

--- a/stories/apps/launch/DEWordCount.stories.js
+++ b/stories/apps/launch/DEWordCount.stories.js
@@ -24,6 +24,7 @@ export const DEWordCount = ({
     loading,
     loadingError,
     submissionError,
+    defaultSelectedMaxCpus,
     defaultMaxCPUCores,
     defaultMaxMemory,
     defaultMaxDiskSpace,
@@ -59,6 +60,7 @@ export const DEWordCount = ({
             app={!loadingError && app}
             loading={loading}
             appError={appError || (loadingError && errorObject)}
+            defaultSelectedMaxCpus={defaultSelectedMaxCpus}
             defaultMaxCPUCores={defaultMaxCPUCores}
             defaultMaxMemory={defaultMaxMemory}
             defaultMaxDiskSpace={defaultMaxDiskSpace}
@@ -120,6 +122,12 @@ DEWordCount.argTypes = {
             type: "boolean",
         },
     },
+    defaultSelectedMaxCpus: {
+        name: "Default Selected Max CPU Cores",
+        control: {
+            type: "number",
+        },
+    },
     defaultMaxCPUCores: {
         name: "Max CPU Cores",
         control: {
@@ -147,6 +155,7 @@ DEWordCount.args = {
     loading: false,
     loadingError: false,
     submissionError: false,
+    defaultSelectedMaxCpus: 4,
     defaultMaxCPUCores: 8,
     defaultMaxMemory: 4 * constants.ONE_GiB,
     defaultMaxDiskSpace: 64 * constants.ONE_GiB,

--- a/stories/configMock.js
+++ b/stories/configMock.js
@@ -20,6 +20,7 @@ export default {
         trash_path: "/iplant/trash/home/de-irods",
     },
     tools: {
+        default_selected_max_cpus: 4,
         admin: {
             max_cpu_limit: 48,
             max_memory_limit: 244 * constants.ONE_GiB,


### PR DESCRIPTION
This PR will update setting the default selected max CPUs in the app launch form, and adds a `tools.default_selected_max_cpus` config to allow us to adjust the default selected value.

This default value will only be selected if it's less than the actual max set by the tool, and only if no `default_max_cpu_cores` is returned from the API (as is the case in job relaunches where a value was requested in the original submission).
