### PR TITLE
When autolaunching an instant launch, redirect to the analysis landing page

### DIFF
--- a/src/components/instantlaunches/InstantLaunchButtonWrapper.js
+++ b/src/components/instantlaunches/InstantLaunchButtonWrapper.js
@@ -12,6 +12,10 @@ import React, { useEffect, useCallback } from "react";
 
 import { useMutation } from "react-query";
 
+import { useRouter } from "next/router";
+
+import NavigationConstants from "common/NavigationConstants";
+
 import { useDefaultOutputDir } from "components/data/utils";
 import withErrorAnnouncer from "components/error/withErrorAnnouncer";
 import { getHost } from "components/utils/getHost";
@@ -52,6 +56,7 @@ function InstantLaunchButtonWrapper(props) {
     const [runErrorDetails, setRunErrorDetails] = React.useState(null);
     const [ilUrl, setIlUrl] = React.useState();
 
+    const router = useRouter();
     const { t } = useTranslation("launch");
 
     React.useEffect(() => {
@@ -74,6 +79,12 @@ function InstantLaunchButtonWrapper(props) {
                     );
                 } else {
                     setOpen(false);
+                }
+                if (autolaunch) {
+                    // go to the analysis landing
+                    router.push(
+                        `/${NavigationConstants.ANALYSES}/${analysis?.id}`
+                    );
                 }
             } else {
                 setOpen(false);

--- a/src/components/instantlaunches/InstantLaunchButtonWrapper.js
+++ b/src/components/instantlaunches/InstantLaunchButtonWrapper.js
@@ -55,22 +55,30 @@ function InstantLaunchButtonWrapper(props) {
         React.useState(false);
     const [runErrorDetails, setRunErrorDetails] = React.useState(null);
     const [ilUrl, setIlUrl] = React.useState();
+    const [landingUrl, setLandingUrl] = React.useState();
 
     const router = useRouter();
     const { t } = useTranslation("launch");
 
     React.useEffect(() => {
-        if (ilUrl) {
+        if (ilUrl && landingUrl) {
             window.open(`${getHost()}${ilUrl}`);
             setIlUrl(null);
             setOpen(false);
+            if (autolaunch) {
+                // go to the analysis landing, not keeping this page in browser history
+                router.replace(landingUrl);
+            }
         }
-    }, [ilUrl]);
+    }, [ilUrl, landingUrl, autolaunch, router]);
 
     const { mutate: launch } = useMutation(instantlyLaunch, {
         onSuccess: (listing) => {
             if (listing.analyses.length > 0) {
                 const analysis = listing.analyses[0];
+                setLandingUrl(
+                    `/${NavigationConstants.ANALYSES}/${analysis?.id}`
+                );
                 if (analysis.interactive_urls?.length > 0) {
                     setIlUrl(
                         `${constants.VICE_LOADING_PAGE}/${encodeURIComponent(
@@ -79,12 +87,6 @@ function InstantLaunchButtonWrapper(props) {
                     );
                 } else {
                     setOpen(false);
-                }
-                if (autolaunch) {
-                    // go to the analysis landing, not keeping this page in browser history
-                    router.replace(
-                        `/${NavigationConstants.ANALYSES}/${analysis?.id}`
-                    );
                 }
             } else {
                 setOpen(false);

--- a/src/components/instantlaunches/InstantLaunchButtonWrapper.js
+++ b/src/components/instantlaunches/InstantLaunchButtonWrapper.js
@@ -81,8 +81,8 @@ function InstantLaunchButtonWrapper(props) {
                     setOpen(false);
                 }
                 if (autolaunch) {
-                    // go to the analysis landing
-                    router.push(
+                    // go to the analysis landing, not keeping this page in browser history
+                    router.replace(
                         `/${NavigationConstants.ANALYSES}/${analysis?.id}`
                     );
                 }


### PR DESCRIPTION
At least for now, only the dedicated launch page uses the `autolaunch` prop, so I don't think we need to add a new prop at this time.