### PR TITLE
CORE-2123 Fix for `useQuery` in pages for `react-query` v4 upgrade

### DIFF
--- a/src/pages/admin/subscriptions.js
+++ b/src/pages/admin/subscriptions.js
@@ -54,39 +54,23 @@ export default function Subscriptions() {
     const onTabSelectionChange = (_event, selectedTab) => {
         setSelectedTab(selectedTab);
     };
-    const [availableAddons, setAvailableAddons] = useState(null);
-    const [getAddonsQueryEnabled, setGetAddonsQueryEnabled] = useState(false);
     const queryClient = useQueryClient();
     const availableAddonsCache = queryClient.getQueryData([
         AVAILABLE_ADDONS_QUERY_KEY,
     ]);
 
-    const preProcessAvailableAddons = React.useCallback(
-        (data) => {
-            if (data?.addons?.length > 0) {
-                setAvailableAddons(data);
-            }
-        },
-        [setAvailableAddons]
-    );
-
-    React.useEffect(() => {
-        if (!!availableAddonsCache) {
-            preProcessAvailableAddons(availableAddonsCache);
-        } else {
-            setGetAddonsQueryEnabled(true);
-        }
-    }, [preProcessAvailableAddons, availableAddonsCache]);
-
-    const { isFetchingAvailableAddons, errorFetchingAvailableAddons } =
-        useQuery({
-            queryKey: [AVAILABLE_ADDONS_QUERY_KEY],
-            queryFn: getAvailableAddOns,
-            enabled: getAddonsQueryEnabled,
-            staleTime: Infinity,
-            cacheTime: Infinity,
-            onSuccess: preProcessAvailableAddons,
-        });
+    const {
+        data,
+        isFetching: isFetchingAvailableAddons,
+        error: errorFetchingAvailableAddons,
+    } = useQuery({
+        queryKey: [AVAILABLE_ADDONS_QUERY_KEY],
+        queryFn: getAvailableAddOns,
+        enabled: !availableAddonsCache,
+        staleTime: Infinity,
+        cacheTime: Infinity,
+    });
+    const availableAddons = availableAddonsCache || data;
 
     const onRouteToListing = useCallback(
         (order, orderBy, page, rowsPerPage, searchTerm) => {

--- a/src/pages/apps/[systemId]/[appId]/versions.js
+++ b/src/pages/apps/[systemId]/[appId]/versions.js
@@ -20,16 +20,17 @@ import {
 } from "serviceFacades/apps";
 
 export default function VersionsOrderEdit() {
-    const [app, setApp] = React.useState(null);
-
     const router = useRouter();
     const { systemId, appId } = router.query;
 
-    const { isFetching, error } = useQuery({
+    const {
+        data: app,
+        isFetching,
+        error,
+    } = useQuery({
         queryKey: [APP_DESCRIPTION_QUERY_KEY, { systemId, appId }],
         queryFn: () => getAppDescription({ systemId, appId }),
         enabled: !!(systemId && appId),
-        onSuccess: setApp,
     });
 
     return (

--- a/src/pages/apps/[systemId]/[appId]/versions/[versionId]/create.js
+++ b/src/pages/apps/[systemId]/[appId]/versions/[versionId]/create.js
@@ -70,28 +70,29 @@ const appGroupCopy = ({ id, ...group }) => {
 };
 
 export default function AppVersionCreate() {
-    const [appDescription, setAppDescription] = React.useState(null);
-    const [workflowDescription, setWorkflowDescription] = React.useState(null);
-    const [appDetails, setAppDetails] = React.useState(null);
-    const [loadingError, setLoadingError] = React.useState(null);
-
     const [userProfile] = useUserProfile();
 
     const router = useRouter();
     const { systemId, appId, versionId } = router.query;
 
-    const isPublic = appDetails?.is_public;
-    const isWorkflow = appDetails?.step_count > 1;
-
-    const { isFetching: appInfoLoading } = useQuery({
+    const {
+        data: appDetails,
+        isFetching: appInfoLoading,
+        error: appInfoError,
+    } = useQuery({
         queryKey: [APP_DETAILS_QUERY_KEY, { systemId, appId }],
         queryFn: () => getAppDetails({ systemId, appId }),
         enabled: !!(userProfile?.id && systemId && appId),
-        onSuccess: setAppDetails,
-        onError: setLoadingError,
     });
 
-    const { isFetching: appUILoading } = useQuery({
+    const isPublic = appDetails?.is_public;
+    const isWorkflow = appDetails?.step_count > 1;
+
+    const {
+        data: appUI,
+        isFetching: appUILoading,
+        error: appUIError,
+    } = useQuery({
         queryKey: [APP_UI_QUERY_KEY, { systemId, appId, versionId }],
         queryFn: () => getAppUI({ systemId, appId, versionId }),
         enabled: !!(
@@ -102,35 +103,34 @@ export default function AppVersionCreate() {
             appDetails &&
             !isWorkflow
         ),
-        onSuccess: (appUI) => {
-            const { version_id, ...appCopy } = appUI;
-            appCopy.groups = appCopy.groups?.map(appGroupCopy);
-
-            setAppDescription(appCopy);
-        },
-        onError: setLoadingError,
     });
 
-    const { isFetching: workflowUILoading } = useQuery({
+    const { version_id, ...appCopy } = appUI || {};
+    const appDescription = appUI && {
+        ...appCopy,
+        groups: appCopy.groups?.map(appGroupCopy),
+    };
+
+    const {
+        data: workflowUI,
+        isFetching: workflowUILoading,
+        error: workflowUIError,
+    } = useQuery({
         queryKey: [PIPELINE_UI_QUERY_KEY, { appId, versionId }],
         queryFn: () => getPipelineUI({ appId, versionId }),
         enabled: !!(userProfile?.id && appId && versionId && isWorkflow),
-        onSuccess: (workflowUI) => {
-            const { version_id, ...workflowCopy } = workflowUI;
-            setWorkflowDescription(workflowCopy);
-        },
-        onError: setLoadingError,
     });
 
-    React.useEffect(() => {
-        if (userProfile?.id) {
-            setLoadingError(null);
-        } else {
-            setLoadingError(signInErrorResponse);
-        }
-    }, [userProfile]);
+    const { version_id: _workflow_version_id, ...workflowCopy } =
+        workflowUI || {};
+    const workflowDescription = workflowCopy;
 
     const loading = appInfoLoading || appUILoading || workflowUILoading;
+    const loadingError =
+        (!userProfile?.id && signInErrorResponse) ||
+        appInfoError ||
+        appUIError ||
+        workflowUIError;
 
     if (isWorkflow) {
         return (

--- a/src/pages/apps/[systemId]/[appId]/versions/[versionId]/edit.js
+++ b/src/pages/apps/[systemId]/[appId]/versions/[versionId]/edit.js
@@ -30,30 +30,31 @@ import {
 import { getPipelineUI, PIPELINE_UI_QUERY_KEY } from "serviceFacades/pipelines";
 
 export default function AppEdit() {
-    const [app, setApp] = React.useState(null);
-    const [workflowDescription, setWorkflowDescription] = React.useState(null);
-    const [appListingInfo, setAppListingInfo] = React.useState(null);
-    const [loadingError, setLoadingError] = React.useState(null);
-
     const [userProfile] = useUserProfile();
 
     const router = useRouter();
     const { systemId, appId, versionId } = router.query;
 
-    const isPublic = appListingInfo?.is_public;
-    const isWorkflow = appListingInfo?.step_count > 1;
-
-    const { isFetching: appInfoLoading } = useQuery({
+    const {
+        data: appInfoResult,
+        isFetching: appInfoLoading,
+        error: appInfoError,
+    } = useQuery({
         queryKey: [APP_BY_ID_QUERY_KEY, { systemId, appId }],
         queryFn: () => getAppById({ systemId, appId }),
         enabled: !!(userProfile?.id && systemId && appId),
-        onSuccess: (result) => {
-            setAppListingInfo(result?.apps[0]);
-        },
-        onError: setLoadingError,
     });
 
-    const { isFetching: appUILoading } = useQuery({
+    const appListingInfo = appInfoResult?.apps[0];
+
+    const isPublic = appListingInfo?.is_public;
+    const isWorkflow = appListingInfo?.step_count > 1;
+
+    const {
+        data: app,
+        isFetching: appUILoading,
+        error: appUIError,
+    } = useQuery({
         queryKey: [APP_UI_QUERY_KEY, { systemId, appId, versionId }],
         queryFn: () => getAppUI({ systemId, appId, versionId }),
         enabled: !!(
@@ -64,27 +65,24 @@ export default function AppEdit() {
             appListingInfo &&
             !isWorkflow
         ),
-        onSuccess: setApp,
-        onError: setLoadingError,
     });
 
-    const { isFetching: workflowUILoading } = useQuery({
+    const {
+        data: workflowDescription,
+        isFetching: workflowUILoading,
+        error: workflowUIError,
+    } = useQuery({
         queryKey: [PIPELINE_UI_QUERY_KEY, { appId, versionId }],
         queryFn: () => getPipelineUI({ appId, versionId }),
         enabled: !!(userProfile?.id && appId && versionId && isWorkflow),
-        onSuccess: setWorkflowDescription,
-        onError: setLoadingError,
     });
 
-    React.useEffect(() => {
-        if (userProfile?.id) {
-            setLoadingError(null);
-        } else {
-            setLoadingError(signInErrorResponse);
-        }
-    }, [userProfile]);
-
     const loading = appInfoLoading || appUILoading || workflowUILoading;
+    const loadingError =
+        (!userProfile?.id && signInErrorResponse) ||
+        appInfoError ||
+        appUIError ||
+        workflowUIError;
 
     if (isWorkflow) {
         return (


### PR DESCRIPTION
It seems the `onSuccess` callback for `useQuery` is working differently now in `react-query` v4, beyond just being deprecated.

This seems to have only affected the App Editor, for some reason, which was retaining the `undefined` app description in its form, and displaying blank form fields even after the app was fetched.

I also noticed that the `subscriptions` page was incorrectly setting the query loading and error values, so I cleaned up that query as well.