### PR TITLE
CORE-2076 Fix resource usage query loading mask in publish dialog

### DIFF
--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -40,6 +40,8 @@ import {
 } from "contexts/uploadTracking";
 import { trackIntercomEvent, IntercomEvents } from "common/intercom";
 
+import { DATA_LISTING_RESOURCE_USAGE_QUERY_KEY } from "serviceFacades/dashboard";
+
 import {
     deleteResources,
     emptyTrash,
@@ -155,7 +157,10 @@ function Listing(props) {
         computeLimitExceeded,
         dataLimitExceeded,
         planCanShare,
-    } = useResourceUsageSummary(showErrorAnnouncer);
+    } = useResourceUsageSummary(
+        showErrorAnnouncer,
+        DATA_LISTING_RESOURCE_USAGE_QUERY_KEY
+    );
 
     const uploadsEnabled = !dataLimitExceeded;
 

--- a/src/pages/analyses/[analysisId]/relaunch.js
+++ b/src/pages/analyses/[analysisId]/relaunch.js
@@ -44,10 +44,7 @@ const Relaunch = ({ showErrorAnnouncer }) => {
     const { analysisId } = router.query;
 
     const { isFetchingUsageSummary, computeLimitExceeded } =
-        useResourceUsageSummary(
-            showErrorAnnouncer,
-            APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY
-        );
+        useResourceUsageSummary(showErrorAnnouncer);
 
     React.useEffect(() => {
         setRelaunchQueryEnabled(!!analysisId);

--- a/src/pages/apps/[systemId]/[appId]/launch.js
+++ b/src/pages/apps/[systemId]/[appId]/launch.js
@@ -43,10 +43,7 @@ function Launch({ showErrorAnnouncer }) {
     const { systemId, appId } = router.query;
 
     const { isFetchingUsageSummary, computeLimitExceeded } =
-        useResourceUsageSummary(
-            showErrorAnnouncer,
-            APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY
-        );
+        useResourceUsageSummary(showErrorAnnouncer);
 
     const launchId =
         router.query["saved-launch-id"] || router.query["quick-launch-id"];

--- a/src/pages/apps/[systemId]/[appId]/versions/[versionId]/launch.js
+++ b/src/pages/apps/[systemId]/[appId]/versions/[versionId]/launch.js
@@ -34,10 +34,7 @@ function Launch({ showErrorAnnouncer }) {
     const { systemId, appId, versionId } = router.query;
 
     const { isFetchingUsageSummary, computeLimitExceeded } =
-        useResourceUsageSummary(
-            showErrorAnnouncer,
-            APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY
-        );
+        useResourceUsageSummary(showErrorAnnouncer);
 
     const { isFetching: appDescriptionLoading } = useQuery({
         queryKey: [

--- a/src/serviceFacades/dashboard.js
+++ b/src/serviceFacades/dashboard.js
@@ -3,8 +3,8 @@ import callApi from "../common/callApi";
 const DASHBOARD_QUERY_KEY = "fetchDashboardItems";
 const ANALYSES_STATS_QUERY_KEY = "fetchAnalysesStats";
 const RESOURCE_USAGE_QUERY_KEY = "fetchResourceUsage";
-const APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY =
-    RESOURCE_USAGE_QUERY_KEY + "AppLaunch";
+const DATA_LISTING_RESOURCE_USAGE_QUERY_KEY =
+    RESOURCE_USAGE_QUERY_KEY + "DataListing";
 
 function getDashboard({ limit }) {
     return callApi({
@@ -41,6 +41,6 @@ export {
     getResourceUsageSummary,
     DASHBOARD_QUERY_KEY,
     ANALYSES_STATS_QUERY_KEY,
-    APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY,
+    DATA_LISTING_RESOURCE_USAGE_QUERY_KEY,
     RESOURCE_USAGE_QUERY_KEY,
 };


### PR DESCRIPTION
Replace the `APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY` with a `DATA_LISTING_RESOURCE_USAGE_QUERY_KEY`, so the data listing has its own resource usage query, no matter where the input selector is opened.

This fixes a bug where the data listing in the folder selector wants to run the resource usage query again, which is causing the apps listing to be replaced with a loading mask, which closes out the data selector and publish app dialogs.

This is a similar bug that the `APP_LAUNCH_RESOURCE_USAGE_QUERY_KEY` fixed in the app launch forms, but the `DATA_LISTING_RESOURCE_USAGE_QUERY_KEY` will cover this case and any other component where the input selector is used.