### PR TITLE
Refactor Global Alerts out of AppBar and into top-level PageWrapper

### DIFF
--- a/src/components/layout/AppBar.js
+++ b/src/components/layout/AppBar.js
@@ -21,11 +21,6 @@ import { useBootstrapInfo } from "contexts/bootstrap";
 import { intercomLogout } from "common/intercom";
 
 import {
-    activeAlerts,
-    ACTIVE_ALERTS_QUERY_KEY,
-} from "serviceFacades/notifications";
-
-import {
     getUserProfile,
     useBootStrap,
     USER_PROFILE_QUERY_KEY,
@@ -77,8 +72,6 @@ import {
 } from "serviceFacades/dashboard";
 import useResourceUsageSummary from "common/useResourceUsageSummary";
 
-import markdownToHtml from "components/utils/markdownToHtml";
-
 import useBreakpoints from "./useBreakpoints";
 
 // hidden in xsDown
@@ -127,7 +120,6 @@ function DEAppBar(props) {
     const [profileRefetchInterval, setProfileRefetchInterval] = useState(null);
     const [anchorEl, setAnchorEl] = useState(null);
     const [runningViceJobs, setRunningViceJobs] = useState([]);
-    const [activeAlertsList, setActiveAlertsList] = useState([]);
 
     const { isSmUp, isSmDown } = useBreakpoints();
 
@@ -168,28 +160,6 @@ function DEAppBar(props) {
         enabled: profileRefetchInterval != null,
         onSuccess: updateUserProfile,
         refetchInterval: profileRefetchInterval,
-    });
-
-    function updateAlerts(queryresp) {
-        const alertsMdPromises = queryresp?.alerts.map((alertMap) =>
-            markdownToHtml(alertMap.alert)
-        );
-        Promise.all(alertsMdPromises).then((values) => {
-            if (
-                values.length !== activeAlertsList.length ||
-                !values.every((el, idx) => activeAlertsList[idx] === el)
-            ) {
-                setActiveAlertsList(values || []);
-            }
-        });
-    }
-
-    useQuery({
-        queryKey: ACTIVE_ALERTS_QUERY_KEY,
-        queryFn: activeAlerts,
-        enabled: true,
-        onSuccess: updateAlerts,
-        refetchInterval: 120000,
     });
 
     useEffect(() => {
@@ -406,19 +376,6 @@ function DEAppBar(props) {
                     [classes.appBarShift]: open,
                 })}
             >
-                {activeAlertsList?.map((text) => {
-                    return (
-                        <Toolbar
-                            key={text}
-                            variant="dense"
-                            className={classes.alertBar}
-                        >
-                            <Typography
-                                dangerouslySetInnerHTML={{ __html: text }}
-                            />
-                        </Toolbar>
-                    );
-                })}
                 <Toolbar>
                     {!isSmUp && (
                         <>

--- a/src/components/layout/GlobalAlerts.js
+++ b/src/components/layout/GlobalAlerts.js
@@ -1,0 +1,70 @@
+/**
+ * Global Alerts component for displaying active alerts.
+ *
+ * @author mian, psarando
+ */
+import { useState } from "react";
+
+import { useQuery } from "react-query";
+
+import markdownToHtml from "components/utils/markdownToHtml";
+
+import {
+    activeAlerts,
+    ACTIVE_ALERTS_QUERY_KEY,
+} from "serviceFacades/notifications";
+
+import { Paper, Toolbar, Typography } from "@mui/material";
+
+const GlobalAlerts = () => {
+    const [activeAlertsList, setActiveAlertsList] = useState([]);
+
+    useQuery({
+        queryKey: ACTIVE_ALERTS_QUERY_KEY,
+        queryFn: activeAlerts,
+        enabled: true,
+        refetchInterval: 2 * 60 * 1000, // 2 minutes
+        onSuccess: (queryresp) => {
+            const alertsMdPromises = queryresp?.alerts.map((alertMap) =>
+                markdownToHtml(alertMap.alert)
+            );
+            Promise.all(alertsMdPromises).then((values) => {
+                if (
+                    values.length !== activeAlertsList.length ||
+                    !values.every((el, idx) => activeAlertsList[idx] === el)
+                ) {
+                    setActiveAlertsList(values || []);
+                }
+            });
+        },
+    });
+
+    return activeAlertsList.length < 1 ? null : (
+        <Paper
+            sx={{
+                marginBottom: 0.5,
+                padding: 0.5,
+            }}
+        >
+            {activeAlertsList.map((text) => {
+                return (
+                    <Toolbar
+                        key={text}
+                        variant="dense"
+                        sx={{
+                            backgroundColor: "#FFC972",
+                            color: "#713916",
+                            marginBottom: 1,
+                        }}
+                    >
+                        <Typography
+                            dangerouslySetInnerHTML={{ __html: text }}
+                        />
+                    </Toolbar>
+                );
+            })}
+        </Paper>
+    );
+};
+
+export default GlobalAlerts;

--- a/src/components/layout/styles.js
+++ b/src/components/layout/styles.js
@@ -24,10 +24,6 @@ const LayoutStyles = (theme) => ({
             }),
         },
     },
-    alertBar: {
-        backgroundColor: "#FFC972",
-        color: "#713916",
-    },
     drawerIcon: {
         flexShrink: 0,
         marginRight: theme.spacing(3.5),

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -24,6 +24,7 @@ import { NotificationsProvider } from "contexts/pushNotifications";
 import { BootstrapInfoProvider } from "contexts/bootstrap";
 import { BagInfoProvider } from "contexts/bagInfo";
 
+import GlobalAlerts from "components/layout/GlobalAlerts";
 import PageWrapper from "components/layout/PageWrapper";
 import useComponentHeight from "components/utils/useComponentHeight";
 import constants from "../constants";
@@ -296,6 +297,7 @@ function MyApp({ Component, pageProps }) {
                                                 <PageWrapper
                                                     appBarHeight={appBarHeight}
                                                 >
+                                                    <GlobalAlerts />
                                                     <Component {...pageProps} />
                                                 </PageWrapper>
                                                 <UploadManager />

--- a/stories/AppBar.stories.js
+++ b/stories/AppBar.stories.js
@@ -1,8 +1,12 @@
 import React from "react";
-import { UserProfileProvider } from "../src/contexts/userProfile";
-import DEAppBar from "../src/components/layout/AppBar";
+
+import { NotificationsProvider } from "contexts/pushNotifications";
+import { UserProfileProvider } from "contexts/userProfile";
+
+import DEAppBar from "components/layout/AppBar";
+import GlobalAlerts from "components/layout/GlobalAlerts";
+
 import { mockAxios } from "./axiosMock";
-import { NotificationsProvider } from "../src/contexts/pushNotifications";
 import notificationsData from "./notifications/notificationsData";
 import testConfig from "./configMock";
 import {
@@ -10,7 +14,7 @@ import {
     FOLDER_TYPE,
     ANALYSIS_TYPE,
     APP_TYPE,
-} from "../src/components/bags";
+} from "components/bags";
 import { runningViceJobs } from "./analyses/AnalysesMocks";
 import { instantLaunchNavDrawerMock } from "./instantlaunches/admin/SavedLaunchListData";
 import {
@@ -142,6 +146,10 @@ const nonEmptyAlerts = {
             end_date: "2100-01-01T00:00:00Z",
             alert: "This is a *testing* alert, with some *formatting* and a [link](https://cyverse.org).",
         },
+        {
+            end_date: "2100-01-01T00:00:00Z",
+            alert: "This is also a **test** of the _alert broadcast system_. _**This is only a test**_.",
+        },
     ],
 };
 
@@ -199,7 +207,9 @@ const appBarTestTemplate = (args) => {
     return (
         <UserProfileProvider>
             <NotificationsProvider wsEnabled={false}>
-                <DEAppBar setAppBarRef={() => {}} clientConfig={testConfig} />
+                <DEAppBar setAppBarRef={() => {}} clientConfig={testConfig}>
+                    <GlobalAlerts />
+                </DEAppBar>
             </NotificationsProvider>
         </UserProfileProvider>
     );


### PR DESCRIPTION
This PR will refactor rendering the active alerts into a `GlobalAlerts` component that is nested inside the top-level `PageWrapper`, just above each page's content.

Since rendering alert markdown is async, the AppBar's height is used for setting the top-level PageWrapper's `appBarHeight` prop before the alert messages are rendered, which caused the bottom of pages to be cut off.

![Dashboard with 2 Alerts](https://github.com/user-attachments/assets/0ed304d4-df9c-4a21-91f1-afc003b8ffc9)

![App Listing with 2 Alerts](https://github.com/user-attachments/assets/c2c448e5-51c1-47e8-8699-e791ddf2e927)
