### PR TITLE
CORE-2057 Fix Admin EditTool form

### DIFF
--- a/src/components/forms/FormSelectField.js
+++ b/src/components/forms/FormSelectField.js
@@ -18,7 +18,7 @@ const FormSelectField = ({
     required,
     form: { touched, errors },
     children,
-    fullWidth,
+    fullWidth = true,
     ...custom
 }) => {
     const errorMsg = getFormError(field.name, touched, errors);
@@ -37,10 +37,6 @@ const FormSelectField = ({
             <FormHelperText>{errorMsg || helperText}</FormHelperText>
         </FormControl>
     );
-};
-
-FormSelectField.defaultProps = {
-    fullWidth: true,
 };
 
 export default FormSelectField;

--- a/src/components/tools/edit/EditTool.js
+++ b/src/components/tools/edit/EditTool.js
@@ -133,8 +133,8 @@ function EditToolDialog(props) {
     });
 
     const { mutate: addNewTool, status: newToolStatus } = useMutation(
-        () =>
-            isAdmin ? adminAddTool(toolSubmission) : addTool(toolSubmission),
+        (submission) =>
+            isAdmin ? adminAddTool(submission) : addTool(submission),
         {
             onSuccess: (data) => {
                 announce({
@@ -154,10 +154,10 @@ function EditToolDialog(props) {
     };
 
     const { mutate: updateCurrentTool, status: updateToolStatus } = useMutation(
-        () =>
+        (submission) =>
             isAdmin
-                ? adminUpdateTool(toolSubmission, overwriteAppsAffectedByTool)
-                : updateTool(toolSubmission),
+                ? adminUpdateTool(submission, overwriteAppsAffectedByTool)
+                : updateTool(submission),
         {
             onSuccess: (data) => {
                 announce({
@@ -186,12 +186,13 @@ function EditToolDialog(props) {
 
     React.useEffect(() => {
         if (overwriteAppsAffectedByTool) {
-            updateCurrentTool();
+            updateCurrentTool(toolSubmission);
         }
-    }, [overwriteAppsAffectedByTool, updateCurrentTool]);
+    }, [overwriteAppsAffectedByTool, toolSubmission, updateCurrentTool]);
 
     const handleSubmit = (values) => {
-        setToolSubmission(formatSubmission(values, config, isAdmin));
+        const submission = formatSubmission(values, config, isAdmin);
+        setToolSubmission(submission);
 
         //avoid dupe submission
         if (
@@ -199,9 +200,9 @@ function EditToolDialog(props) {
             updateToolStatus !== constants.LOADING
         ) {
             if (tool) {
-                updateCurrentTool();
+                updateCurrentTool(submission);
             } else {
-                addNewTool();
+                addNewTool(submission);
             }
         }
     };

--- a/src/components/tools/edit/EditTool.js
+++ b/src/components/tools/edit/EditTool.js
@@ -161,7 +161,7 @@ function EditToolDialog(props) {
         {
             onSuccess: (data) => {
                 announce({
-                    text: t("toolUpdated"),
+                    text: t("toolUpdated", { name: data?.name }),
                 });
                 queryClient.invalidateQueries(TOOLS_QUERY_KEY);
                 setUpdateToolError(null);

--- a/src/components/tools/edit/EditTool.js
+++ b/src/components/tools/edit/EditTool.js
@@ -405,14 +405,12 @@ function EditToolDialog(props) {
                 <Typography>{t("overwritePromptMessage")}</Typography>
                 <List>
                     {appsAffectedByTool?.map((app) => (
-                        <>
-                            <ListItem key={app.id}>
-                                <ListItemIcon>
-                                    <LabelIcon />
-                                </ListItemIcon>
-                                <ListItemText>{app.name}</ListItemText>
-                            </ListItem>
-                        </>
+                        <ListItem key={app.id}>
+                            <ListItemIcon>
+                                <LabelIcon />
+                            </ListItemIcon>
+                            <ListItemText>{app.name}</ListItemText>
+                        </ListItem>
                     ))}
                 </List>
             </DEDialog>

--- a/src/components/tools/listing/TableView.js
+++ b/src/components/tools/listing/TableView.js
@@ -176,19 +176,19 @@ function ToolListing(props) {
                     </TableCell>
                 )}
                 {isAdmin && [
-                    <TableCell key={tool.description}>
+                    <TableCell key="description">
                         <Typography>{tool.description}</Typography>
                     </TableCell>,
-                    <TableCell key={tool.location}>
+                    <TableCell key="location">
                         <Typography>{tool.location}</Typography>
                     </TableCell>,
-                    <TableCell key={tool.type}>
+                    <TableCell key="type">
                         <Typography>{tool.type}</Typography>
                     </TableCell>,
-                    <TableCell key={tool.attribution}>
+                    <TableCell key="attribution">
                         <Typography>{tool.attribution}</Typography>
                     </TableCell>,
-                    <TableCell key={tool.version}>
+                    <TableCell key="version">
                         <Typography>{tool.version}</Typography>
                     </TableCell>,
                 ]}

--- a/src/components/utils/SimpleExpansionPanel.js
+++ b/src/components/utils/SimpleExpansionPanel.js
@@ -37,7 +37,13 @@ const styles = (theme) => ({
 const useStyles = makeStyles()(styles);
 
 function SimpleExpansionPanel(props) {
-    const { header, parentId, defaultExpanded, children, hasErrors } = props;
+    const {
+        header,
+        parentId,
+        defaultExpanded = true,
+        children,
+        hasErrors,
+    } = props;
     const [expanded, setExpanded] = useState(defaultExpanded);
     const { classes } = useStyles();
 
@@ -64,10 +70,6 @@ function SimpleExpansionPanel(props) {
         </Accordion>
     );
 }
-
-SimpleExpansionPanel.defaultProps = {
-    defaultExpanded: true,
-};
 
 SimpleExpansionPanel.propTypes = {
     header: PropTypes.any.isRequired,


### PR DESCRIPTION
This PR will fix a bug in the Admin EditTool form, where an admin attempted to edit a tool and a null tool error in the service facade prevented the PATCH request from being submitted.

The `handleSubmit` function was setting the formatted values in a `toolSubmission` state, then immediately calling `updateCurrentTool` or `addNewTool` mutation queries, which were trying to access that state, but the state values were not available yet.

This PR also includes other minor fixes, such as fixing warnings and the tool edit success announcement.