### PR TITLE
Make the standalone instant launch page show errors immediately

### DIFF
--- a/src/components/instantlaunches/launch/index.js
+++ b/src/components/instantlaunches/launch/index.js
@@ -3,11 +3,9 @@
  *
  * The component that launches a provided instant launch, immediately.
  */
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 
 import { useQuery } from "react-query";
-
-import { useRouter } from "next/router";
 
 import {
     GET_INSTANT_LAUNCH_FULL_KEY,
@@ -28,7 +26,7 @@ import InstantLaunchButtonWrapper from "components/instantlaunches/InstantLaunch
 import withErrorAnnouncer from "components/error/withErrorAnnouncer";
 import LoadingAnimation from "components/vice/loading/LoadingAnimation";
 
-import DEErrorDialog from "components/error/DEErrorDialog";
+import WrappedErrorHandler from "components/error/WrappedErrorHandler";
 
 const InstantLaunchStandalone = (props) => {
     const {
@@ -42,10 +40,7 @@ const InstantLaunchStandalone = (props) => {
         !!config?.subscriptions?.enforce
     );
     const [resource, setResource] = useState(null);
-    const [errDialogOpen, setErrDialogOpen] = useState(false);
-    const [dialogError, setDialogError] = useState(null);
 
-    const router = useRouter();
     const { t } = useTranslation(["instantlaunches", "common"]);
 
     const { data, status, error } = useQuery(
@@ -86,26 +81,10 @@ const InstantLaunchStandalone = (props) => {
         isFetchingUsageSummary,
     ]);
 
-    useEffect(() => {
-        if (error || resourceError) {
-            setDialogError(error || resourceError);
-            setErrDialogOpen(true);
-        }
-    }, [error, resourceError, setErrDialogOpen, setDialogError]);
-
     if (isLoading) {
         return <LoadingAnimation />;
     } else if (error || resourceError) {
-        return (
-            <DEErrorDialog
-                open={errDialogOpen}
-                errorObject={dialogError}
-                handleClose={() => {
-                    setErrDialogOpen(false);
-                    router.push("/");
-                }}
-            />
-        );
+        return <WrappedErrorHandler errorObject={error || resourceError} />;
     } else {
         return (
             <InstantLaunchButtonWrapper

--- a/src/components/instantlaunches/launch/index.js
+++ b/src/components/instantlaunches/launch/index.js
@@ -3,9 +3,11 @@
  *
  * The component that launches a provided instant launch, immediately.
  */
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 import { useQuery } from "react-query";
+
+import { useRouter } from "next/router";
 
 import {
     GET_INSTANT_LAUNCH_FULL_KEY,
@@ -26,7 +28,7 @@ import InstantLaunchButtonWrapper from "components/instantlaunches/InstantLaunch
 import withErrorAnnouncer from "components/error/withErrorAnnouncer";
 import LoadingAnimation from "components/vice/loading/LoadingAnimation";
 
-import ErrorTypographyWithDialog from "components/error/ErrorTypographyWithDialog";
+import DEErrorDialog from "components/error/DEErrorDialog";
 
 const InstantLaunchStandalone = (props) => {
     const {
@@ -40,7 +42,10 @@ const InstantLaunchStandalone = (props) => {
         !!config?.subscriptions?.enforce
     );
     const [resource, setResource] = useState(null);
+    const [errDialogOpen, setErrDialogOpen] = useState(false);
+    const [dialogError, setDialogError] = useState(null);
 
+    const router = useRouter();
     const { t } = useTranslation(["instantlaunches", "common"]);
 
     const { data, status, error } = useQuery(
@@ -81,14 +86,24 @@ const InstantLaunchStandalone = (props) => {
         isFetchingUsageSummary,
     ]);
 
+    useEffect(() => {
+        if (error || resourceError) {
+            setDialogError(error || resourceError);
+            setErrDialogOpen(true);
+        }
+    }, [error, resourceError, setErrDialogOpen, setDialogError]);
+
     if (isLoading) {
         return <LoadingAnimation />;
     } else if (error || resourceError) {
-        const err = error || resourceError;
         return (
-            <ErrorTypographyWithDialog
-                errorMessage={t("instantLaunchError")}
-                errorObject={err}
+            <DEErrorDialog
+                open={errDialogOpen}
+                errorObject={dialogError}
+                handleClose={() => {
+                    setErrDialogOpen(false);
+                    router.push("/");
+                }}
             />
         );
     } else {

--- a/src/components/instantlaunches/launch/index.js
+++ b/src/components/instantlaunches/launch/index.js
@@ -21,6 +21,7 @@ import { useConfig } from "contexts/config";
 import { useUserProfile } from "contexts/userProfile";
 import globalConstants from "../../../constants";
 import { useTranslation } from "i18n";
+import ids from "components/instantlaunches/ids";
 import isQueryLoading from "components/utils/isQueryLoading";
 import InstantLaunchButtonWrapper from "components/instantlaunches/InstantLaunchButtonWrapper";
 import withErrorAnnouncer from "components/error/withErrorAnnouncer";
@@ -84,7 +85,12 @@ const InstantLaunchStandalone = (props) => {
     if (isLoading) {
         return <LoadingAnimation />;
     } else if (error || resourceError) {
-        return <WrappedErrorHandler errorObject={error || resourceError} />;
+        return (
+            <WrappedErrorHandler
+                baseId={ids.BASE}
+                errorObject={error || resourceError}
+            />
+        );
     } else {
         return (
             <InstantLaunchButtonWrapper


### PR DESCRIPTION
This is better than putting it behind an `ErrorTypographyWithDialog` because there's not really much reason to just show a text error that tells you almost nothing with a detail button, on a page with nothing else. I also made it so if you close the error dialog it just redirects you to the dashboard since there's not much reason to stay on the page at that point.