### PR TITLE
CORE-2123 Replace `onSuccess` and `onError` callbacks in pages

### DIFF
--- a/src/pages/analyses/[analysisId]/relaunch.js
+++ b/src/pages/analyses/[analysisId]/relaunch.js
@@ -32,12 +32,6 @@ const Relaunch = ({ showErrorAnnouncer }) => {
     const [relaunchQueryEnabled, setRelaunchQueryEnabled] =
         React.useState(false);
 
-    const [app, setApp] = React.useState(null);
-    const [relaunchError, setRelaunchError] = React.useState(null);
-    const [viceQuota, setViceQuota] = React.useState();
-    const [runningJobs, setRunningJobs] = React.useState();
-    const [hasPendingRequest, setHasPendingRequest] = React.useState();
-
     const router = useRouter();
     const { analysisId } = router.query;
 
@@ -57,36 +51,29 @@ const Relaunch = ({ showErrorAnnouncer }) => {
         }
     }, [analysisId, setRelaunchQueryEnabled]);
 
-    const { isFetching: isFetchingRelaunchInfo } = useQuery({
+    const {
+        isFetching: isFetchingRelaunchInfo,
+        data: app,
+        error: relaunchError,
+    } = useQuery({
         queryKey: relaunchKey,
         queryFn: () => getAnalysisRelaunchInfo(relaunchKey[1]),
         enabled: relaunchQueryEnabled,
-        onSuccess: (resp) => {
-            if (resp?.limitChecks?.canRun || !userProfile?.id) {
-                setApp(resp);
-            } else {
-                setRelaunchError(resp?.limitChecks?.results[0]?.reasonCodes[0]);
-                setViceQuota(
-                    resp?.limitChecks?.results[0]?.additionalInfo?.maxJobs
-                );
-                setRunningJobs(
-                    resp?.limitChecks?.results[0]?.additionalInfo?.runningJobs
-                );
-                setHasPendingRequest(
-                    resp?.limitChecks?.results[0]?.additionalInfo
-                        ?.pendingRequest
-                );
-            }
-        },
-        onError: setRelaunchError,
     });
+
+    const canRun = app?.limitChecks?.canRun || !userProfile?.id;
+    const limitCheck = !canRun && app?.limitChecks?.results[0];
+    const limitCheckReason = limitCheck?.reasonCodes?.[0];
+    const viceQuota = limitCheck?.additionalInfo?.maxJobs;
+    const runningJobs = limitCheck?.additionalInfo?.runningJobs;
+    const hasPendingRequest = limitCheck?.additionalInfo?.pendingRequest;
 
     const loading = isFetchingRelaunchInfo || isFetchingUsageSummary;
 
     return (
         <AppLaunch
             app={app}
-            launchError={relaunchError}
+            launchError={relaunchError || limitCheckReason}
             loading={loading}
             viceQuota={viceQuota}
             runningJobs={runningJobs}

--- a/src/pages/apps/[systemId]/[appId]/launch.js
+++ b/src/pages/apps/[systemId]/[appId]/launch.js
@@ -31,11 +31,6 @@ import withErrorAnnouncer from "components/error/withErrorAnnouncer";
 
 function Launch({ showErrorAnnouncer }) {
     const [userProfile] = useUserProfile();
-    const [app, setApp] = React.useState(null);
-    const [launchError, setLaunchError] = React.useState(null);
-    const [viceQuota, setViceQuota] = React.useState();
-    const [runningJobs, setRunningJobs] = React.useState();
-    const [hasPendingRequest, setHasPendingRequest] = React.useState();
 
     const router = useRouter();
     const { systemId, appId } = router.query;
@@ -46,41 +41,41 @@ function Launch({ showErrorAnnouncer }) {
     const launchId =
         router.query["saved-launch-id"] || router.query["quick-launch-id"];
 
-    const { isFetching: appDescriptionLoading } = useQuery({
+    const {
+        data: app,
+        isFetching: appDescriptionLoading,
+        error: appDescriptionError,
+    } = useQuery({
         queryKey: [APP_DESCRIPTION_QUERY_KEY, { systemId, appId }],
         queryFn: () => getAppDescription({ systemId, appId }),
         enabled: !!(systemId && appId && !launchId),
-        onSuccess: (resp) => {
-            const checks = resp?.limitChecks;
-            if (checks?.canRun || !userProfile?.id) {
-                setApp(resp);
-            } else {
-                const checkResults = resp?.limitChecks?.results[0];
-                const additionalInfo = checkResults?.additionalInfo;
-
-                setLaunchError(checkResults?.reasonCodes[0]);
-                setViceQuota(additionalInfo?.maxJobs);
-                setRunningJobs(additionalInfo?.runningJobs);
-                setHasPendingRequest(additionalInfo?.pendingRequest);
-            }
-        },
-        onError: setLaunchError,
     });
 
-    const { isFetching: savedLaunchLoading } = useQuery({
+    const canRun = app?.limitChecks?.canRun || !userProfile?.id;
+    const limitCheck = !canRun && app?.limitChecks?.results[0];
+    const limitCheckReason = limitCheck?.reasonCodes?.[0];
+    const viceQuota = limitCheck?.additionalInfo?.maxJobs;
+    const runningJobs = limitCheck?.additionalInfo?.runningJobs;
+    const hasPendingRequest = limitCheck?.additionalInfo?.pendingRequest;
+
+    const {
+        data: savedLaunchAppInfo,
+        isFetching: savedLaunchLoading,
+        error: savedLaunchError,
+    } = useQuery({
         queryKey: [SAVED_LAUNCH_APP_INFO, { launchId }],
         queryFn: () => getAppInfo({ launchId }),
         enabled: !!launchId,
-        onSuccess: setApp,
-        onError: setLaunchError,
     });
 
+    const launchError =
+        appDescriptionError || savedLaunchError || limitCheckReason;
     const loading =
         appDescriptionLoading || savedLaunchLoading || isFetchingUsageSummary;
 
     return (
         <AppLaunch
-            app={app}
+            app={app || savedLaunchAppInfo}
             launchError={launchError}
             loading={loading}
             viceQuota={viceQuota}

--- a/src/pages/apps/[systemId]/[appId]/versions/[versionId]/launch.js
+++ b/src/pages/apps/[systemId]/[appId]/versions/[versionId]/launch.js
@@ -23,11 +23,6 @@ import useResourceUsageSummary from "common/useResourceUsageSummary";
 
 function Launch({ showErrorAnnouncer }) {
     const [userProfile] = useUserProfile();
-    const [app, setApp] = React.useState(null);
-    const [launchError, setLaunchError] = React.useState(null);
-    const [viceQuota, setViceQuota] = React.useState();
-    const [runningJobs, setRunningJobs] = React.useState();
-    const [hasPendingRequest, setHasPendingRequest] = React.useState();
 
     const router = useRouter();
     const { systemId, appId, versionId } = router.query;
@@ -35,7 +30,11 @@ function Launch({ showErrorAnnouncer }) {
     const { isFetchingUsageSummary, computeLimitExceeded } =
         useResourceUsageSummary(showErrorAnnouncer);
 
-    const { isFetching: appDescriptionLoading } = useQuery({
+    const {
+        isFetching: appDescriptionLoading,
+        data: app,
+        error: launchError,
+    } = useQuery({
         queryKey: [
             APP_DESCRIPTION_QUERY_KEY,
             {
@@ -51,29 +50,21 @@ function Launch({ showErrorAnnouncer }) {
                 versionId,
             }),
         enabled: !!(systemId && appId && versionId),
-        onSuccess: (resp) => {
-            const checks = resp?.limitChecks;
-            if (checks?.canRun || !userProfile?.id) {
-                setApp(resp);
-            } else {
-                const checkResults = resp?.limitChecks?.results[0];
-                const additionalInfo = checkResults?.additionalInfo;
-
-                setLaunchError(checkResults?.reasonCodes[0]);
-                setViceQuota(additionalInfo?.maxJobs);
-                setRunningJobs(additionalInfo?.runningJobs);
-                setHasPendingRequest(additionalInfo?.pendingRequest);
-            }
-        },
-        onError: setLaunchError,
     });
+
+    const canRun = app?.limitChecks?.canRun || !userProfile?.id;
+    const limitCheck = !canRun && app?.limitChecks?.results[0];
+    const limitCheckReason = limitCheck?.reasonCodes?.[0];
+    const viceQuota = limitCheck?.additionalInfo?.maxJobs;
+    const runningJobs = limitCheck?.additionalInfo?.runningJobs;
+    const hasPendingRequest = limitCheck?.additionalInfo?.pendingRequest;
 
     const loading = appDescriptionLoading || isFetchingUsageSummary;
 
     return (
         <AppLaunch
             app={app}
-            launchError={launchError}
+            launchError={launchError || limitCheckReason}
             loading={loading}
             viceQuota={viceQuota}
             runningJobs={runningJobs}

--- a/src/pages/data/ds/[...pathItems].js
+++ b/src/pages/data/ds/[...pathItems].js
@@ -69,9 +69,6 @@ export default function DataStore() {
     const path = fullPath.replace(baseRoutingPath, "").split("?")[0];
     const resourcePath = decodeURIComponent(path);
 
-    const [details, setDetails] = useState(null);
-    const [errorObject, setErrorObject] = useState(null);
-
     const handlePathChange = useCallback(
         (path, query) => {
             const pathname = `${baseRoutingPath}${getEncodedPath(path)}`;
@@ -137,15 +134,17 @@ export default function DataStore() {
         [baseRoutingPath, router]
     );
 
-    const { isFetching: detailsLoading } = useQuery({
+    const {
+        isFetching: detailsLoading,
+        data: detailsData,
+        error: errorObject,
+    } = useQuery({
         queryKey: [DATA_DETAILS_FROM_PAGE_QUERY_KEY, { paths: [resourcePath] }],
         queryFn: () => getResourceDetails({ paths: [resourcePath] }),
         enabled: (viewMetadata || isFile) && !createFileType,
-        onSuccess: (resp) => {
-            setDetails(resp?.paths[resourcePath]);
-        },
-        onError: setErrorObject,
     });
+
+    const details = detailsData?.paths?.[resourcePath];
 
     if (viewMetadata) {
         return (


### PR DESCRIPTION
Since the `onSuccess` callback for `useQuery` is working differently now in `react-query` v4, beyond just being deprecated, I finished replacing the `onSuccess` and `onError` callbacks in the remaining pages that still used them.