### PR TITLE
Enable public data downloads by using new unauthentication-allowed Terrain endpoints

### DIFF
--- a/src/server/api/downloads.js
+++ b/src/server/api/downloads.js
@@ -79,7 +79,7 @@ const metadataTemplateCSVhandler = async (req, res) => {
 
 const doDownloadFromTerrain = (userID, accessToken, apiURL) => {
     logger.info(`TERRAIN ${userID} GET ${apiURL.href}`);
-    let requestOptions = {
+    const requestOptions = {
         method: "GET",
         url: apiURL,
         headers: {


### PR DESCRIPTION
Well, this was easy and seems to all work as expected. We weren't preventing logged-out users from pushing the buttons already, so nothing needed to be removed as far as that.