### PR TITLE
Add sonora CLAUDE.md with project-specific guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# sonora project guidelines
+
+* Build forms with `formik` plus the field components in `components/forms/`
+  (`FormTextField`, `FormSwitch`, etc.). Don't hand-roll form state or
+  validation wiring.
+* Use `components/table/TableLoading` for table loading states so column
+  headers stay visible while data loads.
+* Keep i18n locale JSON keys (`public/static/locales/**`) sorted
+  alphabetically.


### PR DESCRIPTION
## Summary
- Adds a repo-level `CLAUDE.md` documenting sonora-specific conventions for AI-assisted work: build forms with `formik` + `components/forms/` field components, use `components/table/TableLoading` for table loading states, and keep i18n locale JSON keys sorted alphabetically.

## Test plan
- [ ] N/A — documentation-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)