### PR TITLE
CORE-2034 Update data listing with new metadata search endpoint

### DIFF
--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -257,7 +257,7 @@ function Listing(props) {
         queryKey: [FILESYSTEM_FIND_METADATA_QUERY_KEY, { dataId: data?.id }],
         queryFn: () =>
             findFilesystemMetadata({
-                attribute: LocalContextsAttrs.LOCAL_CONTEXTS,
+                attribute: [LocalContextsAttrs.LOCAL_CONTEXTS],
                 "target-id": [data.id, ...data.listing.map((r) => r.id)],
             }),
         enabled: !!data?.id,

--- a/src/components/data/listing/TableView.js
+++ b/src/components/data/listing/TableView.js
@@ -33,17 +33,12 @@ import EmptyTable from "components/table/EmptyTable";
 import { formatDate } from "components/utils/DateFormatter";
 
 import LocalContextsLabelDisplay from "components/metadata/LocalContextsLabelDisplay";
-import {
-    LocalContextsAttrs,
-    parseProjectID,
-} from "components/models/metadata/LocalContexts";
+import { parseProjectID } from "components/models/metadata/LocalContexts";
 
 import InstantLaunchButton from "components/instantlaunches";
 import { defaultInstantLaunch } from "serviceFacades/instantlaunches";
 
 import {
-    FILESYSTEM_METADATA_QUERY_KEY,
-    getFilesystemMetadata,
     getLocalContextsProject,
     LOCAL_CONTEXTS_QUERY_KEY,
 } from "serviceFacades/metadata";
@@ -70,37 +65,13 @@ function ResourceNameCell({
     computeLimitExceeded,
     handlePathChange,
     limitQueries,
+    localContextsURIMap,
 }) {
     const theme = useTheme();
-    const [localContextsProjectURI, setLocalContextsProjectURI] = useState();
 
     const resourceId = resource.id;
-
-    useQuery({
-        queryKey: [FILESYSTEM_METADATA_QUERY_KEY, { dataId: resourceId }],
-        queryFn: () =>
-            limitQueries(() => getFilesystemMetadata({ dataId: resourceId })),
-        enabled: !!resourceId,
-        onSuccess: (metadata) => {
-            const { avus } = metadata;
-
-            const rightsURI = avus
-                ?.find((avu) => avu.attr === LocalContextsAttrs.LOCAL_CONTEXTS)
-                ?.avus?.find(
-                    (childAVU) =>
-                        childAVU.attr === LocalContextsAttrs.RIGHTS_URI
-                )?.value;
-
-            if (rightsURI) {
-                setLocalContextsProjectURI(rightsURI);
-            }
-        },
-        onError: (error) =>
-            console.log(
-                "Unable to fetch metadata for folder " + resource.label,
-                error
-            ), // fail silently.
-    });
+    const localContextsProjectURI =
+        localContextsURIMap && localContextsURIMap[resourceId];
 
     const projectID = parseProjectID(localContextsProjectURI);
 
@@ -270,6 +241,7 @@ function TableView(props) {
         onMoveSelected,
         instantLaunchDefaultsMapping,
         computeLimitExceeded,
+        localContextsURIMap,
     } = props;
 
     const { classes: invalidRowClass } = invalidRowStyles();
@@ -507,6 +479,9 @@ function TableView(props) {
                                             }
                                             handlePathChange={handlePathChange}
                                             limitQueries={limitQueries}
+                                            localContextsURIMap={
+                                                localContextsURIMap
+                                            }
                                         />
                                         {getColumnDetails(displayColumns).map(
                                             (column, index) => (

--- a/src/server/api/metadata.js
+++ b/src/server/api/metadata.js
@@ -19,6 +19,19 @@ export default function metadataRouter() {
 
     logger.info("************ Adding Metadata handlers **********");
 
+    logger.info("adding the POST /api/filesystem/metadata/search handler");
+    api.post(
+        "/filesystem/metadata/search",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "POST",
+            pathname: "/filesystem/metadata/search",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        })
+    );
+
     logger.info("adding the GET /api/filesystem/metadata/templates handler");
     api.get(
         "/filesystem/metadata/templates",
@@ -48,16 +61,6 @@ export default function metadataRouter() {
         "/filesystem/metadata/template/:templateId/zip-csv",
         auth.authnTokenMiddleware,
         metadataTemplateCSVhandler
-    );
-
-    logger.info("adding the GET /api/filesystem/metadata handler");
-    api.get(
-        "/filesystem/metadata",
-        auth.authnTokenMiddleware,
-        terrainHandler({
-            method: "GET",
-            pathname: "/filesystem/metadata",
-        })
     );
 
     logger.info("adding the GET /api/filesystem/:dataId/metadata handler");

--- a/src/server/api/metadata.js
+++ b/src/server/api/metadata.js
@@ -50,6 +50,16 @@ export default function metadataRouter() {
         metadataTemplateCSVhandler
     );
 
+    logger.info("adding the GET /api/filesystem/metadata handler");
+    api.get(
+        "/filesystem/metadata",
+        auth.authnTokenMiddleware,
+        terrainHandler({
+            method: "GET",
+            pathname: "/filesystem/metadata",
+        })
+    );
+
     logger.info("adding the GET /api/filesystem/:dataId/metadata handler");
     api.get(
         "/filesystem/:dataId/metadata",

--- a/src/serviceFacades/metadata.js
+++ b/src/serviceFacades/metadata.js
@@ -6,6 +6,7 @@ import axiosInstance from "../common/getAxios";
 
 const EXTERNAL_API_DEFAULT_RESULT_LIMIT = 50;
 const FILESYSTEM_METADATA_QUERY_KEY = "fetchFilesystemMetadataKey";
+const FILESYSTEM_FIND_METADATA_QUERY_KEY = "fetchFilesystemBulkMetadataKey";
 const FILESYSTEM_METADATA_TEMPLATE_QUERY_KEY =
     "fetchFilesystemMetadataTemplateKey";
 const FILESYSTEM_METADATA_TEMPLATE_LISTING_QUERY_KEY =
@@ -25,6 +26,14 @@ function getFilesystemMetadataTemplate(templateId) {
     return callApi({
         endpoint: `/api/filesystem/metadata/template/${templateId}`,
         method: "GET",
+    });
+}
+
+function findFilesystemMetadata(params) {
+    return callApi({
+        endpoint: `/api/filesystem/metadata`,
+        method: "GET",
+        params,
     });
 }
 
@@ -149,6 +158,7 @@ function getLocalContextsProject({ projectID }) {
 }
 
 export {
+    FILESYSTEM_FIND_METADATA_QUERY_KEY,
     FILESYSTEM_METADATA_QUERY_KEY,
     FILESYSTEM_METADATA_TEMPLATE_QUERY_KEY,
     FILESYSTEM_METADATA_TEMPLATE_LISTING_QUERY_KEY,
@@ -156,6 +166,7 @@ export {
     SEARCH_OLS_QUERY_KEY,
     SEARCH_UAT_QUERY_KEY,
     getFilesystemMetadata,
+    findFilesystemMetadata,
     getFilesystemMetadataTemplate,
     getFilesystemMetadataTemplateListing,
     saveFilesystemMetadata,

--- a/src/serviceFacades/metadata.js
+++ b/src/serviceFacades/metadata.js
@@ -15,6 +15,14 @@ const SEARCH_OLS_QUERY_KEY = "searchOntologyLookupServiceKey";
 const SEARCH_UAT_QUERY_KEY = "searchUnifiedAstronomyThesaurusKey";
 const LOCAL_CONTEXTS_QUERY_KEY = "localContextsKey";
 
+function findFilesystemMetadata(body) {
+    return callApi({
+        endpoint: `/api/filesystem/metadata/search`,
+        method: "POST",
+        body,
+    });
+}
+
 function getFilesystemMetadataTemplateListing() {
     return callApi({
         endpoint: "/api/filesystem/metadata/templates",
@@ -26,14 +34,6 @@ function getFilesystemMetadataTemplate(templateId) {
     return callApi({
         endpoint: `/api/filesystem/metadata/template/${templateId}`,
         method: "GET",
-    });
-}
-
-function findFilesystemMetadata(params) {
-    return callApi({
-        endpoint: `/api/filesystem/metadata`,
-        method: "GET",
-        params,
     });
 }
 

--- a/stories/data/Listing.stories.js
+++ b/stories/data/Listing.stories.js
@@ -81,8 +81,8 @@ const DataListingTestTemplate = (args) => {
         .onGet(/\/api\/resource-usage\/summary.*/)
         .reply(usageSummaryError ? 400 : 200, usageSummaryResponse);
 
-    mockAxios.onGet("/api/filesystem/metadata").reply((config) => {
-        console.log("getMetadata", config.url, config.params);
+    mockAxios.onPost("/api/filesystem/metadata/search").reply((config) => {
+        console.log("Search Metadata", config.url, config.data);
 
         return [200, MockMetadata];
     });

--- a/stories/data/Listing.stories.js
+++ b/stories/data/Listing.stories.js
@@ -81,8 +81,8 @@ const DataListingTestTemplate = (args) => {
         .onGet(/\/api\/resource-usage\/summary.*/)
         .reply(usageSummaryError ? 400 : 200, usageSummaryResponse);
 
-    mockAxios.onGet(/\/api\/filesystem\/.*\/metadata/).reply((config) => {
-        console.log("getMetadata", config.url);
+    mockAxios.onGet("/api/filesystem/metadata").reply((config) => {
+        console.log("getMetadata", config.url, config.params);
 
         return [200, MockMetadata];
     });


### PR DESCRIPTION
This PR will update the data listing so that each `ResourceNameCell` in the listing no longer queries the API for that item's metadata.

Instead, the top-level folder will use the new `POST /filesystem/metadata/search` endpoint (added in cyverse-de/terrain#305) to search for `LocalContexts` metadata for itself, and each item in its listing, all in one API call.