### PR TITLE
Update file viewer to download binary files instead of displaying them

### DIFF
--- a/src/components/data/viewers/FileViewer.js
+++ b/src/components/data/viewers/FileViewer.js
@@ -271,18 +271,22 @@ export default function FileViewer(props) {
                         setViewerType(VIEWER_TYPE.PATH_LIST);
                         break;
                     } else {
-                        if (!createFileType) {
-                            setReadChunkKey([
-                                READ_CHUNK_QUERY_KEY,
-                                {
-                                    path,
-                                    chunkSize:
-                                        viewerConstants.DEFAULT_PAGE_SIZE,
-                                },
-                            ]);
-                            setReadChunkQueryEnabled(true);
+                        if (manifest["content-type"].startsWith("text/")) {
+                            if (!createFileType) {
+                                setReadChunkKey([
+                                    READ_CHUNK_QUERY_KEY,
+                                    {
+                                        path,
+                                        chunkSize:
+                                            viewerConstants.DEFAULT_PAGE_SIZE,
+                                    },
+                                ]);
+                                setReadChunkQueryEnabled(true);
+                            }
+                            setViewerType(VIEWER_TYPE.PLAIN);
+                        } else {
+                            setViewerType(VIEWER_TYPE.DOCUMENT);
                         }
-                        setViewerType(VIEWER_TYPE.PLAIN);
                         break;
                     }
             }

--- a/src/components/data/viewers/FileViewer.js
+++ b/src/components/data/viewers/FileViewer.js
@@ -275,7 +275,6 @@ export default function FileViewer(props) {
                         const viewableApplicationTypes = [
                             mimeTypes.JSON,
                             mimeTypes.XML,
-                            mimeTypes.XHTML_XML,
                         ];
 
                         if (

--- a/src/components/data/viewers/FileViewer.js
+++ b/src/components/data/viewers/FileViewer.js
@@ -271,7 +271,17 @@ export default function FileViewer(props) {
                         setViewerType(VIEWER_TYPE.PATH_LIST);
                         break;
                     } else {
-                        if (manifest["content-type"].startsWith("text/")) {
+                        // Special handling for text-based formats that don't use text/ prefix
+                        const viewableApplicationTypes = [
+                            mimeTypes.JSON,
+                            mimeTypes.XML,
+                            mimeTypes.XHTML_XML,
+                        ];
+
+                        if (
+                            manifest["content-type"].startsWith("text/") ||
+                            viewableApplicationTypes.includes(mimeType)
+                        ) {
                             if (!createFileType) {
                                 setReadChunkKey([
                                     READ_CHUNK_QUERY_KEY,


### PR DESCRIPTION
The file viewer was attempting to display binary files in the text editor.

Modified the file viewer to automatically trigger downloads for non-text files instead of trying to display them. This is implemented by checking if the content-type starts with "text/" - if not, the file is handled by VIEWER_TYPE.DOCUMENT which opens in a new tab/window for download.

Testing: 
- Verified .txt .py .csv .pdf .jpg .png etc. still open in the file editor as expected
- Verified binary files (.xlsx, .docx, etc.) now trigger download instead of displaying in editor