### PR TITLE
Instant Launch badges (WIP)

### DIFF
--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -43,6 +43,7 @@
     "help": "Help",
     "home": "Home",
     "instantLaunches": "Instant Launches",
+    "instantLaunch": "Instant Launch",
     "interactiveAnalysisUrl": "{{message}}. Access your running analysis here.",
     "intercomAriaLabel": "Chat with CyVerse support",
     "learnMore": "Learn More",

--- a/src/components/instantlaunches/launch/index.js
+++ b/src/components/instantlaunches/launch/index.js
@@ -3,11 +3,89 @@
  *
  * The component that launches a provided instant launch, immediately.
  */
-import React from "react";
+import React, { useState } from "react";
+
+import { useQuery } from "react-query";
+
+import {
+    GET_INSTANT_LAUNCH_FULL_KEY,
+    getFullInstantLaunch,
+} from "serviceFacades/instantlaunches";
+import {
+    getResourceUsageSummary,
+    RESOURCE_USAGE_QUERY_KEY,
+} from "serviceFacades/dashboard";
+import { getUserQuota } from "common/resourceUsage";
+import { useConfig } from "contexts/config";
+import { useUserProfile } from "contexts/userProfile";
+import globalConstants from "../../../constants";
+import { useTranslation } from "i18n";
+import isQueryLoading from "components/utils/isQueryLoading";
+import InstantLaunchButtonWrapper from "components/instantlaunches/InstantLaunchButtonWrapper";
+import DELink from "components/utils/DELink";
+import withErrorAnnouncer from "components/error/withErrorAnnouncer";
 
 const InstantLaunchStandalone = (props) => {
-    const { id: instant_launch_id } = props;
-    return <p>itsa {instant_launch_id}</p>;
+    const { id: instant_launch_id, showErrorAnnouncer } = props;
+    const [config] = useConfig();
+    const [userProfile] = useUserProfile();
+    const [computeLimitExceeded, setComputeLimitExceeded] = useState(
+        !!config?.subscriptions?.enforce
+    );
+    const { t } = useTranslation(["instantlaunches", "common"]);
+
+    const { data, status, error } = useQuery(
+        [GET_INSTANT_LAUNCH_FULL_KEY, instant_launch_id],
+        () => getFullInstantLaunch(instant_launch_id)
+    );
+
+    const { isFetching: isFetchingUsageSummary } = useQuery({
+        queryKey: [RESOURCE_USAGE_QUERY_KEY],
+        queryFn: getResourceUsageSummary,
+        enabled: !!config?.subscriptions?.enforce && !!userProfile?.id,
+        onSuccess: (respData) => {
+            const computeUsage = respData?.cpu_usage?.total || 0;
+            const subscription = respData?.subscription;
+            const computeQuota = getUserQuota(
+                globalConstants.CPU_HOURS_RESOURCE_NAME,
+                subscription
+            );
+            setComputeLimitExceeded(computeUsage >= computeQuota);
+        },
+        onError: (e) => {
+            showErrorAnnouncer(t("common:usageSummaryError"), e);
+        },
+    });
+
+    const isLoading = isQueryLoading([status, isFetchingUsageSummary]);
+    if (isLoading) {
+        return <p>... loading ...</p>;
+    } else if (error) {
+        return (
+            <p>
+                error{" "}
+                {error?.response?.status === 404 ? "not found" : "unsure why"}
+            </p>
+        );
+    } else {
+        return (
+            <>
+                {JSON.stringify(data)}
+                <br />
+                <InstantLaunchButtonWrapper
+                    instantLaunch={data}
+                    computeLimitExceeded={computeLimitExceeded}
+                    render={(onClick) => (
+                        <DELink
+                            onClick={onClick}
+                            text={"LAUNCH"}
+                            title={"LAUNCH"}
+                        />
+                    )}
+                />
+            </>
+        );
+    }
 };
 
-export default InstantLaunchStandalone;
+export default withErrorAnnouncer(InstantLaunchStandalone);

