### PR TITLE
Amend analysis page icons

### DIFF
--- a/src/components/analyses/landing/AnalysisSubmissionLanding.js
+++ b/src/components/analyses/landing/AnalysisSubmissionLanding.js
@@ -431,7 +431,9 @@ export default function AnalysisSubmissionLanding(props) {
                                                 onClick={() => {
                                                     handleTerminateSelected();
                                                 }}
-                                                startIcon={<CancelIcon />}
+                                                startIcon={
+                                                    <CancelIcon color="error" />
+                                                }
                                             >
                                                 {!isSmDown && (
                                                     <>{t("terminate")}</>

--- a/src/components/analyses/landing/AnalysisSubmissionLanding.js
+++ b/src/components/analyses/landing/AnalysisSubmissionLanding.js
@@ -73,8 +73,9 @@ import {
     useTheme,
 } from "@mui/material";
 import {
-    ContactSupport,
+    Cancel as CancelIcon,
     ExpandMore,
+    HourglassEmptyRounded as HourGlassIcon,
     Refresh,
     Launch,
 } from "@mui/icons-material";
@@ -392,28 +393,52 @@ export default function AnalysisSubmissionLanding(props) {
                                             {!isSmDown && <>{t("refresh")}</>}
                                         </Button>
                                     </Grid>
-                                    <Grid item>
-                                        {allowShareWithSupport && (
+                                    {allowTimeExtn && (
+                                        <Grid item>
                                             <Button
                                                 id={buildID(
                                                     baseId,
-                                                    ids.SHARE_WITH_SUPPORT
+                                                    ids.MENUITEM_EXTEND_TIME_LIMIT
                                                 )}
                                                 variant="outlined"
-                                                onClick={() =>
-                                                    setHelpOpen(true)
-                                                }
                                                 size="small"
-                                                startIcon={
-                                                    <ContactSupport fontSize="small" />
-                                                }
+                                                disableElevation
                                                 color="primary"
-                                                title={t("requestHelp")}
+                                                onClick={() => {
+                                                    setConfirmExtendTimeLimitDlgOpen(
+                                                        true
+                                                    );
+                                                }}
+                                                startIcon={<HourGlassIcon />}
                                             >
-                                                {t("requestHelp")}
+                                                {!isSmDown && (
+                                                    <>{t("extendTime")}</>
+                                                )}
                                             </Button>
-                                        )}
-                                    </Grid>
+                                        </Grid>
+                                    )}
+                                    {allowCancel && (
+                                        <Grid item>
+                                            <Button
+                                                id={buildID(
+                                                    baseId,
+                                                    ids.MENUITEM_CANCEL
+                                                )}
+                                                variant="outlined"
+                                                size="small"
+                                                disableElevation
+                                                color="primary"
+                                                onClick={() => {
+                                                    handleTerminateSelected();
+                                                }}
+                                                startIcon={<CancelIcon />}
+                                            >
+                                                {!isSmDown && (
+                                                    <>{t("terminate")}</>
+                                                )}
+                                            </Button>
+                                        </Grid>
+                                    )}
                                 </>
                             )}
 

--- a/src/components/analyses/landing/DotMenuItems.js
+++ b/src/components/analyses/landing/DotMenuItems.js
@@ -75,7 +75,7 @@ export default function DotMenuItems(props) {
                 <ListItemText primary={t("refresh")} />
             </MenuItem>
         ),
-        isMdDown && allowShareWithSupport && (
+        allowShareWithSupport && (
             <MenuItem
                 key={buildID(baseId, ids.MENUITEM_SHARE_WITH_SUPPORT)}
                 id={buildID(baseId, ids.MENUITEM_SHARE_WITH_SUPPORT)}
@@ -166,7 +166,7 @@ export default function DotMenuItems(props) {
                 <ListItemText primary={t("updateComments")} />
             </MenuItem>
         ),
-        allowTimeExtn && (
+        isMdDown && allowTimeExtn && (
             <MenuItem
                 key={buildID(baseId, ids.MENUITEM_EXTEND_TIME_LIMIT)}
                 id={buildID(baseId, ids.MENUITEM_EXTEND_TIME_LIMIT)}
@@ -181,7 +181,7 @@ export default function DotMenuItems(props) {
                 <ListItemText primary={t("extendTime")} />
             </MenuItem>
         ),
-        allowCancel && (
+        isMdDown && allowCancel && (
             <MenuItem
                 key={buildID(baseId, ids.MENUITEM_CANCEL)}
                 id={buildID(baseId, ids.MENUITEM_CANCEL)}

--- a/src/components/analyses/landing/DotMenuItems.js
+++ b/src/components/analyses/landing/DotMenuItems.js
@@ -191,7 +191,7 @@ export default function DotMenuItems(props) {
                 }}
             >
                 <ListItemIcon>
-                    <CancelIcon fontSize="small" />
+                    <CancelIcon color="error" fontSize="small" />
                 </ListItemIcon>
                 <ListItemText primary={t("terminate")} />
             </MenuItem>


### PR DESCRIPTION
Upon design conversations, "Share with Support" doesn't need prime placement on this page, because there's already a button for it in the top bar of every page. However, extend & terminate are more primary actions that should appear on large screens.

when big:
![image](https://github.com/user-attachments/assets/76f0bded-e0f4-499a-9fd0-d79da3da8d9a)

(with menu open)
![image](https://github.com/user-attachments/assets/d827524c-2393-40cd-aeb4-b8cea945119d)

when smaller, with menu open:
![image](https://github.com/user-attachments/assets/6c661763-c523-4107-9828-48493f4c5c5d)

Thoughts/questions:

* Should the terminate icon (or the whole button, maybe) be changed to the red that's used for the small action buttons on the analysis overview
* Should "extend time limit" be distinguished at all by color, or any of the other (otherwise unchanged) buttons, especially if we change "terminate".