### PR TITLE
Support passing a resource path to the instant launch page

### DIFF
--- a/src/components/instantlaunches/launch/index.js
+++ b/src/components/instantlaunches/launch/index.js
@@ -15,6 +15,7 @@ import {
     getResourceUsageSummary,
     RESOURCE_USAGE_QUERY_KEY,
 } from "serviceFacades/dashboard";
+import { useDataDetails } from "serviceFacades/filesystem";
 import { getUserQuota } from "common/resourceUsage";
 import { useConfig } from "contexts/config";
 import { useUserProfile } from "contexts/userProfile";
@@ -29,13 +30,19 @@ import ErrorTypography from "components/error/ErrorTypography";
 import DEErrorDialog from "components/error/DEErrorDialog";
 
 const InstantLaunchStandalone = (props) => {
-    const { id: instant_launch_id, showErrorAnnouncer } = props;
+    const {
+        id: instant_launch_id,
+        resource: resource_path,
+        showErrorAnnouncer,
+    } = props;
     const [config] = useConfig();
     const [userProfile] = useUserProfile();
     const [computeLimitExceeded, setComputeLimitExceeded] = useState(
         !!config?.subscriptions?.enforce
     );
     const [errorDialogOpen, setErrorDialogOpen] = useState(false);
+    const [resource, setResource] = useState(!!resource_path ? null : {});
+
     const { t } = useTranslation(["instantlaunches", "common"]);
 
     const { data, status, error } = useQuery(
@@ -61,20 +68,34 @@ const InstantLaunchStandalone = (props) => {
         },
     });
 
-    const isLoading = isQueryLoading([status, isFetchingUsageSummary]);
+    const { isFetching: isLoadingResource, error: resourceError } =
+        useDataDetails({
+            paths: [resource_path],
+            enabled: !!resource_path,
+            onSuccess: (resp) => {
+                setResource(resp?.paths[resource_path]);
+            },
+        });
+
+    const isLoading = isQueryLoading([
+        status,
+        isLoadingResource,
+        isFetchingUsageSummary,
+    ]);
 
     if (isLoading) {
         return <LoadingAnimation />;
-    } else if (error) {
+    } else if (error || resourceError) {
+        const err = error || resourceError;
         return (
             <>
                 <ErrorTypography
-                    errorMessage={error.message}
+                    errorMessage={err.message}
                     onDetailsClick={() => setErrorDialogOpen(true)}
                 />
                 <DEErrorDialog
                     open={errorDialogOpen}
-                    errorObject={error}
+                    errorObject={err}
                     handleClose={() => setErrorDialogOpen(false)}
                 />
             </>
@@ -83,6 +104,7 @@ const InstantLaunchStandalone = (props) => {
         return (
             <InstantLaunchButtonWrapper
                 instantLaunch={data}
+                resource={resource}
                 computeLimitExceeded={computeLimitExceeded}
                 autolaunch={true}
             />

--- a/src/components/instantlaunches/launch/index.js
+++ b/src/components/instantlaunches/launch/index.js
@@ -26,8 +26,7 @@ import InstantLaunchButtonWrapper from "components/instantlaunches/InstantLaunch
 import withErrorAnnouncer from "components/error/withErrorAnnouncer";
 import LoadingAnimation from "components/vice/loading/LoadingAnimation";
 
-import ErrorTypography from "components/error/ErrorTypography";
-import DEErrorDialog from "components/error/DEErrorDialog";
+import ErrorTypographyWithDialog from "components/error/ErrorTypographyWithDialog";
 
 const InstantLaunchStandalone = (props) => {
     const {
@@ -40,7 +39,6 @@ const InstantLaunchStandalone = (props) => {
     const [computeLimitExceeded, setComputeLimitExceeded] = useState(
         !!config?.subscriptions?.enforce
     );
-    const [errorDialogOpen, setErrorDialogOpen] = useState(false);
     const [resource, setResource] = useState(!!resource_path ? null : {});
 
     const { t } = useTranslation(["instantlaunches", "common"]);
@@ -88,17 +86,10 @@ const InstantLaunchStandalone = (props) => {
     } else if (error || resourceError) {
         const err = error || resourceError;
         return (
-            <>
-                <ErrorTypography
-                    errorMessage={err.message}
-                    onDetailsClick={() => setErrorDialogOpen(true)}
-                />
-                <DEErrorDialog
-                    open={errorDialogOpen}
-                    errorObject={err}
-                    handleClose={() => setErrorDialogOpen(false)}
-                />
-            </>
+            <ErrorTypographyWithDialog
+                errorMessage={t("instantLaunchError")}
+                errorObject={err}
+            />
         );
     } else {
         return (

--- a/src/components/instantlaunches/launch/index.js
+++ b/src/components/instantlaunches/launch/index.js
@@ -39,7 +39,7 @@ const InstantLaunchStandalone = (props) => {
     const [computeLimitExceeded, setComputeLimitExceeded] = useState(
         !!config?.subscriptions?.enforce
     );
-    const [resource, setResource] = useState(!!resource_path ? null : {});
+    const [resource, setResource] = useState(null);
 
     const { t } = useTranslation(["instantlaunches", "common"]);
 

--- a/src/pages/instantlaunch/[id]/index.js
+++ b/src/pages/instantlaunch/[id]/index.js
@@ -15,9 +15,9 @@ import InstantLaunchStandalone from "components/instantlaunches/launch";
 
 export default function InstantLaunch() {
     const router = useRouter();
-    const { id } = router.query;
+    const { id, resource } = router.query;
 
-    return <InstantLaunchStandalone id={id} />;
+    return <InstantLaunchStandalone id={id} resource={resource} />;
 }
 
 export async function getServerSideProps({ locale }) {


### PR DESCRIPTION
This was easier than expected. Grabs a stat if a path's passed in, shows an error if it gets one, passes along the data to the instant launch. Nice.