### PR TITLE
Add automatic SSO redirect for authenticated users

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -101,6 +101,20 @@ app.prepare()
         logger.info("configuring keycloak");
         server.use(keycloakClient.middleware());
 
+        server.get("/", keycloakClient.checkSso(), async (req, res, next) => {
+            try {
+                const userProfile = authn.getUserProfile(req);
+
+                if (userProfile) {
+                    return res.redirect(`/${NavigationConstants.DASHBOARD}`);
+                }
+
+                return nextHandler(req, res);
+            } catch (error) {
+                return next(error);
+            }
+        });
+
         logger.info("adding the /login handler");
         server.get("/login", keycloakClient.protect(), (req, res) => {
             res.redirect("/");


### PR DESCRIPTION
When a user has an active Keycloak session,  they will now be automatically redirected to the dashboard instead of seeing the landing/login page.

- Add checkSso middleware to root route
- Add redirect to dashboard for authenticated users
- Maintain fallback to landing page for unauthenticated users