### PR TITLE
CORE-2050 Disable Sharing for Users with Basic Subscriptions

### DIFF
--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -86,6 +86,7 @@
     "select": "Select",
     "selectAllLabel": "Select All",
     "settings": "Settings",
+    "sharingNotAvailable": "Sharing feature is not available for Basic subscriptions. Please upgrade your subscription tier. <subscriptionLink>More details here</subscriptionLink>.",
     "sortLabel": "Sort",
     "submit": "Submit",
     "subscriptions": "Subscriptions",

--- a/src/__tests__/apps.js
+++ b/src/__tests__/apps.js
@@ -3,7 +3,7 @@ import TestRenderer from "react-test-renderer";
 
 import { AppsTableViewTest } from "../../stories/apps/TableView.stories";
 import { mockAxios } from "../../stories/axiosMock";
-import { AppsListingTest } from "../../stories/apps/Listing.stories";
+import { NormalListing } from "../../stories/apps/Listing.stories";
 import { I18nProviderWrapper } from "__mocks__/i18nProviderWrapper";
 import { UserProfileProvider } from "contexts/userProfile";
 import { ConfigProvider } from "contexts/config";
@@ -38,7 +38,7 @@ test("App Listing view", () => {
         <RQWrapper>
             <I18nProviderWrapper>
                 <BagInfoProvider>
-                    <AppsListingTest />
+                    <NormalListing />
                 </BagInfoProvider>
             </I18nProviderWrapper>
         </RQWrapper>

--- a/src/common/useResourceUsageSummary.js
+++ b/src/common/useResourceUsageSummary.js
@@ -1,0 +1,99 @@
+/**
+ * A hook to fetch a user's resource usage summary,
+ * along with convenience flags and parsed values.
+ *
+ * @author psarando
+ */
+import { useQuery } from "react-query";
+
+import constants from "../constants";
+import { useTranslation } from "i18n";
+import { useConfig } from "contexts/config";
+import { useUserProfile } from "contexts/userProfile";
+import {
+    getResourceUsageSummary,
+    RESOURCE_USAGE_QUERY_KEY,
+} from "serviceFacades/dashboard";
+
+import { getUserQuota } from "./resourceUsage";
+
+/**
+ * A hook to fetch a user's resource usage summary.
+ *
+ * @param {function} showErrorAnnouncer - Function to show error announcements.
+ *
+ * @returns {object} An object containing the resource usage summary
+ *                   along with convenience flags and parsed values.
+ */
+function useResourceUsageSummary(showErrorAnnouncer) {
+    const { t } = useTranslation("common");
+    const [config] = useConfig();
+    const [userProfile] = useUserProfile();
+
+    const enforceSubscriptions = config?.subscriptions?.enforce;
+
+    const {
+        isFetching: isFetchingUsageSummary,
+        data: resourceUsageSummary,
+        error: resourceUsageError,
+    } = useQuery({
+        queryKey: [RESOURCE_USAGE_QUERY_KEY, userProfile?.id],
+        queryFn: getResourceUsageSummary,
+        enabled: enforceSubscriptions && !!userProfile?.id,
+        onError: (e) => {
+            showErrorAnnouncer(t("usageSummaryError"), e);
+        },
+    });
+
+    const dataUsage = resourceUsageSummary?.data_usage?.total || 0;
+    const computeUsage = resourceUsageSummary?.cpu_usage?.total || 0;
+    const subscription = resourceUsageSummary?.subscription;
+
+    const storageQuota = getUserQuota(
+        constants.DATA_STORAGE_RESOURCE_NAME,
+        subscription
+    );
+    const computeQuota = getUserQuota(
+        constants.CPU_HOURS_RESOURCE_NAME,
+        subscription
+    );
+
+    const planName = subscription?.plan?.name || constants.PLAN_NAME_BASIC;
+    const hasAddons = subscription?.addons?.length > 0;
+    const hasDataAddon = !!subscription?.addons?.find(
+        ({ addon }) =>
+            addon.resource_type.name === constants.DATA_STORAGE_RESOURCE_NAME
+    );
+    const hasCPUAddon = !!subscription?.addons?.find(
+        ({ addon }) =>
+            addon.resource_type.name === constants.CPU_HOURS_RESOURCE_NAME
+    );
+
+    const dataLimitExceeded = enforceSubscriptions && dataUsage >= storageQuota;
+    const computeLimitExceeded =
+        enforceSubscriptions && computeUsage >= computeQuota;
+
+    const planCanShare =
+        !enforceSubscriptions ||
+        planName !== constants.PLAN_NAME_BASIC ||
+        hasAddons;
+
+    return {
+        isFetchingUsageSummary,
+        resourceUsageSummary,
+        resourceUsageError,
+        planName,
+        computeUsage,
+        computeQuota,
+        dataUsage,
+        storageQuota,
+        hasAddons,
+        hasDataAddon,
+        hasCPUAddon,
+        computeLimitExceeded,
+        dataLimitExceeded,
+        planCanShare,
+    };
+}
+
+export default useResourceUsageSummary;

--- a/src/components/analyses/landing/AnalysisSubmissionLanding.js
+++ b/src/components/analyses/landing/AnalysisSubmissionLanding.js
@@ -298,9 +298,15 @@ export default function AnalysisSubmissionLanding(props) {
         enabled: enforceSubscriptions && !!userProfile?.id,
         onSuccess: (respData) => {
             const subscription = respData?.subscription;
+            const planName = subscription?.plan?.name;
+            const hasCPUAddon = subscription?.addons?.find(
+                ({ addon }) =>
+                    addon.resource_type.name ===
+                    constants.CPU_HOURS_RESOURCE_NAME
+            );
 
             setPlanCanShare(
-                subscription?.plan?.name !== constants.PLAN_NAME_BASIC
+                planName !== constants.PLAN_NAME_BASIC || hasCPUAddon
             );
         },
         onError: (e) => {

--- a/src/components/analyses/landing/AnalysisSubmissionLanding.js
+++ b/src/components/analyses/landing/AnalysisSubmissionLanding.js
@@ -463,7 +463,7 @@ export default function AnalysisSubmissionLanding(props) {
                                             allowEdit={allowEdit}
                                             onClose={onClose}
                                             analysis={analysis}
-                                            canShare={canShare}
+                                            canShare={sharable}
                                             setSharingDlgOpen={
                                                 setSharingDlgOpen
                                             }

--- a/src/components/analyses/landing/DotMenuItems.js
+++ b/src/components/analyses/landing/DotMenuItems.js
@@ -43,6 +43,7 @@ export default function DotMenuItems(props) {
         allowEdit,
         onClose,
         canShare,
+        planCanShare,
         setSharingDlgOpen,
         setPendingTerminationDlgOpen,
         handleTimeLimitExtnClick,
@@ -109,6 +110,7 @@ export default function DotMenuItems(props) {
             <SharingMenuItem
                 key={buildID(baseId, shareIds.SHARING_MENU_ITEM)}
                 baseId={baseId}
+                planCanShare={planCanShare}
                 onClose={onClose}
                 setSharingDlgOpen={setSharingDlgOpen}
             />

--- a/src/components/analyses/listing/Listing.js
+++ b/src/components/analyses/listing/Listing.js
@@ -295,9 +295,15 @@ function Listing(props) {
         enabled: enforceSubscriptions && !!userProfile?.id,
         onSuccess: (respData) => {
             const subscription = respData?.subscription;
+            const planName = subscription?.plan?.name;
+            const hasCPUAddon = subscription?.addons?.find(
+                ({ addon }) =>
+                    addon.resource_type.name ===
+                    globalConstants.CPU_HOURS_RESOURCE_NAME
+            );
 
             setPlanCanShare(
-                subscription?.plan?.name !== globalConstants.PLAN_NAME_BASIC
+                planName !== globalConstants.PLAN_NAME_BASIC || hasCPUAddon
             );
         },
         onError: (e) => {

--- a/src/components/analyses/toolbar/AnalysesDotMenu.js
+++ b/src/components/analyses/toolbar/AnalysesDotMenu.js
@@ -87,6 +87,7 @@ function DotMenuItems(props) {
         onClose,
         selectedAnalyses,
         canShare,
+        planCanShare,
         setSharingDlgOpen,
         isSingleSelection,
         onFilterSelected,
@@ -139,6 +140,7 @@ function DotMenuItems(props) {
             <SharingMenuItem
                 key={buildID(baseId, shareIds.SHARING_MENU_ITEM)}
                 baseId={baseId}
+                planCanShare={planCanShare}
                 onClose={onClose}
                 setSharingDlgOpen={setSharingDlgOpen}
             />

--- a/src/components/analyses/toolbar/Toolbar.js
+++ b/src/components/analyses/toolbar/Toolbar.js
@@ -151,6 +151,7 @@ function AnalysesToolbar(props) {
         handleTerminateSelected,
         handleBatchIconClick,
         canShare,
+        planCanShare,
         setPendingTerminationDlgOpen,
         handleTimeLimitExtnClick,
         onRefreshSelected,
@@ -263,6 +264,7 @@ function AnalysesToolbar(props) {
                         {canShare && (
                             <SharingButton
                                 baseId={baseId}
+                                planCanShare={planCanShare}
                                 setSharingDlgOpen={setSharingDlgOpen}
                                 size="small"
                             />
@@ -287,6 +289,7 @@ function AnalysesToolbar(props) {
                         handleBatchIconClick={handleBatchIconClick}
                         onFilterSelected={() => setOpenFilterDialog(true)}
                         canShare={canShare}
+                        planCanShare={planCanShare}
                         setSharingDlgOpen={setSharingDlgOpen}
                         setPendingTerminationDlgOpen={
                             setPendingTerminationDlgOpen

--- a/src/components/announcer/Announcer.js
+++ b/src/components/announcer/Announcer.js
@@ -120,7 +120,7 @@ function Announcer(props) {
 
 Announcer.propTypes = {
     open: PropTypes.bool.isRequired,
-    message: PropTypes.string,
+    message: PropTypes.node,
     variant: PropTypes.oneOf(["success", "warning", "error", "info"])
         .isRequired,
     duration: PropTypes.number,

--- a/src/components/apps/listing/Listing.js
+++ b/src/components/apps/listing/Listing.js
@@ -344,9 +344,15 @@ function Listing(props) {
         enabled: !isAdminView && enforceSubscriptions && !!userProfile?.id,
         onSuccess: (respData) => {
             const subscription = respData?.subscription;
+            const planName = subscription?.plan?.name;
+            const hasCPUAddon = subscription?.addons?.find(
+                ({ addon }) =>
+                    addon.resource_type.name ===
+                    constants.CPU_HOURS_RESOURCE_NAME
+            );
 
             setPlanCanShare(
-                subscription?.plan?.name !== constants.PLAN_NAME_BASIC
+                planName !== constants.PLAN_NAME_BASIC || hasCPUAddon
             );
         },
         onError: (e) => {

--- a/src/components/apps/listing/RowDotMenu.js
+++ b/src/components/apps/listing/RowDotMenu.js
@@ -40,6 +40,7 @@ function RowDotMenu(props) {
         baseId,
         ButtonProps,
         canShare,
+        planCanShare,
         handleDisable,
         handleDelete,
         setSharingDlgOpen,
@@ -108,6 +109,7 @@ function RowDotMenu(props) {
                             key={buildID(baseId, shareIds.SHARING_MENU_ITEM)}
                             baseId={baseId}
                             onClose={onClose}
+                            planCanShare={planCanShare}
                             setSharingDlgOpen={setSharingDlgOpen}
                         />
                     ),

--- a/src/components/apps/listing/TableView.js
+++ b/src/components/apps/listing/TableView.js
@@ -107,6 +107,7 @@ function TableView(props) {
         orderBy,
         selected,
         canShare,
+        planCanShare,
         onDetailsSelected,
         setSharingDlgOpen,
         onDocSelected,
@@ -312,6 +313,9 @@ function TableView(props) {
                                                         )}
                                                         app={app}
                                                         canShare={canShare}
+                                                        planCanShare={
+                                                            planCanShare
+                                                        }
                                                         handleDelete={
                                                             handleDelete
                                                         }

--- a/src/components/apps/toolbar/AppsDotMenu.js
+++ b/src/components/apps/toolbar/AppsDotMenu.js
@@ -48,6 +48,7 @@ function AppsDotMenu(props) {
         addToBagEnabled,
         onAddToBagClicked,
         canShare,
+        planCanShare,
         setSharingDlgOpen,
         onDocSelected,
         onQLSelected,
@@ -113,6 +114,7 @@ function AppsDotMenu(props) {
                     <SharingMenuItem
                         key={buildID(baseId, shareIds.SHARING_MENU_ITEM)}
                         baseId={baseId}
+                        planCanShare={planCanShare}
                         onClose={onClose}
                         setSharingDlgOpen={setSharingDlgOpen}
                     />

--- a/src/components/apps/toolbar/Toolbar.js
+++ b/src/components/apps/toolbar/Toolbar.js
@@ -133,6 +133,7 @@ function AppsToolbar(props) {
         addToBagEnabled,
         onAddToBagClicked = () => {},
         canShare,
+        planCanShare,
         setSharingDlgOpen,
         onDocSelected,
         onQLSelected,
@@ -235,6 +236,7 @@ function AppsToolbar(props) {
                             {canShare && (
                                 <SharingButton
                                     baseId={baseId}
+                                    planCanShare={planCanShare}
                                     setSharingDlgOpen={setSharingDlgOpen}
                                     size="small"
                                 />
@@ -311,6 +313,7 @@ function AppsToolbar(props) {
                             onAddToBagClicked={onAddToBagClicked}
                             onFilterSelected={() => setOpenFilterDialog(true)}
                             canShare={canShare}
+                            planCanShare={planCanShare}
                             setSharingDlgOpen={setSharingDlgOpen}
                             onDocSelected={onDocSelected}
                             onQLSelected={onQLSelected}

--- a/src/components/dashboard/constants.js
+++ b/src/components/dashboard/constants.js
@@ -45,5 +45,4 @@ export const SM_PIXELS = 600;
 export const XS_NUM_COLUMNS = 1;
 export const XS_PIXELS = 0;
 
-export const FEATURE_MATRIX_URL = "https://cyverse.org/subscribe";
 export const QUOTA_ENFORCE_URL = "https://cyverse.org/quota-enforce";

--- a/src/components/dashboard/dashboardItem/ResourceUsageItem.js
+++ b/src/components/dashboard/dashboardItem/ResourceUsageItem.js
@@ -25,7 +25,7 @@ import ExternalLink from "components/utils/ExternalLink";
 import ErrorTypographyWithDialog from "components/error/ErrorTypographyWithDialog";
 import { formatDateObject } from "components/utils/DateFormatter";
 
-import { FEATURE_MATRIX_URL } from "../constants";
+import constants from "../../../constants";
 import { useConfig } from "contexts/config";
 
 import { Skeleton } from "@mui/material";
@@ -88,7 +88,9 @@ export default function ResourceUsageItem(props) {
                                         components={{
                                             featureMatrixLink: (
                                                 <ExternalLink
-                                                    href={FEATURE_MATRIX_URL}
+                                                    href={
+                                                        constants.SUBSCRIBE_URL
+                                                    }
                                                 />
                                             ),
                                         }}

--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -161,7 +161,7 @@ function Listing(props) {
 
     const enforceSubscriptions = config?.subscriptions?.enforce;
 
-    const [canShare, setCanShare] = useState(!enforceSubscriptions);
+    const [planCanShare, setPlanCanShare] = useState(!enforceSubscriptions);
     const [uploadsEnabled, setUploadsEnabled] = useState(!enforceSubscriptions);
     const [computeLimitExceeded, setComputeLimitExceeded] =
         useState(enforceSubscriptions);
@@ -335,7 +335,9 @@ function Listing(props) {
                     constants.DATA_STORAGE_RESOURCE_NAME
             );
 
-            setCanShare(planName !== constants.PLAN_NAME_BASIC || hasDataAddon);
+            setPlanCanShare(
+                planName !== constants.PLAN_NAME_BASIC || hasDataAddon
+            );
             setUploadsEnabled(dataUsage < storageQuota);
             setComputeLimitExceeded(computeUsage >= computeQuota);
         },
@@ -751,7 +753,7 @@ function Listing(props) {
                     onRenameSelected={onRenameClicked}
                     onMoveSelected={onMoveSelected}
                     uploadsEnabled={uploadsEnabled}
-                    canShare={canShare}
+                    planCanShare={planCanShare}
                 />
                 {localContextsProjectURI && localContextsProject && (
                     <Stack>
@@ -799,7 +801,7 @@ function Listing(props) {
                             instantLaunchDefaultsMapping
                         }
                         computeLimitExceeded={computeLimitExceeded}
-                        canShare={canShare}
+                        planCanShare={planCanShare}
                         localContextsURIMap={localContextsURIMap}
                     />
                 )}

--- a/src/components/data/listing/RowDotMenu.js
+++ b/src/components/data/listing/RowDotMenu.js
@@ -45,7 +45,7 @@ function RowDotMenu(props) {
         onRenameSelected,
         onMoveSelected,
         inTrash,
-        canShare,
+        planCanShare,
     } = props;
     const { t } = useTranslation("common");
     const { t: i18nData } = useTranslation("data");
@@ -54,7 +54,7 @@ function RowDotMenu(props) {
     const renameEnabled = !inTrash && isWritable(resource.permission);
     const publicLinkEnabled =
         !inTrash && isOwner && !containsFolders([resource]);
-    const sharingEnabled = canShare && !inTrash && isOwner;
+    const sharingEnabled = !inTrash && isOwner;
     const moveMiEnabled = !inTrash && isOwner;
     const partialLink = useDataNavigationLink(
         resource?.path,
@@ -85,6 +85,7 @@ function RowDotMenu(props) {
                     <SharingMenuItem
                         key={buildID(baseId, shareIds.SHARING_MENU_ITEM)}
                         baseId={baseId}
+                        planCanShare={planCanShare}
                         onClose={onClose}
                         setSharingDlgOpen={setSharingDlgOpen}
                     />

--- a/src/components/data/listing/TableView.js
+++ b/src/components/data/listing/TableView.js
@@ -241,7 +241,7 @@ function TableView(props) {
         onMoveSelected,
         instantLaunchDefaultsMapping,
         computeLimitExceeded,
-        canShare,
+        planCanShare,
         localContextsURIMap,
     } = props;
 
@@ -509,7 +509,7 @@ function TableView(props) {
                                                         )
                                                     }
                                                     resource={resource}
-                                                    canShare={canShare}
+                                                    planCanShare={planCanShare}
                                                     setSharingDlgOpen={
                                                         setSharingDlgOpen
                                                     }

--- a/src/components/data/toolbar/DataDotMenu.js
+++ b/src/components/data/toolbar/DataDotMenu.js
@@ -86,6 +86,7 @@ function DataDotMenu(props) {
         handleRestore,
         onRenameSelected,
         onMoveSelected,
+        planCanShare,
     } = props;
 
     const { t } = useTranslation("data");
@@ -216,6 +217,7 @@ function DataDotMenu(props) {
                                           shareIds.SHARING_MENU_ITEM
                                       )}
                                       baseId={baseId}
+                                      planCanShare={planCanShare}
                                       onClose={onClose}
                                       setSharingDlgOpen={setSharingDlgOpen}
                                   />

--- a/src/components/data/toolbar/Toolbar.js
+++ b/src/components/data/toolbar/Toolbar.js
@@ -71,7 +71,7 @@ function DataToolbar(props) {
         onMoveSelected,
         onAdvancedDataSearchSelected,
         uploadsEnabled,
-        canShare,
+        planCanShare,
     } = props;
 
     const { t } = useTranslation("data");
@@ -87,7 +87,7 @@ function DataToolbar(props) {
 
     const inTrash = isPathInTrash(path, baseTrashPath);
     const uploadEnabled = !inTrash && isWritable(permission);
-    const sharingEnabled = canShare && !inTrash && isOwner(selectedResources);
+    const sharingEnabled = !inTrash && isOwner(selectedResources);
     const bagEnabled = !inTrash && selected && selected.length > 0;
     const hasDotMenu =
         (selectedResources && selectedResources.length > 0 && !inTrash) ||
@@ -180,6 +180,7 @@ function DataToolbar(props) {
                                 <SharingButton
                                     size="small"
                                     baseId={toolbarId}
+                                    planCanShare={planCanShare}
                                     setSharingDlgOpen={setSharingDlgOpen}
                                 />
                             )}
@@ -229,6 +230,7 @@ function DataToolbar(props) {
                             onRefreshSelected={onRefreshSelected}
                             uploadEnabled={uploadEnabled}
                             sharingEnabled={sharingEnabled}
+                            planCanShare={planCanShare}
                             bagEnabled={bagEnabled}
                             handleEmptyTrash={() =>
                                 setEmptyTrashConfirmOpen(true)

--- a/src/components/instantlaunches/launch/index.js
+++ b/src/components/instantlaunches/launch/index.js
@@ -11,16 +11,8 @@ import {
     GET_INSTANT_LAUNCH_FULL_KEY,
     getFullInstantLaunch,
 } from "serviceFacades/instantlaunches";
-import {
-    getResourceUsageSummary,
-    RESOURCE_USAGE_QUERY_KEY,
-} from "serviceFacades/dashboard";
 import { useDataDetails } from "serviceFacades/filesystem";
-import { getUserQuota } from "common/resourceUsage";
-import { useConfig } from "contexts/config";
-import { useUserProfile } from "contexts/userProfile";
-import globalConstants from "../../../constants";
-import { useTranslation } from "i18n";
+import useResourceUsageSummary from "common/useResourceUsageSummary";
 import ids from "components/instantlaunches/ids";
 import isQueryLoading from "components/utils/isQueryLoading";
 import InstantLaunchButtonWrapper from "components/instantlaunches/InstantLaunchButtonWrapper";
@@ -35,37 +27,15 @@ const InstantLaunchStandalone = (props) => {
         resource: resource_path,
         showErrorAnnouncer,
     } = props;
-    const [config] = useConfig();
-    const [userProfile] = useUserProfile();
-    const [computeLimitExceeded, setComputeLimitExceeded] = useState(
-        !!config?.subscriptions?.enforce
-    );
     const [resource, setResource] = useState(null);
-
-    const { t } = useTranslation(["instantlaunches", "common"]);
 
     const { data, status, error } = useQuery(
         [GET_INSTANT_LAUNCH_FULL_KEY, instant_launch_id],
         () => getFullInstantLaunch(instant_launch_id)
     );
 
-    const { isFetching: isFetchingUsageSummary } = useQuery({
-        queryKey: [RESOURCE_USAGE_QUERY_KEY],
-        queryFn: getResourceUsageSummary,
-        enabled: !!config?.subscriptions?.enforce && !!userProfile?.id,
-        onSuccess: (respData) => {
-            const computeUsage = respData?.cpu_usage?.total || 0;
-            const subscription = respData?.subscription;
-            const computeQuota = getUserQuota(
-                globalConstants.CPU_HOURS_RESOURCE_NAME,
-                subscription
-            );
-            setComputeLimitExceeded(computeUsage >= computeQuota);
-        },
-        onError: (e) => {
-            showErrorAnnouncer(t("common:usageSummaryError"), e);
-        },
-    });
+    const { isFetchingUsageSummary, computeLimitExceeded } =
+        useResourceUsageSummary(showErrorAnnouncer);
 
     const { isFetching: isLoadingResource, error: resourceError } =
         useDataDetails({

--- a/src/components/sharing/SharingButton.js
+++ b/src/components/sharing/SharingButton.js
@@ -12,10 +12,17 @@ import { Share } from "@mui/icons-material";
 
 import { useTranslation } from "i18n";
 import ids from "./ids";
+import announcePlanCannotShare from "./announcePlanCannotShare";
 
 function SharingButton(props) {
-    const { baseId, setSharingDlgOpen, size = "medium", margin = 1 } = props;
-    const { t } = useTranslation("sharing");
+    const {
+        baseId,
+        planCanShare,
+        setSharingDlgOpen,
+        size = "medium",
+        margin = 1,
+    } = props;
+    const { t } = useTranslation(["sharing", "common"]);
 
     return (
         <Button
@@ -24,7 +31,13 @@ function SharingButton(props) {
             disableElevation
             color="primary"
             size={size}
-            onClick={() => setSharingDlgOpen(true)}
+            onClick={() => {
+                if (planCanShare) {
+                    setSharingDlgOpen(true);
+                } else {
+                    announcePlanCannotShare(t);
+                }
+            }}
             startIcon={<Share />}
             style={{ margin }}
         >

--- a/src/components/sharing/SharingMenuItem.js
+++ b/src/components/sharing/SharingMenuItem.js
@@ -11,18 +11,24 @@ import { ListItemIcon, ListItemText, MenuItem } from "@mui/material";
 import { Share } from "@mui/icons-material";
 
 import ids from "./ids";
+import announcePlanCannotShare from "./announcePlanCannotShare";
 import { useTranslation } from "i18n";
 
 function SharingMenuItem(props) {
-    const { baseId, onClose, setSharingDlgOpen } = props;
-    const { t } = useTranslation("sharing");
+    const { baseId, planCanShare, onClose, setSharingDlgOpen } = props;
+    const { t } = useTranslation(["sharing", "common"]);
 
     return (
         <MenuItem
             id={buildID(baseId, ids.SHARING_MENU_ITEM)}
             onClick={() => {
                 onClose();
-                setSharingDlgOpen(true);
+
+                if (planCanShare) {
+                    setSharingDlgOpen(true);
+                } else {
+                    announcePlanCannotShare(t);
+                }
             }}
         >
             <ListItemIcon>

--- a/src/components/sharing/announcePlanCannotShare.js
+++ b/src/components/sharing/announcePlanCannotShare.js
@@ -1,0 +1,36 @@
+/**
+ * @author psarando
+ */
+
+import React from "react";
+
+import { Trans } from "i18n";
+import constants from "../../constants";
+
+import { WARNING } from "components/announcer/AnnouncerConstants";
+import { announce } from "components/announcer/CyVerseAnnouncer";
+import ExternalLink from "components/utils/ExternalLink";
+
+/**
+ * An announcer to display a message when a subscription does not allow sharing.
+ *
+ * @param t - The i18n translation function returned by `useTranslation`.
+ *            The `common` namespace is required.
+ */
+const announcePlanCannotShare = (t) =>
+    announce({
+        text: (
+            <Trans
+                t={t}
+                i18nKey="common:sharingNotAvailable"
+                components={{
+                    subscriptionLink: (
+                        <ExternalLink href={constants.SUBSCRIBE_URL} />
+                    ),
+                }}
+            />
+        ),
+        variant: WARNING,
+    });
+
+export default announcePlanCannotShare;

--- a/src/constants.js
+++ b/src/constants.js
@@ -118,6 +118,8 @@ const constants = {
     CPU_HOURS_QUOTA_LIMIT_DEFAULT: 20,
     CPU_HOURS_RESOURCE_NAME: "cpu.hours",
     PLAN_NAME_BASIC: "Basic",
+
+    SUBSCRIBE_URL: "https://cyverse.org/subscribe",
 };
 
 export default constants;

--- a/src/pages/apps/[systemId]/[appId]/launch.js
+++ b/src/pages/apps/[systemId]/[appId]/launch.js
@@ -10,7 +10,7 @@ import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useQuery } from "react-query";
 
-import { i18n, RequiredNamespaces, useTranslation } from "i18n";
+import { i18n, RequiredNamespaces } from "i18n";
 
 import {
     getAppDescription,
@@ -25,34 +25,24 @@ import {
 import AppLaunch from "components/apps/launch";
 import { useUserProfile } from "contexts/userProfile";
 
-import {
-    getResourceUsageSummary,
-    RESOURCE_USAGE_QUERY_KEY,
-} from "serviceFacades/dashboard";
-import { useConfig } from "contexts/config";
+import useResourceUsageSummary from "common/useResourceUsageSummary";
 
-import { getUserQuota } from "../../../../common/resourceUsage";
-import globalConstants from "../../../../constants";
 import withErrorAnnouncer from "components/error/withErrorAnnouncer";
 
-export const APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY =
-    RESOURCE_USAGE_QUERY_KEY + "AppLaunch";
-
 function Launch({ showErrorAnnouncer }) {
-    const { t } = useTranslation("common");
-    const [config] = useConfig();
     const [userProfile] = useUserProfile();
     const [app, setApp] = React.useState(null);
     const [launchError, setLaunchError] = React.useState(null);
     const [viceQuota, setViceQuota] = React.useState();
     const [runningJobs, setRunningJobs] = React.useState();
     const [hasPendingRequest, setHasPendingRequest] = React.useState();
-    const [computeLimitExceeded, setComputeLimitExceeded] = React.useState(
-        !!config?.subscriptions?.enforce
-    );
 
     const router = useRouter();
     const { systemId, appId } = router.query;
+
+    const { isFetchingUsageSummary, computeLimitExceeded } =
+        useResourceUsageSummary(showErrorAnnouncer);
+
     const launchId =
         router.query["saved-launch-id"] || router.query["quick-launch-id"];
 
@@ -85,26 +75,8 @@ function Launch({ showErrorAnnouncer }) {
         onError: setLaunchError,
     });
 
-    const { isFetching: fetchingUsageSummary } = useQuery({
-        queryKey: [APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY],
-        queryFn: getResourceUsageSummary,
-        enabled: !!config?.subscriptions?.enforce && !!userProfile?.id,
-        onSuccess: (respData) => {
-            const usage = respData?.cpu_usage?.total || 0;
-            const subscription = respData?.subscription;
-            const quota = getUserQuota(
-                globalConstants.CPU_HOURS_RESOURCE_NAME,
-                subscription
-            );
-            setComputeLimitExceeded(usage >= quota);
-        },
-        onError: (e) => {
-            showErrorAnnouncer(t("usageSummaryError"), e);
-        },
-    });
-
     const loading =
-        appDescriptionLoading || savedLaunchLoading || fetchingUsageSummary;
+        appDescriptionLoading || savedLaunchLoading || isFetchingUsageSummary;
 
     return (
         <AppLaunch

--- a/src/pages/apps/[systemId]/[appId]/versions/[versionId]/launch.js
+++ b/src/pages/apps/[systemId]/[appId]/versions/[versionId]/launch.js
@@ -17,9 +17,11 @@ import {
 } from "serviceFacades/apps";
 
 import AppLaunch from "components/apps/launch";
+import withErrorAnnouncer from "components/error/withErrorAnnouncer";
 import { useUserProfile } from "contexts/userProfile";
+import useResourceUsageSummary from "common/useResourceUsageSummary";
 
-export default function Launch() {
+function Launch({ showErrorAnnouncer }) {
     const [userProfile] = useUserProfile();
     const [app, setApp] = React.useState(null);
     const [launchError, setLaunchError] = React.useState(null);
@@ -30,7 +32,10 @@ export default function Launch() {
     const router = useRouter();
     const { systemId, appId, versionId } = router.query;
 
-    const { isFetching: loading } = useQuery({
+    const { isFetchingUsageSummary, computeLimitExceeded } =
+        useResourceUsageSummary(showErrorAnnouncer);
+
+    const { isFetching: appDescriptionLoading } = useQuery({
         queryKey: [
             APP_DESCRIPTION_QUERY_KEY,
             {
@@ -63,6 +68,8 @@ export default function Launch() {
         onError: setLaunchError,
     });
 
+    const loading = appDescriptionLoading || isFetchingUsageSummary;
+
     return (
         <AppLaunch
             app={app}
@@ -71,6 +78,7 @@ export default function Launch() {
             viceQuota={viceQuota}
             runningJobs={runningJobs}
             pendingRequest={hasPendingRequest}
+            computeLimitExceeded={computeLimitExceeded}
         />
     );
 }
@@ -91,3 +99,5 @@ export async function getServerSideProps({ locale }) {
         },
     };
 }
+
+export default withErrorAnnouncer(Launch);

--- a/stories/analyses/AnalysisSubmissionLanding.stories.js
+++ b/stories/analyses/AnalysisSubmissionLanding.stories.js
@@ -4,6 +4,7 @@ import { AXIOS_DELAY, mockAxios } from "../axiosMock";
 import {
     usageSummaryResponse,
     usageSummaryBasicSubscriptionResponse,
+    usageSummaryBasicSubscriptionAddonsResponse,
 } from "../usageSummaryMock";
 import {
     deWordCountAnalysis,
@@ -89,3 +90,12 @@ BasicSubscriptionLanding.args = {
     usageSummaryResponse: usageSummaryBasicSubscriptionResponse,
 };
 BasicSubscriptionLanding.argTypes = argTypes;
+
+export const BasicSubscriptionWithAddonsLanding =
+    AnalysisSubmissionLandingTemplate.bind({});
+BasicSubscriptionWithAddonsLanding.parameters = parameters;
+BasicSubscriptionWithAddonsLanding.args = {
+    ...args,
+    usageSummaryResponse: usageSummaryBasicSubscriptionAddonsResponse,
+};
+BasicSubscriptionWithAddonsLanding.argTypes = argTypes;

--- a/stories/analyses/AnalysisSubmissionLanding.stories.js
+++ b/stories/analyses/AnalysisSubmissionLanding.stories.js
@@ -2,6 +2,10 @@ import React from "react";
 import { useQueryClient } from "react-query";
 import { AXIOS_DELAY, mockAxios } from "../axiosMock";
 import {
+    usageSummaryResponse,
+    usageSummaryBasicSubscriptionResponse,
+} from "../usageSummaryMock";
+import {
     deWordCountAnalysis,
     runningVICEAnalysis,
     params,
@@ -17,7 +21,11 @@ export default {
     title: "Analyses / Submission Landing",
 };
 
-export const AnalysisSubmissionLandingTest = ({ analysis, timeLimit }) => {
+const AnalysisSubmissionLandingTemplate = ({
+    analysis,
+    timeLimit,
+    usageSummaryResponse,
+}) => {
     const queryClient = useQueryClient();
 
     React.useEffect(() => {
@@ -35,6 +43,9 @@ export const AnalysisSubmissionLandingTest = ({ analysis, timeLimit }) => {
     mockAxios
         .onGet(new RegExp("/api/analyses/.*/time-limit"))
         .reply(200, { time_limit: convertTimeLimitArgType(timeLimit) });
+    mockAxios
+        .onGet(new RegExp("/api/resource-usage/summary.*"))
+        .reply(200, usageSummaryResponse);
 
     return (
         <NotificationsProvider wsEnabled={false}>
@@ -45,14 +56,14 @@ export const AnalysisSubmissionLandingTest = ({ analysis, timeLimit }) => {
         </NotificationsProvider>
     );
 };
-AnalysisSubmissionLandingTest.parameters = {
+const parameters = {
     chromatic: { delay: AXIOS_DELAY * 2 },
 };
-AnalysisSubmissionLandingTest.args = {
+const args = {
     analysis: "DE",
     timeLimit: "null",
 };
-AnalysisSubmissionLandingTest.argTypes = {
+const argTypes = {
     analysis: {
         options: ["DE", "VICE"],
         mapping: {
@@ -63,3 +74,18 @@ AnalysisSubmissionLandingTest.argTypes = {
     },
     ...TimeLimitArgType,
 };
+
+export const NormalLanding = AnalysisSubmissionLandingTemplate.bind({});
+NormalLanding.parameters = parameters;
+NormalLanding.args = { ...args, usageSummaryResponse };
+NormalLanding.argTypes = argTypes;
+
+export const BasicSubscriptionLanding = AnalysisSubmissionLandingTemplate.bind(
+    {}
+);
+BasicSubscriptionLanding.parameters = parameters;
+BasicSubscriptionLanding.args = {
+    ...args,
+    usageSummaryResponse: usageSummaryBasicSubscriptionResponse,
+};
+BasicSubscriptionLanding.argTypes = argTypes;

--- a/stories/analyses/Listing.stories.js
+++ b/stories/analyses/Listing.stories.js
@@ -8,6 +8,11 @@ import constants from "../../src/constants";
 
 import { mockAxios } from "../axiosMock";
 
+import {
+    usageSummaryResponse,
+    usageSummaryBasicSubscriptionResponse,
+} from "../usageSummaryMock";
+
 import { info, listing } from "./AnalysesMocks";
 import { convertTimeLimitArgType, TimeLimitArgType } from "./ArgTypes";
 
@@ -74,7 +79,7 @@ const errorResponse = {
     reason: "This error will only occur once! Please try again...",
 };
 
-export const AnalysesListingTest = ({ timeLimit }) => {
+const AnalysesListingTemplate = ({ timeLimit, usageSummaryResponse }) => {
     const queryClient = useQueryClient();
 
     React.useEffect(() => {
@@ -158,11 +163,23 @@ export const AnalysesListingTest = ({ timeLimit }) => {
         console.log("Support Email", config.url, JSON.parse(config.data));
         return [200];
     });
+    mockAxios
+        .onGet(new RegExp("/api/resource-usage/summary.*"))
+        .reply(200, usageSummaryResponse);
 
     return <ListingTest />;
 };
 
-AnalysesListingTest.args = {
+export const NormalListing = AnalysesListingTemplate.bind({});
+NormalListing.args = {
     timeLimit: "null",
+    usageSummaryResponse,
 };
-AnalysesListingTest.argTypes = TimeLimitArgType;
+NormalListing.argTypes = TimeLimitArgType;
+
+export const BasicSubscriptionListing = AnalysesListingTemplate.bind({});
+BasicSubscriptionListing.args = {
+    timeLimit: "null",
+    usageSummaryResponse: usageSummaryBasicSubscriptionResponse,
+};
+BasicSubscriptionListing.argTypes = TimeLimitArgType;

--- a/stories/analyses/Listing.stories.js
+++ b/stories/analyses/Listing.stories.js
@@ -11,6 +11,7 @@ import { mockAxios } from "../axiosMock";
 import {
     usageSummaryResponse,
     usageSummaryBasicSubscriptionResponse,
+    usageSummaryBasicSubscriptionAddonsResponse,
 } from "../usageSummaryMock";
 
 import { info, listing } from "./AnalysesMocks";
@@ -183,3 +184,12 @@ BasicSubscriptionListing.args = {
     usageSummaryResponse: usageSummaryBasicSubscriptionResponse,
 };
 BasicSubscriptionListing.argTypes = TimeLimitArgType;
+
+export const BasicSubscriptionWithAddonsListing = AnalysesListingTemplate.bind(
+    {}
+);
+BasicSubscriptionWithAddonsListing.args = {
+    timeLimit: "null",
+    usageSummaryResponse: usageSummaryBasicSubscriptionAddonsResponse,
+};
+BasicSubscriptionWithAddonsListing.argTypes = TimeLimitArgType;

--- a/stories/apps/Listing.stories.js
+++ b/stories/apps/Listing.stories.js
@@ -5,6 +5,7 @@ import { useTranslation } from "i18n";
 import { AXIOS_DELAY, errorResponseJSON, mockAxios } from "../axiosMock";
 import userProfileMock from "../userProfileMock";
 import {
+    usageSummaryBasicSubscriptionAddonsResponse,
     usageSummaryBasicSubscriptionResponse,
     usageSummaryResponse,
 } from "../usageSummaryMock";
@@ -216,3 +217,11 @@ BasicSubscriptionListing.args = {
 };
 BasicSubscriptionListing.argTypes = argTypes;
 BasicSubscriptionListing.parameters = parameters;
+
+export const BasicSubscriptionWithAddonsListing = AppsListingTemplate.bind({});
+BasicSubscriptionWithAddonsListing.args = {
+    ...args,
+    usageSummaryResponse: usageSummaryBasicSubscriptionAddonsResponse,
+};
+BasicSubscriptionWithAddonsListing.argTypes = argTypes;
+BasicSubscriptionWithAddonsListing.parameters = parameters;

--- a/stories/apps/Listing.stories.js
+++ b/stories/apps/Listing.stories.js
@@ -4,6 +4,10 @@ import { useTranslation } from "i18n";
 
 import { AXIOS_DELAY, errorResponseJSON, mockAxios } from "../axiosMock";
 import userProfileMock from "../userProfileMock";
+import {
+    usageSummaryBasicSubscriptionResponse,
+    usageSummaryResponse,
+} from "../usageSummaryMock";
 
 import {
     adminDetails,
@@ -36,7 +40,7 @@ export default {
     title: "Apps / Listing",
 };
 
-function ListingTest({ isAdminView }) {
+function ListingTest({ isAdminView, usageSummaryResponse }) {
     //Note: the params must exactly with original call made by react-query
     mockAxios.reset();
     mockAxios.onGet("/api/apps/categories?public=false").reply(200, categories);
@@ -114,6 +118,9 @@ function ListingTest({ isAdminView }) {
     mockAxios
         .onGet(/\/api\/user-info.*username=superman.*/)
         .reply(200, userInfoMemberResp);
+    mockAxios
+        .onGet(new RegExp("/api/resource-usage/summary.*"))
+        .reply(200, usageSummaryResponse);
 
     const { t } = useTranslation("apps");
     const fields = appFields(t);
@@ -167,21 +174,24 @@ function ListingTest({ isAdminView }) {
     );
 }
 
-export const AppsListingTest = ({ isAdminView }) => {
+const AppsListingTemplate = ({ isAdminView, usageSummaryResponse }) => {
     return (
         <UploadTrackingProvider>
             <UserProfileProvider>
-                <ListingTest isAdminView={isAdminView} />
+                <ListingTest
+                    isAdminView={isAdminView}
+                    usageSummaryResponse={usageSummaryResponse}
+                />
             </UserProfileProvider>
         </UploadTrackingProvider>
     );
 };
 
-AppsListingTest.args = {
+const args = {
     isAdminView: false,
 };
 
-AppsListingTest.argTypes = {
+const argTypes = {
     isAdminView: {
         name: "Admin View",
         control: {
@@ -190,6 +200,19 @@ AppsListingTest.argTypes = {
     },
 };
 
-AppsListingTest.parameters = {
+const parameters = {
     chromatic: { delay: AXIOS_DELAY * 2 + 500 },
 };
+
+export const NormalListing = AppsListingTemplate.bind({});
+NormalListing.args = { ...args, usageSummaryResponse };
+NormalListing.argTypes = argTypes;
+NormalListing.parameters = parameters;
+
+export const BasicSubscriptionListing = AppsListingTemplate.bind({});
+BasicSubscriptionListing.args = {
+    ...args,
+    usageSummaryResponse: usageSummaryBasicSubscriptionResponse,
+};
+BasicSubscriptionListing.argTypes = argTypes;
+BasicSubscriptionListing.parameters = parameters;


### PR DESCRIPTION
This PR will update the `Share` button for apps, analyses, and data to display a warning announcer, with a link to the subscription page, for users that only have unpaid `Basic` subscriptions, and no CPU or Data add-ons.

This also restores the data listing sharing buttons for unpaid `Basic` subscriptions, but will display the warning message.

This PR also refactors the queries for fetching a user's resource usage summary into a common `useResourceUsageSummary` hook, which also returns common flags and usage values.

--- 
![Warning Announcer message](https://github.com/user-attachments/assets/3746bb2d-9c31-4234-aa39-6f26e963ca5b)
