### PR TITLE
Expand sonora Justfile to mirror terrain's recipe surface

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -8,17 +8,20 @@ build-flags := ""
 
 default: build
 
-test:
-    npm run test
-
 deps:
     npm install
 
 build: deps
-    npm run build	
+    npm run build
+
+dev:
+    npm run dev
+
+run:
+    npm start
 
 build-image:
-    {{ container-runtime }} build -f {{ build-context}}/{{ dockerfile }} -t {{ image-name }}:{{ tag }} --platform {{ platform }} {{ build-flags }} {{ build-context}}
+    {{ container-runtime }} build -f {{ build-context }}/{{ dockerfile }} -t {{ image-name }}:{{ tag }} --platform {{ platform }} {{ build-flags }} {{ build-context }}
 
 push:
     {{ container-runtime }} push {{ image-name }}:{{ tag }}
@@ -61,6 +64,26 @@ write-build-file output-file="build.json":
       ]
     }
     EOF
+
+test:
+    npm test
+
+lint:
+    npm run lint
+
+fmt-check:
+    npm run check-format
+
+fmt-fix:
+    npm run format
+
+check: fmt-check lint test
+
+storybook:
+    npm run storybook
+
+build-storybook:
+    npm run build-storybook
 
 clean:
     npm run clean


### PR DESCRIPTION
## Summary
- Adds `dev`, `run`, `lint`, `fmt-check`, `fmt-fix`, `check`, `storybook`, and `build-storybook` recipes so the common npm scripts are reachable through `just`, matching the recipe surface of terrain's Justfile.
- `check` runs `fmt-check lint test`, mirroring the npm `check` script.
- Normalizes `{{ build-context }}` spacing and drops a stray trailing tab on the `build` recipe.

## Test plan
- [x] `just --list` parses and shows all 16 recipes.
- [ ] Spot-check a recipe or two locally (e.g. `just lint`, `just fmt-check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)