### PR TITLE
Reset hasLaunched after closing the instant launch dialog

### DIFF
--- a/src/components/instantlaunches/InstantLaunchButtonWrapper.js
+++ b/src/components/instantlaunches/InstantLaunchButtonWrapper.js
@@ -74,6 +74,8 @@ function InstantLaunchButtonWrapper(props) {
             window.open(`${getHost()}${ilUrl}`);
             setIlUrl(null);
             setOpen(false);
+            // reset the value so after it closes you can launch a second by reopening
+            setHasLaunched(false);
             if (autolaunch) {
                 // go to the analysis landing, not keeping this page in browser history
                 router.replace(landingUrl);

--- a/src/components/instantlaunches/index.js
+++ b/src/components/instantlaunches/index.js
@@ -63,7 +63,7 @@ export const InstantLaunchSubmissionDialog = ({
             <DialogContent>
                 {appInfo && (
                     <Typography variant="body1">
-                        {resource
+                        {resource && resource.path
                             ? t("launchingAppWithData", {
                                   appName: appInfo.name,
                                   path: resource.path,


### PR DESCRIPTION
this way it can be reopened to launch again.