--- a/src/components/instantlaunches/launch/index.js
+++ b/src/components/instantlaunches/launch/index.js
@@ -22,7 +22,6 @@ import globalConstants from "../../../constants";
 import { useTranslation } from "i18n";
 import isQueryLoading from "components/utils/isQueryLoading";
 import InstantLaunchButtonWrapper from "components/instantlaunches/InstantLaunchButtonWrapper";
-import DELink from "components/utils/DELink";
 import withErrorAnnouncer from "components/error/withErrorAnnouncer";
 
 const InstantLaunchStandalone = (props) => {
@@ -58,6 +57,7 @@ const InstantLaunchStandalone = (props) => {
     });
 
     const isLoading = isQueryLoading([status, isFetchingUsageSummary]);
+
     if (isLoading) {
         return <p>... loading ...</p>;
     } else if (error) {
@@ -69,21 +69,11 @@ const InstantLaunchStandalone = (props) => {
         );
     } else {
         return (
-            <>
-                {JSON.stringify(data)}
-                <br />
-                <InstantLaunchButtonWrapper
-                    instantLaunch={data}
-                    computeLimitExceeded={computeLimitExceeded}
-                    render={(onClick) => (
-                        <DELink
-                            onClick={onClick}
-                            text={"LAUNCH"}
-                            title={"LAUNCH"}
-                        />
-                    )}
-                />
-            </>
+            <InstantLaunchButtonWrapper
+                instantLaunch={data}
+                computeLimitExceeded={computeLimitExceeded}
+                autolaunch={true}
+            />
         );
     }
 };

--- a/src/components/instantlaunches/launch/index.js
+++ b/src/components/instantlaunches/launch/index.js
@@ -25,6 +25,9 @@ import InstantLaunchButtonWrapper from "components/instantlaunches/InstantLaunch
 import withErrorAnnouncer from "components/error/withErrorAnnouncer";
 import LoadingAnimation from "components/vice/loading/LoadingAnimation";
 
