### PR TITLE
CORE-2123 Replace react-query `status` usage with `isFetching`

### DIFF
--- a/src/components/analyses/landing/BatchResults.js
+++ b/src/components/analyses/landing/BatchResults.js
@@ -37,7 +37,7 @@ export default function BatchResults(props) {
     let analysisRecordFields = analysisFields(t);
 
     const {
-        status,
+        isFetching,
         data,
         isFetchingNextPage,
         fetchNextPage,
@@ -104,7 +104,7 @@ export default function BatchResults(props) {
         );
     }
     if (
-        status !== constants.LOADING &&
+        !isFetching &&
         (!data ||
             data.pages.length === 0 ||
             data.pages[0].analyses.length === 0)

--- a/src/components/analyses/landing/BatchResults.js
+++ b/src/components/analyses/landing/BatchResults.js
@@ -103,14 +103,6 @@ export default function BatchResults(props) {
             />
         );
     }
-    if (
-        !isFetching &&
-        (!data ||
-            data.pages.length === 0 ||
-            data.pages[0].analyses.length === 0)
-    ) {
-        return <Typography>{t("noResults")}</Typography>;
-    }
 
     let flatData = [];
     if (data && data.pages[0].analyses.length > 0) {
@@ -133,7 +125,8 @@ export default function BatchResults(props) {
                     baseId={baseId}
                     columns={columns}
                     data={flatData}
-                    loading={isFetchingNextPage}
+                    loading={isFetching || isFetchingNextPage}
+                    emptyDataMessage={t("noAnalyses")}
                     sortable
                 />
             </AccordionDetails>

--- a/src/components/dashboard/dashboardItem/AnalysesStats.js
+++ b/src/components/dashboard/dashboardItem/AnalysesStats.js
@@ -156,12 +156,12 @@ const getFormattedData = (data, theme) => {
 export default function AnalysesStats() {
     const { t } = useTranslation("dashboard");
     const theme = useTheme();
-    const { status, data, error } = useQuery(
+    const { isFetching, isError, data, error } = useQuery(
         [ANALYSES_STATS_QUERY_KEY],
         getAnalysesStats
     );
 
-    if (status === "error") {
+    if (isError) {
         return (
             <div style={{ padding: theme.spacing(1) }}>
                 <ErrorTypographyWithDialog
@@ -171,7 +171,7 @@ export default function AnalysesStats() {
             </div>
         );
     }
-    if (status === "loading") {
+    if (isFetching) {
         return <Skeleton variant="rectangular" width={300} height={200} />;
     }
     const jobTotal = data["status-count"].reduce(

--- a/src/components/dashboard/dashboardItem/LoginTable.js
+++ b/src/components/dashboard/dashboardItem/LoginTable.js
@@ -32,12 +32,12 @@ export default function LoginsTable() {
     const { t } = useTranslation(["dashboard", "common"]);
 
     const theme = useTheme();
-    const { status, data, error } = useQuery({
+    const { isFetching, isError, data, error } = useQuery({
         queryKey: [LOGINS_QUERY_KEY],
         queryFn: () => logins({ limit: 5 }),
     });
 
-    if (status === "error") {
+    if (isError) {
         return (
             <div style={{ padding: theme.spacing(1) }}>
                 <ErrorTypographyWithDialog
@@ -47,7 +47,7 @@ export default function LoginsTable() {
             </div>
         );
     }
-    if (status === "loading") {
+    if (isFetching) {
         return <Skeleton variant="rectangular" height={200} />;
     }
     return (

--- a/src/components/dashboard/index.js
+++ b/src/components/dashboard/index.js
@@ -131,14 +131,13 @@ const Dashboard = (props) => {
         dashboardEl,
     });
 
-    const { status, data, error } = useQuery(
+    const { isFetching, isError, data, error } = useQuery(
         [DASHBOARD_QUERY_KEY, { limit: constants.SECTION_ITEM_LIMIT }],
         () => getDashboard({ limit: constants.SECTION_ITEM_LIMIT })
     );
-    const hasErrored = status === "error";
 
     // Display the error message if an error occurred.
-    if (hasErrored) {
+    if (isError) {
         showErrorAnnouncer(t("dashboardInitError", { error: error.message }));
     }
 
@@ -262,8 +261,7 @@ const Dashboard = (props) => {
     // The base ID for the dashboard.
     const baseId = fns.makeID(ids.ROOT);
 
-    const isLoading =
-        status === "loading" || analysisLoading || isFetchingUsageSummary;
+    const isLoading = isFetching || analysisLoading || isFetchingUsageSummary;
 
     return (
         <div ref={dashboardEl} id={baseId} className={classes.gridRoot}>

--- a/src/components/data/TagSearch.js
+++ b/src/components/data/TagSearch.js
@@ -79,7 +79,7 @@ function TagSearch(props) {
         },
     });
 
-    const { status: tagSuggestionStatus } = useQuery({
+    const { isFetching: tagSuggestionFetching } = useQuery({
         queryKey: ["tagSuggestion", searchTerm],
         queryFn: () => getTagSuggestions({ searchTerm }),
         enabled: !!userProfile?.id,
@@ -182,7 +182,7 @@ function TagSearch(props) {
         tagCreationStatus,
         tagDetachStatus,
         isFetchingTags,
-        tagSuggestionStatus,
+        tagSuggestionFetching,
     ]);
 
     return (

--- a/src/components/data/viewers/PathListViewer.js
+++ b/src/components/data/viewers/PathListViewer.js
@@ -15,7 +15,6 @@ import React, {
 import { useRowSelect, useTable } from "react-table";
 import { useTranslation } from "i18n";
 
-import constants from "../../../constants";
 import { UploadTrackingProvider } from "contexts/uploadTracking";
 
 import ids from "./ids";
@@ -77,7 +76,7 @@ function PathListViewer(props) {
 
     const [dirty, setDirty] = useState(false);
     const [editorData, setEditorData] = useState([]);
-    const [fileSaveStatus, setFileSaveStatus] = useState();
+    const [fileSaving, setFileSaving] = useState(false);
 
     const defaultStartingPath = useSelectorDefaultFolderPath();
 
@@ -197,11 +196,14 @@ function PathListViewer(props) {
                 createFileType={createFileType}
                 onNewFileSaved={onNewFileSaved}
                 getFileContent={getContent}
-                onSaving={setFileSaveStatus}
-                onSaveComplete={() => setDirty(false)}
+                onSaving={() => setFileSaving(true)}
+                onSaveComplete={() => {
+                    setFileSaving(false);
+                    setDirty(false);
+                }}
                 isPathListViewer={true}
             />
-            {(loading || fileSaveStatus === constants.LOADING) && (
+            {(loading || fileSaving) && (
                 <CircularProgress
                     thickness={7}
                     color="primary"

--- a/src/components/data/viewers/Toolbar.js
+++ b/src/components/data/viewers/Toolbar.js
@@ -9,6 +9,7 @@ import React, { useEffect, useState } from "react";
 
 import { useMutation, useQueryClient, useQuery } from "@tanstack/react-query";
 import { useTranslation } from "i18n";
+import constants from "../../../constants";
 import { NavigationParams } from "common/NavigationConstants";
 
 import ids from "./ids";
@@ -163,7 +164,7 @@ function ViewerToolbar(props) {
         },
     });
 
-    const { mutate: saveTextAsFile, isLoading: fileSaveLoading } = useMutation(
+    const { mutate: saveTextAsFile, status: fileSaveStatus } = useMutation(
         uploadTextAsFile,
         {
             onSuccess: (resp) => {
@@ -200,7 +201,7 @@ function ViewerToolbar(props) {
         if (createFileType) {
             setSaveAsDialogOpen(true);
         } else {
-            onSaving(fileSaveLoading);
+            onSaving();
             saveTextAsFile({
                 dest: path,
                 content: getFileContent(),
@@ -606,7 +607,7 @@ function ViewerToolbar(props) {
                         newFile: createFileType ? true : false,
                     });
                 }}
-                loading={fileSaveLoading}
+                loading={fileSaveStatus === constants.LOADING}
             />
         </>
     );

--- a/src/components/instantlaunches/launch/index.js
+++ b/src/components/instantlaunches/launch/index.js
@@ -29,7 +29,7 @@ const InstantLaunchStandalone = (props) => {
     } = props;
     const [resource, setResource] = useState(null);
 
-    const { data, status, error } = useQuery(
+    const { data, isFetching, error } = useQuery(
         [GET_INSTANT_LAUNCH_FULL_KEY, instant_launch_id],
         () => getFullInstantLaunch(instant_launch_id)
     );
@@ -47,7 +47,7 @@ const InstantLaunchStandalone = (props) => {
         });
 
     const isLoading = isQueryLoading([
-        status,
+        isFetching,
         isLoadingResource,
         isFetchingUsageSummary,
     ]);

--- a/src/components/instantlaunches/listing/index.js
+++ b/src/components/instantlaunches/listing/index.js
@@ -38,7 +38,7 @@ function Listing(props) {
         constants.METADATA.INSTANT_LAUNCH_LOCATION_ATTR;
     const instantLaunchListing = constants.METADATA.INSTANT_LAUNCH_LISTING;
 
-    const { data, status, error } = useQuery(
+    const { data, isFetching, error } = useQuery(
         [
             LIST_INSTANT_LAUNCHES_BY_METADATA_KEY,
             instantLaunchLocationAttr,
@@ -116,7 +116,7 @@ function Listing(props) {
         ];
     }, [baseId, t, computeLimitExceeded]);
 
-    const isLoading = isQueryLoading([status, isFetchingUsageSummary]);
+    const isLoading = isQueryLoading([isFetching, isFetchingUsageSummary]);
 
     if (error) {
         return <WrappedErrorHandler errorObject={error} baseId={baseId} />;

--- a/src/components/search/detailed/AnalysesSearchResults.js
+++ b/src/components/search/detailed/AnalysesSearchResults.js
@@ -62,7 +62,7 @@ export default function AnalysesSearchResults(props) {
     const [selectedAnalysis, setSelectedAnalysis] = useState();
 
     const {
-        status,
+        isFetching,
         data,
         isFetchingNextPage,
         fetchNextPage,
@@ -172,7 +172,7 @@ export default function AnalysesSearchResults(props) {
         );
     }
     if (
-        status !== constants.LOADING &&
+        !isFetching &&
         (!data ||
             data.pages.length === 0 ||
             data.pages[0].analyses.length === 0)
@@ -193,7 +193,7 @@ export default function AnalysesSearchResults(props) {
                 columns={columns}
                 data={flatData}
                 baseId={baseId}
-                loading={status === constants.LOADING}
+                loading={isFetching}
                 fetchMore={fetchNextPage}
                 isFetchingMore={isFetchingNextPage}
                 canFetchMore={hasNextPage}

--- a/src/components/search/detailed/AppSearchResults.js
+++ b/src/components/search/detailed/AppSearchResults.js
@@ -97,7 +97,7 @@ export default function AppSearchResults(props) {
     const [order, setOrder] = useState(constants.SORT_ASCENDING);
     const [orderBy, setOrderBy] = useState(appRecordFields.NAME.key);
     const {
-        status,
+        isFetching,
         data,
         isFetchingNextPage,
         fetchNextPage,
@@ -204,7 +204,7 @@ export default function AppSearchResults(props) {
         );
     }
     if (
-        status !== constants.LOADING &&
+        !isFetching &&
         (!data || data.pages.length === 0 || data.pages[0].apps.length === 0)
     ) {
         return <Typography>{t("noResults")}</Typography>;
@@ -218,7 +218,7 @@ export default function AppSearchResults(props) {
                 columns={columns}
                 data={flatData}
                 baseId={baseId}
-                loading={status === constants.LOADING}
+                loading={isFetching}
                 fetchMore={fetchNextPage}
                 isFetchingMore={isFetchingNextPage}
                 canFetchMore={hasNextPage}

--- a/src/components/search/detailed/DataSearchResults.js
+++ b/src/components/search/detailed/DataSearchResults.js
@@ -17,7 +17,6 @@ import { ERROR, SUCCESS } from "components/announcer/AnnouncerConstants";
 
 import DELink from "components/utils/DELink";
 
-import constants from "../../../constants";
 import SearchResultsTable from "./SearchResultsTable";
 import { useDataSearchInfinite } from "../searchQueries";
 import searchConstants from "../constants";
@@ -134,7 +133,7 @@ function DataSearchResults(props) {
     });
 
     const {
-        status,
+        isFetching,
         data,
         isFetchingNextPage,
         fetchNextPage,
@@ -317,7 +316,7 @@ function DataSearchResults(props) {
         );
     }
     if (
-        status !== constants.LOADING &&
+        !isFetching &&
         (!data || data.pages.length === 0 || data.pages[0]?.hits?.length === 0)
     ) {
         return (
@@ -342,7 +341,7 @@ function DataSearchResults(props) {
                 columns={columns}
                 data={flatData}
                 baseId={baseId}
-                loading={status === constants.LOADING}
+                loading={isFetching}
                 fetchMore={fetchNextPage}
                 isFetchingMore={isFetchingNextPage}
                 canFetchMore={hasNextPage}

--- a/src/components/search/detailed/DataSearchResults.js
+++ b/src/components/search/detailed/DataSearchResults.js
@@ -317,7 +317,10 @@ function DataSearchResults(props) {
     }
     if (
         !isFetching &&
-        (!data || data.pages.length === 0 || data.pages[0]?.hits?.length === 0)
+        (!data ||
+            data.pages.length === 0 ||
+            !data.pages[0]?.hits ||
+            data.pages[0]?.hits.length === 0)
     ) {
         return (
             <>

--- a/src/components/sharing/SubjectSearchField.js
+++ b/src/components/sharing/SubjectSearchField.js
@@ -90,7 +90,7 @@ function SubjectSearchField(props) {
     // Get QueryClient from the context
     const queryClient = useQueryClient();
 
-    const { status: subjectSearchStatus } = useQuery({
+    const { isFetching: subjectSearchFetching } = useQuery({
         queryKey: [SEARCH_SUBJECTS_QUERY_KEY, searchTerm],
         queryFn: () => searchSubjects({ searchTerm }),
         enabled: !!(searchTerm && searchTerm.length > 2),
@@ -109,7 +109,7 @@ function SubjectSearchField(props) {
         },
     });
 
-    const { status: recentContactsStatus } = useQuery({
+    const { isFetching: recentContactsFetching } = useQuery({
         queryKey: [RECENT_CONTACTS_QUERY],
         queryFn: fetchRecentContactsList,
         onSuccess: (resp) => {
@@ -217,8 +217,8 @@ function SubjectSearchField(props) {
     };
 
     const loading = isQueryLoading([
-        subjectSearchStatus,
-        recentContactsStatus,
+        subjectSearchFetching,
+        recentContactsFetching,
         addRecentContactStatus,
         removeRecentContactStatus,
     ]);

--- a/src/components/vice/admin/table/actionButtons.js
+++ b/src/components/vice/admin/table/actionButtons.js
@@ -58,12 +58,10 @@ const ActionButtons = ({
 
     const externalID = row.original.externalID;
 
-    const { status, data, error } = useQuery(["async-data", externalID], () =>
-        asyncData(externalID)
+    const { isFetching, isError, data, error } = useQuery(
+        ["async-data", externalID],
+        () => asyncData(externalID)
     );
-
-    const isLoading = status === "loading";
-    const hasErrored = status === "error";
 
     const onClick = (_event, dataFn, msgKey) => {
         let tlErr;
@@ -84,19 +82,19 @@ const ActionButtons = ({
     };
 
     useEffect(() => {
-        if (hasErrored) {
+        if (isError) {
             announce({
                 text: `Action buttons not available: ${error.message}`,
                 variant: ERROR,
             });
         }
-    }, [hasErrored, error]);
+    }, [isError, error]);
 
     return (
         <div className={classes.actions}>
-            {isLoading ? (
+            {isFetching ? (
                 <ActionButtonsSkeleton id={id(externalID, "skeleton")} />
-            ) : !hasErrored ? (
+            ) : !isError ? (
                 <>
                     <ActionButton
                         external={externalID}

--- a/src/components/vice/admin/table/actionButtons.js
+++ b/src/components/vice/admin/table/actionButtons.js
@@ -131,7 +131,7 @@ const ActionButtons = ({
                     <ActionButton
                         externalID={externalID}
                         name="saveAndExit"
-                        handler={handleExit}
+                        handler={handleSaveAndExit}
                         popperMsgKey="saveAndExitCommandSent"
                         onClick={onClick}
                     />

--- a/src/pages/analyses/[analysisId]/relaunch.js
+++ b/src/pages/analyses/[analysisId]/relaunch.js
@@ -12,7 +12,6 @@ import { useQuery } from "@tanstack/react-query";
 
 import { i18n, RequiredNamespaces } from "i18n";
 
-import constants from "../../../constants";
 import {
     getAnalysisRelaunchInfo,
     ANALYSIS_RELAUNCH_QUERY_KEY,
@@ -58,7 +57,7 @@ const Relaunch = ({ showErrorAnnouncer }) => {
         }
     }, [analysisId, setRelaunchQueryEnabled]);
 
-    const { status: relaunchStatus } = useQuery({
+    const { isFetching: isFetchingRelaunchInfo } = useQuery({
         queryKey: relaunchKey,
         queryFn: () => getAnalysisRelaunchInfo(relaunchKey[1]),
         enabled: relaunchQueryEnabled,
@@ -82,8 +81,7 @@ const Relaunch = ({ showErrorAnnouncer }) => {
         onError: setRelaunchError,
     });
 
-    const loading =
-        relaunchStatus === constants.LOADING || isFetchingUsageSummary;
+    const loading = isFetchingRelaunchInfo || isFetchingUsageSummary;
 
     return (
         <AppLaunch


### PR DESCRIPTION
In react-query v4, `status` is always initially `loading`, even when the query is disabled and has no data.

This PR also includes a fix in `PathListViewer` for the use of the data viewer toolbar's `onSaving` prop
(making it consistent with the other TextViewers).