### PR TITLE
CORE-2050 Fixes for the Resource Usage Summary query

### DIFF
--- a/src/common/useResourceUsageSummary.js
+++ b/src/common/useResourceUsageSummary.js
@@ -44,7 +44,7 @@ function useResourceUsageSummary(
     } = useQuery({
         queryKey: [queryKey, userProfile?.id],
         queryFn: getResourceUsageSummary,
-        enabled: enforceSubscriptions && !!userProfile?.id,
+        enabled: !!(enforceSubscriptions && userProfile?.id),
         onError: (e) => {
             showErrorAnnouncer(t("usageSummaryError"), e);
         },

--- a/src/common/useResourceUsageSummary.js
+++ b/src/common/useResourceUsageSummary.js
@@ -21,11 +21,16 @@ import { getUserQuota } from "./resourceUsage";
  * A hook to fetch a user's resource usage summary.
  *
  * @param {function} showErrorAnnouncer - Function to show error announcements.
+ * @param {string} [queryKey=RESOURCE_USAGE_QUERY_KEY] - Optional query key for
+ *                  fetching the resource usage summary.
  *
  * @returns {object} An object containing the resource usage summary
  *                   along with convenience flags and parsed values.
  */
-function useResourceUsageSummary(showErrorAnnouncer) {
+function useResourceUsageSummary(
+    showErrorAnnouncer,
+    queryKey = RESOURCE_USAGE_QUERY_KEY
+) {
     const { t } = useTranslation("common");
     const [config] = useConfig();
     const [userProfile] = useUserProfile();
@@ -37,7 +42,7 @@ function useResourceUsageSummary(showErrorAnnouncer) {
         data: resourceUsageSummary,
         error: resourceUsageError,
     } = useQuery({
-        queryKey: [RESOURCE_USAGE_QUERY_KEY, userProfile?.id],
+        queryKey: [queryKey, userProfile?.id],
         queryFn: getResourceUsageSummary,
         enabled: enforceSubscriptions && !!userProfile?.id,
         onError: (e) => {

--- a/src/pages/analyses/[analysisId]/relaunch.js
+++ b/src/pages/analyses/[analysisId]/relaunch.js
@@ -17,6 +17,7 @@ import {
     getAnalysisRelaunchInfo,
     ANALYSIS_RELAUNCH_QUERY_KEY,
 } from "serviceFacades/analyses";
+import { APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY } from "serviceFacades/dashboard";
 
 import useResourceUsageSummary from "common/useResourceUsageSummary";
 
@@ -43,7 +44,10 @@ const Relaunch = ({ showErrorAnnouncer }) => {
     const { analysisId } = router.query;
 
     const { isFetchingUsageSummary, computeLimitExceeded } =
-        useResourceUsageSummary(showErrorAnnouncer);
+        useResourceUsageSummary(
+            showErrorAnnouncer,
+            APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY
+        );
 
     React.useEffect(() => {
         setRelaunchQueryEnabled(!!analysisId);

--- a/src/pages/apps/[systemId]/[appId]/launch.js
+++ b/src/pages/apps/[systemId]/[appId]/launch.js
@@ -17,6 +17,8 @@ import {
     APP_DESCRIPTION_QUERY_KEY,
 } from "serviceFacades/apps";
 
+import { APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY } from "serviceFacades/dashboard";
+
 import {
     SAVED_LAUNCH_APP_INFO,
     getAppInfo,
@@ -41,7 +43,10 @@ function Launch({ showErrorAnnouncer }) {
     const { systemId, appId } = router.query;
 
     const { isFetchingUsageSummary, computeLimitExceeded } =
-        useResourceUsageSummary(showErrorAnnouncer);
+        useResourceUsageSummary(
+            showErrorAnnouncer,
+            APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY
+        );
 
     const launchId =
         router.query["saved-launch-id"] || router.query["quick-launch-id"];

--- a/src/pages/apps/[systemId]/[appId]/versions/[versionId]/launch.js
+++ b/src/pages/apps/[systemId]/[appId]/versions/[versionId]/launch.js
@@ -15,6 +15,7 @@ import {
     getAppDescription,
     APP_DESCRIPTION_QUERY_KEY,
 } from "serviceFacades/apps";
+import { APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY } from "serviceFacades/dashboard";
 
 import AppLaunch from "components/apps/launch";
 import withErrorAnnouncer from "components/error/withErrorAnnouncer";
@@ -33,7 +34,10 @@ function Launch({ showErrorAnnouncer }) {
     const { systemId, appId, versionId } = router.query;
 
     const { isFetchingUsageSummary, computeLimitExceeded } =
-        useResourceUsageSummary(showErrorAnnouncer);
+        useResourceUsageSummary(
+            showErrorAnnouncer,
+            APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY
+        );
 
     const { isFetching: appDescriptionLoading } = useQuery({
         queryKey: [

--- a/src/serviceFacades/dashboard.js
+++ b/src/serviceFacades/dashboard.js
@@ -3,6 +3,9 @@ import callApi from "../common/callApi";
 const DASHBOARD_QUERY_KEY = "fetchDashboardItems";
 const ANALYSES_STATS_QUERY_KEY = "fetchAnalysesStats";
 const RESOURCE_USAGE_QUERY_KEY = "fetchResourceUsage";
+const APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY =
+    RESOURCE_USAGE_QUERY_KEY + "AppLaunch";
+
 function getDashboard({ limit }) {
     return callApi({
         endpoint: `/api/dashboard?limit=${limit}`,
@@ -38,5 +41,6 @@ export {
     getResourceUsageSummary,
     DASHBOARD_QUERY_KEY,
     ANALYSES_STATS_QUERY_KEY,
+    APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY,
     RESOURCE_USAGE_QUERY_KEY,
 };


### PR DESCRIPTION
This PR will add the following fixes:

* Restore the `APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY` removed by #632.
  * This will prevent the app launch forms from being masked (which will reset the form and lose all progress) when an input selector's data listing gets masked by the Resource Usage Summary query.
* Fix a bug that displays an error fetching the summary for logged out users.
  * The `config?.subscriptions?.enforce` flag might return `undefined` initially, but the query's `enabled` flag must be a `boolean`, so this query would run for logged out users and display an error.