+import ErrorTypography from "components/error/ErrorTypography";
+import DEErrorDialog from "components/error/DEErrorDialog";
+
 const InstantLaunchStandalone = (props) => {
     const { id: instant_launch_id, showErrorAnnouncer } = props;
     const [config] = useConfig();
@@ -32,6 +35,7 @@ const InstantLaunchStandalone = (props) => {
     const [computeLimitExceeded, setComputeLimitExceeded] = useState(
         !!config?.subscriptions?.enforce
     );
+    const [errorDialogOpen, setErrorDialogOpen] = useState(false);
     const { t } = useTranslation(["instantlaunches", "common"]);
 
     const { data, status, error } = useQuery(
@@ -63,10 +67,17 @@ const InstantLaunchStandalone = (props) => {
         return <LoadingAnimation />;
     } else if (error) {
         return (
-            <p>
-                error{" "}
-                {error?.response?.status === 404 ? "not found" : "unsure why"}
-            </p>
+            <>
+                <ErrorTypography
+                    errorMessage={error.message}
+                    onDetailsClick={() => setErrorDialogOpen(true)}
+                />
+                <DEErrorDialog
+                    open={errorDialogOpen}
+                    errorObject={error}
+                    handleClose={() => setErrorDialogOpen(false)}
+                />
+            </>
         );
     } else {
         return (

--- a/src/components/instantlaunches/launch/index.js
+++ b/src/components/instantlaunches/launch/index.js
@@ -23,6 +23,7 @@ import { useTranslation } from "i18n";
 import isQueryLoading from "components/utils/isQueryLoading";
 import InstantLaunchButtonWrapper from "components/instantlaunches/InstantLaunchButtonWrapper";
 import withErrorAnnouncer from "components/error/withErrorAnnouncer";
+import LoadingAnimation from "components/vice/loading/LoadingAnimation";
 
 const InstantLaunchStandalone = (props) => {
     const { id: instant_launch_id, showErrorAnnouncer } = props;
@@ -59,7 +60,7 @@ const InstantLaunchStandalone = (props) => {
     const isLoading = isQueryLoading([status, isFetchingUsageSummary]);
 
     if (isLoading) {
-        return <p>... loading ...</p>;
+        return <LoadingAnimation />;
     } else if (error) {
         return (
             <p>

--- a/src/components/instantlaunches/launch/index.js
+++ b/src/components/instantlaunches/launch/index.js
@@ -1,0 +1,13 @@
+/**
+ * @author mian
+ *
+ * The component that launches a provided instant launch, immediately.
+ */
+import React from "react";
+
+const InstantLaunchStandalone = (props) => {
+    const { id: instant_launch_id } = props;
+    return <p>itsa {instant_launch_id}</p>;
+};
+
+export default InstantLaunchStandalone;

--- a/src/pages/instantlaunch/[id]/index.js
+++ b/src/pages/instantlaunch/[id]/index.js
@@ -1,0 +1,33 @@
+/**
+ * @author mian
+ *
+ * Instant launch launch page
+ */
+import React from "react";
+
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+
+import { i18n, RequiredNamespaces } from "i18n";
+
+import { useRouter } from "next/router";
+
+import InstantLaunchStandalone from "components/instantlaunches/launch";
+
+export default function InstantLaunch() {
+    const router = useRouter();
+    const { id } = router.query;
+
+    return <InstantLaunchStandalone id={id} />;
+}
+
+export async function getServerSideProps({ locale }) {
+    const title = i18n.t("instantLaunches");
+
+    return {
+        props: {
+            title,
+            // "instantlaunches" already included by RequiredNamespaces
+            ...(await serverSideTranslations(locale, RequiredNamespaces)),
+        },
+    };
+}

--- a/src/pages/instantlaunch/[id]/index.js
+++ b/src/pages/instantlaunch/[id]/index.js
@@ -21,7 +21,7 @@ export default function InstantLaunch() {
 }
 
 export async function getServerSideProps({ locale }) {
-    const title = i18n.t("instantLaunches");
+    const title = i18n?.t("instantLaunches") || "";
 
     return {
         props: {

--- a/src/pages/instantlaunch/[id]/index.js
+++ b/src/pages/instantlaunch/[id]/index.js
@@ -21,7 +21,7 @@ export default function InstantLaunch() {
 }
 
 export async function getServerSideProps({ locale }) {
-    const title = i18n?.t("instantLaunches") || "";
+    const title = i18n.t("instantLaunch");
 
     return {
         props: {

--- a/src/server/api/instantlaunches.js
+++ b/src/server/api/instantlaunches.js
@@ -165,6 +165,19 @@ export default () => {
         })
     );
 
+    logger.info("adding the GET /instantlaunches/:id/full handler");
+    api.get(
+        "/instantlaunches/:id/full",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "GET",
+            pathname: "/instantlaunches/:id/full",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        })
+    );
+
     logger.info("Add the PUT /admin/instantlaunches/:id/metadata handler");
     api.put(
         "/admin/instantlaunches/:id/metadata",

--- a/src/serviceFacades/instantlaunches.js
+++ b/src/serviceFacades/instantlaunches.js
@@ -20,6 +20,7 @@ export const DASHBOARD_INSTANT_LAUNCHES_KEY = "dashboardInstantLaunches";
 export const LIST_PUBLIC_SAVED_LAUNCHES_KEY = "listPublicSavedLaunches";
 export const LIST_INSTANT_LAUNCHES_BY_METADATA_KEY =
     "fetchInstantLaunchesByMetadata";
+export const GET_INSTANT_LAUNCH_FULL_KEY = "fetchFullInstantLaunch";
 
 export const getDefaultsMapping = () =>
     callApi({
@@ -74,6 +75,12 @@ export const listFullInstantLaunches = (id) =>
 export const getInstantLaunchMetadata = (id) =>
     callApi({
         endpoint: `/api/admin/instantlaunches/${id}/metadata`,
+        method: "GET",
+    });
+
+export const getFullInstantLaunch = (id) =>
+    callApi({
+        endpoint: `/api/instantlaunches/${id}/full`,
         method: "GET",
     });
 


### PR DESCRIPTION
This (so far) adds a single new page at `/instantlaunches/:id`, which immediately launches the provided instant launch.

Continuing work:
* allow passing an input parameter as a query parameter, to be integrated into the submission
* something beyond an empty page (possibly just a redirect to the analysis landing after a job is launched)
* added info in the popup dialog that tells you what you're launching