### PR TITLE
CORE-2123 Migrate tables to `@tanstack/react-table` v8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
                 "@next/bundle-analyzer": "^12.3.4",
                 "@tanstack/react-query": "^4.43.0",
                 "@tanstack/react-query-devtools": "^4.43.0",
+                "@tanstack/react-table": "^8.21.3",
                 "amqplib": "^0.8.0",
                 "animated-number-react": "^0.1.1",
                 "axios": "^1.13.5",
@@ -6509,6 +6510,39 @@
                 "@tanstack/react-query": "^4.43.0",
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
                 "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@tanstack/react-table": {
+            "version": "8.21.3",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+            "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/table-core": "8.21.3"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "react": ">=16.8",
+                "react-dom": ">=16.8"
+            }
+        },
+        "node_modules/@tanstack/table-core": {
+            "version": "8.21.3",
+            "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+            "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
             }
         },
         "node_modules/@testim/chrome-version": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,6 @@
                 "react-i18next": "^13.5.0",
                 "react-joyride": "^3.0.0",
                 "react-player": "^2.6.2",
-                "react-table": "^7.7.0",
                 "sanitize-html": "^2.3.2",
                 "showdown": "^1.9.1",
                 "sockette": "^2.0.6",
@@ -20062,19 +20061,6 @@
             "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/react-table": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.8.0.tgz",
-            "integrity": "sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==",
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/tannerlinsley"
-            },
-            "peerDependencies": {
-                "react": "^16.8.3 || ^17.0.0-0 || ^18.0.0"
-            }
         },
         "node_modules/react-test-renderer": {
             "version": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,6 @@
         "react-i18next": "^13.5.0",
         "react-joyride": "^3.0.0",
         "react-player": "^2.6.2",
-        "react-table": "^7.7.0",
         "sanitize-html": "^2.3.2",
         "showdown": "^1.9.1",
         "sockette": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
         "@next/bundle-analyzer": "^12.3.4",
         "@tanstack/react-query": "^4.43.0",
         "@tanstack/react-query-devtools": "^4.43.0",
+        "@tanstack/react-table": "^8.21.3",
         "amqplib": "^0.8.0",
         "animated-number-react": "^0.1.1",
         "axios": "^1.13.5",

--- a/src/components/analyses/landing/BatchResults.js
+++ b/src/components/analyses/landing/BatchResults.js
@@ -71,9 +71,9 @@ export default function BatchResults(props) {
     const columns = React.useMemo(
         () => [
             {
-                Header: analysisRecordFields.NAME.fieldName,
-                accessor: analysisRecordFields.NAME.key,
-                Cell: ({ row }) => (
+                header: analysisRecordFields.NAME.fieldName,
+                accessorKey: analysisRecordFields.NAME.key,
+                cell: ({ row }) => (
                     <Link
                         href={`/${NavigationConstants.ANALYSES}/${row?.original.id}?view=${BATCH_DRILL_DOWN}`}
                         legacyBehavior
@@ -87,8 +87,8 @@ export default function BatchResults(props) {
                 ),
             },
             {
-                Header: analysisRecordFields.STATUS.fieldName,
-                accessor: analysisRecordFields.STATUS.key,
+                header: analysisRecordFields.STATUS.fieldName,
+                accessorKey: analysisRecordFields.STATUS.key,
             },
         ],
         [analysisRecordFields]

--- a/src/components/apps/admin/referenceGenomes/ReferenceGenomes.js
+++ b/src/components/apps/admin/referenceGenomes/ReferenceGenomes.js
@@ -99,9 +99,9 @@ function ReferenceGenomes(props) {
     const columns = React.useMemo(
         () => [
             {
-                Header: t("name"),
-                accessor: refGenomeConstants.keys.NAME,
-                Cell: ({ row, value }) => (
+                header: t("name"),
+                accessorKey: refGenomeConstants.keys.NAME,
+                cell: ({ row, getValue }) => (
                     <>
                         {row?.original?.deleted && (
                             <RemoveCircleIcon
@@ -115,22 +115,22 @@ function ReferenceGenomes(props) {
                             }}
                             underline="hover"
                         >
-                            {value}
+                            {getValue()}
                         </Link>
                     </>
                 ),
             },
             {
-                Header: t("path"),
-                accessor: refGenomeConstants.keys.PATH,
+                header: t("path"),
+                accessorKey: refGenomeConstants.keys.PATH,
             },
             {
-                Header: t("createdBy"),
-                accessor: refGenomeConstants.keys.CREATED_BY,
+                header: t("createdBy"),
+                accessorKey: refGenomeConstants.keys.CREATED_BY,
             },
             {
-                Header: t("createdOn"),
-                accessor: refGenomeConstants.keys.CREATED_ON,
+                header: t("createdOn"),
+                accessorKey: refGenomeConstants.keys.CREATED_ON,
             },
         ],
         [t, theme.palette.error.main]

--- a/src/components/apps/admin/referenceGenomes/TableView.js
+++ b/src/components/apps/admin/referenceGenomes/TableView.js
@@ -5,14 +5,15 @@
  *
  */
 
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 
 import {
-    useRowSelect,
-    useGlobalFilter,
-    useSortBy,
-    useTable,
-} from "react-table";
+    useReactTable,
+    getCoreRowModel,
+    getFilteredRowModel,
+    getSortedRowModel,
+    flexRender,
+} from "@tanstack/react-table";
 
 import refGenomeConstants from "./constants";
 import TableToolbar from "./Toolbar";
@@ -32,20 +33,6 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import TableSortLabel from "@mui/material/TableSortLabel";
 
-const IndeterminateCheckbox = React.forwardRef(function IndeterminateCheckbox(
-    { indeterminate, ...rest },
-    ref
-) {
-    const defaultRef = React.useRef();
-    const resolvedRef = ref || defaultRef;
-
-    React.useEffect(() => {
-        resolvedRef.current.indeterminate = indeterminate;
-    }, [resolvedRef, indeterminate]);
-
-    return <Checkbox type="Checkbox" ref={resolvedRef} {...rest} />;
-});
-
 const EnhancedTable = ({
     baseId,
     columns,
@@ -54,80 +41,82 @@ const EnhancedTable = ({
     onDeletedClicked,
 }) => {
     const [lastSelectIndex, setLastSelectIndex] = useState(-1);
-    const {
-        getTableProps,
-        headerGroups,
-        prepareRow,
-        rows,
-        preGlobalFilteredRows,
-        setGlobalFilter,
-        selectedFlatRows,
-        state: { globalFilter },
-        toggleRowSelected,
-    } = useTable(
-        {
-            columns,
-            data,
-            disableSortBy: true,
-            initialState: {
-                sortBy: [
-                    {
-                        id: refGenomeConstants.keys.NAME,
-                        desc: false,
-                    },
-                ],
-            },
-        },
-        useGlobalFilter,
-        useSortBy,
-        useRowSelect,
-        (hooks) => {
-            hooks.allColumns.push((columns) => [
-                // Let's make a column for selection
-                {
-                    id: "selection",
-                    // The header can use the table's getToggleAllRowsSelectedProps method
-                    // to render a checkbox
-                    Header: ({ getToggleAllRowsSelectedProps }) => (
-                        <IndeterminateCheckbox
-                            {...getToggleAllRowsSelectedProps()}
-                        />
-                    ),
-                    // The cell can use the individual row's getToggleRowSelectedProps method
-                    // to the render a checkbox
-                    Cell: ({ row }) => (
-                        <IndeterminateCheckbox
-                            {...row.getToggleRowSelectedProps()}
-                        />
-                    ),
-                },
-                ...columns,
-            ]);
-        }
+    const [globalFilter, setGlobalFilter] = useState("");
+    const [rowSelection, setRowSelection] = useState({});
+    const [sorting, setSorting] = useState([
+        { id: refGenomeConstants.keys.NAME, desc: false },
+    ]);
+
+    const selectionColumn = useMemo(
+        () => ({
+            id: "selection",
+            header: ({ table }) => (
+                <Checkbox
+                    checked={table.getIsAllRowsSelected()}
+                    indeterminate={table.getIsSomeRowsSelected()}
+                    onChange={table.getToggleAllRowsSelectedHandler()}
+                />
+            ),
+            cell: ({ row }) => (
+                <Checkbox
+                    checked={row.getIsSelected()}
+                    indeterminate={row.getIsSomeSelected()}
+                    onChange={row.getToggleSelectedHandler()}
+                />
+            ),
+            enableSorting: false,
+        }),
+        []
     );
 
-    const select = (rows) => {
-        let newSelected = [...new Set([...selectedFlatRows, ...rows])];
-        newSelected.forEach((row) => toggleRowSelected(row.index, true));
+    const tableColumns = useMemo(
+        () => [selectionColumn, ...columns],
+        [selectionColumn, columns]
+    );
+
+    const table = useReactTable({
+        columns: tableColumns,
+        data,
+        state: { globalFilter, rowSelection, sorting },
+        onGlobalFilterChange: setGlobalFilter,
+        onRowSelectionChange: setRowSelection,
+        onSortingChange: setSorting,
+        enableSortingRemoval: false,
+        getCoreRowModel: getCoreRowModel(),
+        getFilteredRowModel: getFilteredRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+    });
+
+    const rows = table.getRowModel().rows;
+
+    const select = (targetRows) => {
+        const newSelection = { ...rowSelection };
+        targetRows.forEach((row) => {
+            newSelection[row.id] = true;
+        });
+        setRowSelection(newSelection);
     };
 
-    const deselect = (rows) => {
-        const newSelected = selectedFlatRows.filter((row) =>
-            rows.includes(row)
-        );
-
-        newSelected.forEach((row) => toggleRowSelected(row.index, false));
+    const deselect = (targetRows) => {
+        const newSelection = { ...rowSelection };
+        targetRows.forEach((row) => {
+            // Need to delete this key, rather than simply set it to `false`,
+            // otherwise the `indeterminate` flag in the `selectionColumn`
+            // header Checkbox does not work correctly.
+            delete newSelection[row.id];
+        });
+        setRowSelection(newSelection);
     };
 
     const rangeSelect = (start, end, row) => {
         if (start > -1) {
-            const rangeIds = [];
+            const rangeRows = [];
             for (let i = start; i <= end; i++) {
-                rangeIds.push(rows[i]);
+                rangeRows.push(rows[i]);
             }
 
-            let isTargetSelected = selectedFlatRows.includes(row);
-            isTargetSelected ? deselect(rangeIds) : select(rangeIds);
+            let isTargetSelected = row.getIsSelected();
+            isTargetSelected ? deselect(rangeRows) : select(rangeRows);
         }
     };
 
@@ -137,7 +126,7 @@ const EnhancedTable = ({
                 ? rangeSelect(index, lastSelectIndex, row)
                 : rangeSelect(lastSelectIndex, index, row);
         } else {
-            toggleRowSelected(index, !row.isSelected);
+            row.toggleSelected(!row.getIsSelected());
         }
 
         setLastSelectIndex(index);
@@ -148,35 +137,38 @@ const EnhancedTable = ({
         <>
             <TableToolbar
                 baseId={tableId}
-                preGlobalFilteredRows={preGlobalFilteredRows}
+                preGlobalFilteredRows={table.getPreFilteredRowModel().rows}
                 setGlobalFilter={setGlobalFilter}
                 globalFilter={globalFilter}
                 onAddClicked={onAddClicked}
                 onDeletedClicked={onDeletedClicked}
             />
             <TableContainer component={Paper} style={{ overflow: "auto" }}>
-                <Table size="small" stickyHeader {...getTableProps()}>
+                <Table size="small" stickyHeader>
                     <TableHead>
-                        {headerGroups.map((headerGroup) => (
-                            <TableRow
-                                key={headerGroup.id}
-                                {...headerGroup.getHeaderGroupProps()}
-                            >
-                                {headerGroup.headers.map((column) => (
+                        {table.getHeaderGroups().map((headerGroup) => (
+                            <TableRow key={headerGroup.id}>
+                                {headerGroup.headers.map((header) => (
                                     <TableCell
-                                        key={column.id}
-                                        {...(column.id === "selection"
-                                            ? column.getHeaderProps()
-                                            : column.getHeaderProps(
-                                                  column.getSortByToggleProps()
-                                              ))}
+                                        key={header.id}
+                                        onClick={
+                                            header.column.getCanSort()
+                                                ? header.column.getToggleSortingHandler()
+                                                : undefined
+                                        }
                                     >
-                                        {column.render("Header")}
-                                        {column.id !== "selection" ? (
+                                        {flexRender(
+                                            header.column.columnDef.header,
+                                            header.getContext()
+                                        )}
+                                        {header.column.getCanSort() ? (
                                             <TableSortLabel
-                                                active={column.isSorted}
+                                                active={
+                                                    !!header.column.getIsSorted()
+                                                }
                                                 direction={
-                                                    column.isSortedDesc
+                                                    header.column.getIsSorted() ===
+                                                    "desc"
                                                         ? "desc"
                                                         : "asc"
                                                 }
@@ -189,22 +181,20 @@ const EnhancedTable = ({
                     </TableHead>
                     <TableBody>
                         {rows.map((row, index) => {
-                            prepareRow(row);
                             return (
                                 <TableRow
                                     key={row.id}
-                                    {...row.getRowProps()}
                                     onClick={(event) =>
                                         handleClick(event, row, index)
                                     }
                                 >
-                                    {row.cells.map((cell) => {
+                                    {row.getVisibleCells().map((cell) => {
                                         return (
-                                            <TableCell
-                                                key={cell.row.id}
-                                                {...cell.getCellProps()}
-                                            >
-                                                {cell.render("Cell")}
+                                            <TableCell key={cell.id}>
+                                                {flexRender(
+                                                    cell.column.columnDef.cell,
+                                                    cell.getContext()
+                                                )}
                                             </TableCell>
                                         );
                                     })}

--- a/src/components/collections/Listing.js
+++ b/src/components/collections/Listing.js
@@ -61,23 +61,23 @@ function Listing(props) {
     const columns = useMemo(() => {
         return [
             {
-                Header: COLLECTION_COLUMNS.NAME.fieldName,
-                accessor: COLLECTION_COLUMNS.NAME.key,
-                Cell: ({ row, value }) => {
+                header: COLLECTION_COLUMNS.NAME.fieldName,
+                accessorKey: COLLECTION_COLUMNS.NAME.key,
+                cell: ({ row, getValue }) => {
                     const collection = row.original;
                     const rowId = buildID(tableId, collection.id);
                     return (
                         <DELink
                             id={buildID(rowId, ids.COLLECTION_LINK)}
                             onClick={() => onCollectionSelected(collection)}
-                            text={value}
+                            text={getValue()}
                         />
                     );
                 },
             },
             {
-                Header: COLLECTION_COLUMNS.DESCRIPTION.fieldName,
-                accessor: COLLECTION_COLUMNS.DESCRIPTION.key,
+                header: COLLECTION_COLUMNS.DESCRIPTION.fieldName,
+                accessorKey: COLLECTION_COLUMNS.DESCRIPTION.key,
             },
         ];
     }, [COLLECTION_COLUMNS, onCollectionSelected, tableId]);

--- a/src/components/collections/form/Admins.js
+++ b/src/components/collections/form/Admins.js
@@ -64,9 +64,10 @@ function Admins(props) {
 
         return [
             {
-                Header: t("sharing:user"),
-                accessor: getUserPrimaryText,
-                Cell: ({ row }) => {
+                header: t("sharing:user"),
+                accessorFn: getUserPrimaryText,
+                id: "user",
+                cell: ({ row }) => {
                     return (
                         <Field name={`${name}.${row.index}`}>
                             {({ field: { value } }) => {
@@ -77,9 +78,9 @@ function Admins(props) {
                 },
             },
             {
-                Header: "",
-                accessor: "id",
-                Cell: ({ row }) => {
+                header: "",
+                accessorKey: "id",
+                cell: ({ row }) => {
                     const subject = row.original;
                     const rowId = getRowId(row);
                     if (isAdmin && !isSelf(subject)) {

--- a/src/components/data/viewers/PathListViewer.js
+++ b/src/components/data/viewers/PathListViewer.js
@@ -4,15 +4,13 @@
  * @author sriram
  *
  */
-import React, {
-    useCallback,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
-} from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 
-import { useRowSelect, useTable } from "react-table";
+import {
+    useReactTable,
+    getCoreRowModel,
+    flexRender,
+} from "@tanstack/react-table";
 import { useTranslation } from "i18n";
 
 import { UploadTrackingProvider } from "contexts/uploadTracking";
@@ -41,20 +39,6 @@ import {
     TableRow,
 } from "@mui/material";
 
-const IndeterminateCheckbox = React.forwardRef(function IndeterminateCheckbox(
-    { indeterminate, ...rest },
-    ref
-) {
-    const defaultRef = useRef();
-    const resolvedRef = ref || defaultRef;
-
-    useEffect(() => {
-        resolvedRef.current.indeterminate = indeterminate;
-    }, [resolvedRef, indeterminate]);
-
-    return <Checkbox type="Checkbox" ref={resolvedRef} {...rest} />;
-});
-
 function PathListViewer(props) {
     const {
         baseId,
@@ -77,6 +61,8 @@ function PathListViewer(props) {
     const [dirty, setDirty] = useState(false);
     const [editorData, setEditorData] = useState([]);
     const [fileSaving, setFileSaving] = useState(false);
+    const [columnVisibility, setColumnVisibility] = useState({});
+    const [rowSelection, setRowSelection] = useState({});
 
     const defaultStartingPath = useSelectorDefaultFolderPath();
 
@@ -85,7 +71,33 @@ function PathListViewer(props) {
         [data, t]
     );
 
-    const pathAccessor = columns[1].accessor;
+    const pathAccessor = columns[1]?.accessorKey;
+
+    const selectionColumn = useMemo(
+        () => ({
+            id: "selection",
+            header: ({ table }) => (
+                <Checkbox
+                    checked={table.getIsAllRowsSelected()}
+                    indeterminate={table.getIsSomeRowsSelected()}
+                    onChange={table.getToggleAllRowsSelectedHandler()}
+                />
+            ),
+            cell: ({ row }) => (
+                <Checkbox
+                    checked={row.getIsSelected()}
+                    indeterminate={row.getIsSomeSelected()}
+                    onChange={row.getToggleSelectedHandler()}
+                />
+            ),
+        }),
+        []
+    );
+
+    const tableColumns = useMemo(
+        () => [selectionColumn, ...columns],
+        [selectionColumn, columns]
+    );
 
     const setLineNumbers = useCallback(
         (tableData) => {
@@ -118,48 +130,17 @@ function PathListViewer(props) {
         return content;
     };
 
-    const {
-        getTableProps,
-        getTableBodyProps,
-        headerGroups,
-        rows,
-        prepareRow,
-        setHiddenColumns,
-        selectedFlatRows,
-        state: { hiddenColumns, selectedRowIds },
-    } = useTable(
-        {
-            columns,
-            data: editorData,
-            initialState: {
-                hiddenColumns: [],
-            },
-        },
-        useRowSelect,
-        (hooks) => {
-            hooks.allColumns.push((columns) => [
-                // Let's make a column for selection
-                {
-                    id: "selection",
-                    // The header can use the table's getToggleAllRowsSelectedProps method
-                    // to render a checkbox
-                    Header: ({ getToggleAllRowsSelectedProps }) => (
-                        <IndeterminateCheckbox
-                            {...getToggleAllRowsSelectedProps()}
-                        />
-                    ),
-                    // The cell can use the individual row's getToggleRowSelectedProps method
-                    // to the render a checkbox
-                    Cell: ({ row }) => (
-                        <IndeterminateCheckbox
-                            {...row.getToggleRowSelectedProps()}
-                        />
-                    ),
-                },
-                ...columns,
-            ]);
-        }
-    );
+    const table = useReactTable({
+        columns: tableColumns,
+        data: editorData,
+        state: { columnVisibility, rowSelection },
+        onColumnVisibilityChange: setColumnVisibility,
+        onRowSelectionChange: setRowSelection,
+        getCoreRowModel: getCoreRowModel(),
+    });
+
+    const selectedRows = table.getSelectedRowModel().rows;
+
     return (
         <PageWrapper appBarHeight={120}>
             <Toolbar
@@ -167,29 +148,31 @@ function PathListViewer(props) {
                 path={path}
                 resourceId={resourceId}
                 allowLineNumbers={true}
-                showLineNumbers={!hiddenColumns?.includes(LINE_NUMBER_ACCESSOR)}
-                onShowLineNumbers={(showLineNumbers) => {
-                    if (showLineNumbers) {
-                        setHiddenColumns([]);
-                    } else {
-                        setHiddenColumns([LINE_NUMBER_ACCESSOR]);
-                    }
+                showLineNumbers={
+                    columnVisibility[LINE_NUMBER_ACCESSOR] !== false
+                }
+                onShowLineNumbers={(show) => {
+                    setColumnVisibility({
+                        ...columnVisibility,
+                        [LINE_NUMBER_ACCESSOR]: show,
+                    });
                 }}
                 editable={editable}
                 onAddRow={() => {
                     setOpen(true);
                 }}
                 onDeleteRow={() => {
-                    selectedFlatRows.forEach((selRow) => {
+                    selectedRows.forEach((selRow) => {
                         const newData = editorData.filter(
                             (row, index) => index !== selRow.index
                         );
                         setEditorData(setLineNumbers([...newData]));
                         setDirty(true);
                     });
+                    setRowSelection({});
                 }}
                 dirty={dirty}
-                selectionCount={Object.keys(selectedRowIds).length}
+                selectionCount={selectedRows.length}
                 handlePathChange={handlePathChange}
                 onRefresh={onRefresh}
                 fileName={fileName}
@@ -219,43 +202,34 @@ function PathListViewer(props) {
                     id={buildID(baseId, ids.VIEWER_STRUCTURED, fileName)}
                     size="small"
                     stickyHeader
-                    {...getTableProps()}
                 >
                     <TableHead>
-                        {headerGroups.map((headerGroup) => (
-                            <TableRow
-                                key={headerGroup.id}
-                                {...headerGroup.getHeaderGroupProps()}
-                            >
-                                {headerGroup.headers.map((column) => (
-                                    <TableCell
-                                        key={column.id}
-                                        {...column.getHeaderProps()}
-                                    >
-                                        {column.render("Header")}
+                        {table.getHeaderGroups().map((headerGroup) => (
+                            <TableRow key={headerGroup.id}>
+                                {headerGroup.headers.map((header) => (
+                                    <TableCell key={header.id}>
+                                        {flexRender(
+                                            header.column.columnDef.header,
+                                            header.getContext()
+                                        )}
                                     </TableCell>
                                 ))}
                             </TableRow>
                         ))}
                     </TableHead>
-                    <TableBody {...getTableBodyProps()}>
-                        {rows.map((row) => {
-                            prepareRow(row);
-                            return (
-                                <TableRow key={row.id} {...row.getRowProps()}>
-                                    {row.cells.map((cell) => {
-                                        return (
-                                            <TableCell
-                                                key={cell.row.id}
-                                                {...cell.getCellProps()}
-                                            >
-                                                {cell.render("Cell")}
-                                            </TableCell>
-                                        );
-                                    })}
-                                </TableRow>
-                            );
-                        })}
+                    <TableBody>
+                        {table.getRowModel().rows.map((row) => (
+                            <TableRow key={row.id}>
+                                {row.getVisibleCells().map((cell) => (
+                                    <TableCell key={cell.id}>
+                                        {flexRender(
+                                            cell.column.columnDef.cell,
+                                            cell.getContext()
+                                        )}
+                                    </TableCell>
+                                ))}
+                            </TableRow>
+                        ))}
                     </TableBody>
                 </Table>
             </TableContainer>

--- a/src/components/data/viewers/StructuredTextViewer.js
+++ b/src/components/data/viewers/StructuredTextViewer.js
@@ -4,8 +4,12 @@
  * @author sriram
  *
  */
-import React, { useEffect, useMemo } from "react";
-import { useTable } from "react-table";
+import React, { useEffect, useMemo, useState } from "react";
+import {
+    useReactTable,
+    getCoreRowModel,
+    flexRender,
+} from "@tanstack/react-table";
 import { useTranslation } from "i18n";
 
 import ids from "./ids";
@@ -52,6 +56,7 @@ export default function StructuredTextViewer(props) {
     const [isFileSaving, setFileSaving] = React.useState();
     const [editorValue, setEditorValue] = React.useState();
     const [initialValue, setInitialValue] = React.useState();
+    const [columnVisibility, setColumnVisibility] = useState({});
 
     useEffect(() => {
         setInitialValue(rawData);
@@ -80,22 +85,17 @@ export default function StructuredTextViewer(props) {
         return editorValue;
     };
 
-    const {
-        getTableProps,
-        getTableBodyProps,
-        headerGroups,
-        rows,
-        prepareRow,
-        setHiddenColumns,
-        state,
-    } = useTable({
+    const table = useReactTable({
         columns,
         data: dataToDisplay,
-        initialState: {
-            hiddenColumns: [],
-        },
+        state: { columnVisibility },
+        onColumnVisibilityChange: setColumnVisibility,
+        getCoreRowModel: getCoreRowModel(),
     });
+
     const busy = loading || isFileSaving;
+
+    const showLineNumbers = columnVisibility[LINE_NUMBER_ACCESSOR] !== false;
 
     const TableView = () => (
         <TableContainer
@@ -108,43 +108,34 @@ export default function StructuredTextViewer(props) {
                 id={buildID(baseId, ids.VIEWER_STRUCTURED, fileName)}
                 size="small"
                 stickyHeader
-                {...getTableProps()}
             >
                 <TableHead>
-                    {headerGroups.map((headerGroup) => (
-                        <TableRow
-                            key={headerGroup.id}
-                            {...headerGroup.getHeaderGroupProps()}
-                        >
-                            {headerGroup.headers.map((column) => (
-                                <TableCell
-                                    key={column.id}
-                                    {...column.getHeaderProps()}
-                                >
-                                    {column.render("Header")}
+                    {table.getHeaderGroups().map((headerGroup) => (
+                        <TableRow key={headerGroup.id}>
+                            {headerGroup.headers.map((header) => (
+                                <TableCell key={header.id}>
+                                    {flexRender(
+                                        header.column.columnDef.header,
+                                        header.getContext()
+                                    )}
                                 </TableCell>
                             ))}
                         </TableRow>
                     ))}
                 </TableHead>
-                <TableBody {...getTableBodyProps()}>
-                    {rows.map((row) => {
-                        prepareRow(row);
-                        return (
-                            <TableRow key={row.id} {...row.getRowProps()}>
-                                {row.cells.map((cell) => {
-                                    return (
-                                        <TableCell
-                                            key={cell.row.id}
-                                            {...cell.getCellProps()}
-                                        >
-                                            {cell.render("Cell")}
-                                        </TableCell>
-                                    );
-                                })}
-                            </TableRow>
-                        );
-                    })}
+                <TableBody>
+                    {table.getRowModel().rows.map((row) => (
+                        <TableRow key={row.id}>
+                            {row.getVisibleCells().map((cell) => (
+                                <TableCell key={cell.id}>
+                                    {flexRender(
+                                        cell.column.columnDef.cell,
+                                        cell.getContext()
+                                    )}
+                                </TableCell>
+                            ))}
+                        </TableRow>
+                    ))}
                 </TableBody>
             </Table>
         </TableContainer>
@@ -156,15 +147,12 @@ export default function StructuredTextViewer(props) {
                 path={path}
                 resourceId={resourceId}
                 allowLineNumbers={true}
-                showLineNumbers={
-                    !state?.hiddenColumns?.includes(LINE_NUMBER_ACCESSOR)
-                }
-                onShowLineNumbers={(showLineNumbers) => {
-                    if (showLineNumbers) {
-                        setHiddenColumns([]);
-                    } else {
-                        setHiddenColumns([LINE_NUMBER_ACCESSOR]);
-                    }
+                showLineNumbers={showLineNumbers}
+                onShowLineNumbers={(show) => {
+                    setColumnVisibility({
+                        ...columnVisibility,
+                        [LINE_NUMBER_ACCESSOR]: show,
+                    });
                 }}
                 firstRowHeader={firstRowHeader}
                 onFirstRowHeader={(header) => setFirstRowHeader(header)}
@@ -196,11 +184,7 @@ export default function StructuredTextViewer(props) {
                     leftPanel={
                         <Editor
                             baseId={baseId}
-                            showLineNumbers={
-                                !state?.hiddenColumns?.includes(
-                                    LINE_NUMBER_ACCESSOR
-                                )
-                            }
+                            showLineNumbers={showLineNumbers}
                             editable={editable}
                             initialValue={initialValue}
                             setEditorValue={setEditorValue}

--- a/src/components/data/viewers/utils.js
+++ b/src/components/data/viewers/utils.js
@@ -5,7 +5,7 @@ const LINE_NUMBER_ACCESSOR = "lineNumber";
 
 /**
  *
- * Get columns array definition to use with react-table in PathListViewer and StructuredTextViewer
+ * Get columns array definition to use with @tanstack/react-table in PathListViewer and StructuredTextViewer
  *
  * @param {string} data - data to be displayed in react table.
  * @param {boolean} firstRowHeader - first row to be used as header or not
@@ -14,10 +14,10 @@ const LINE_NUMBER_ACCESSOR = "lineNumber";
 function getColumns(data, firstRowHeader, pathLabel) {
     let cols = [
         {
-            Header: "#",
-            accessor: LINE_NUMBER_ACCESSOR,
-            disableSortBy: true,
-            Cell: ({ row }) => {
+            header: "#",
+            accessorKey: LINE_NUMBER_ACCESSOR,
+            enableSorting: false,
+            cell: ({ row }) => {
                 return (
                     <Typography color="primary">
                         {row.original[LINE_NUMBER_ACCESSOR]}
@@ -33,9 +33,9 @@ function getColumns(data, firstRowHeader, pathLabel) {
 
     if (pathLabel) {
         cols.push({
-            Header: pathLabel,
-            accessor: Object.keys(data[0])[0],
-            disableSortBy: true,
+            header: pathLabel,
+            accessorKey: Object.keys(data[0])[0],
+            enableSorting: false,
         });
         return cols;
     }
@@ -48,15 +48,15 @@ function getColumns(data, firstRowHeader, pathLabel) {
         if (colId !== LINE_NUMBER_ACCESSOR) {
             if (colHeaders) {
                 cols.push({
-                    Header: colHeaders[colId],
-                    accessor: colId,
-                    disableSortBy: true,
+                    header: colHeaders[colId],
+                    accessorKey: colId,
+                    enableSorting: false,
                 });
             } else {
                 cols.push({
-                    Header: colId,
-                    accessor: colId,
-                    disableSortBy: true,
+                    header: colId,
+                    accessorKey: colId,
+                    enableSorting: false,
                 });
             }
         }

--- a/src/components/instantlaunches/admin/InstantLaunchList.js
+++ b/src/components/instantlaunches/admin/InstantLaunchList.js
@@ -335,10 +335,10 @@ const InstantLaunchList = ({ showErrorAnnouncer }) => {
     const columns = React.useMemo(() => {
         return [
             {
-                Header: "",
-                accessor: "quick_launch_id",
-                disableSortBy: true,
-                Cell: ({ row }) => {
+                header: "",
+                accessorKey: "quick_launch_id",
+                enableSorting: false,
+                cell: ({ row }) => {
                     const il = row.original;
 
                     const inDashboard = isInDashboard(
@@ -364,29 +364,29 @@ const InstantLaunchList = ({ showErrorAnnouncer }) => {
                 },
             },
             {
-                Header: t("common:name"),
-                accessor: "quick_launch_name",
+                header: t("common:name"),
+                accessorKey: "quick_launch_name",
             },
             {
-                Header: t("app"),
-                accessor: "app_name",
+                header: t("app"),
+                accessorKey: "app_name",
             },
             {
-                Header: t("appVersion"),
-                accessor: "app_version",
+                header: t("appVersion"),
+                accessorKey: "app_version",
             },
             {
-                Header: t("createdBy"),
-                accessor: "added_by",
-                Cell: ({ row }) => {
+                header: t("createdBy"),
+                accessorKey: "added_by",
+                cell: ({ row }) => {
                     const instantLaunch = row.original;
                     return shortenUsername(instantLaunch.added_by);
                 },
             },
             {
-                Header: t("addedOn"),
-                accessor: "added_on",
-                Cell: ({ row }) => {
+                header: t("addedOn"),
+                accessorKey: "added_on",
+                cell: ({ row }) => {
                     const instantLaunch = row.original;
                     const addedOn = Date.parse(instantLaunch.added_on);
 
@@ -394,10 +394,10 @@ const InstantLaunchList = ({ showErrorAnnouncer }) => {
                 },
             },
             {
-                Header: "",
-                accessor: "id",
-                disableSortBy: true,
-                Cell: ({ row }) => {
+                header: "",
+                accessorKey: "id",
+                enableSorting: false,
+                cell: ({ row }) => {
                     const il = row.original;
 
                     const rowID = buildID(baseID, ids.TABLE, ids.ROW, il.id);

--- a/src/components/instantlaunches/listing/index.js
+++ b/src/components/instantlaunches/listing/index.js
@@ -59,9 +59,9 @@ function Listing(props) {
         const listingId = buildID(baseId, ids.LISTING);
         return [
             {
-                Header: t("name"),
-                accessor: "quick_launch_name",
-                Cell: ({ row }) => {
+                header: t("name"),
+                accessorKey: "quick_launch_name",
+                cell: ({ row }) => {
                     const instantLaunch = row.original;
                     return (
                         <InstantLaunchButtonWrapper
@@ -80,17 +80,17 @@ function Listing(props) {
                 },
             },
             {
-                Header: t("app"),
-                accessor: "app_name",
+                header: t("app"),
+                accessorKey: "app_name",
             },
             {
-                Header: t("appVersion"),
-                accessor: "app_version",
+                header: t("appVersion"),
+                accessorKey: "app_version",
             },
             {
-                Header: "",
-                accessor: "id",
-                Cell: ({ row }) => {
+                header: "",
+                accessorKey: "id",
+                cell: ({ row }) => {
                     const instantLaunch = row.original;
                     const { app_id, app_version_id, submission } =
                         instantLaunch;

--- a/src/components/search/detailed/AnalysesSearchResults.js
+++ b/src/components/search/detailed/AnalysesSearchResults.js
@@ -124,29 +124,29 @@ export default function AnalysesSearchResults(props) {
     const columns = React.useMemo(
         () => [
             {
-                Header: analysisRecordFields.NAME.fieldName,
-                accessor: analysisRecordFields.NAME.key,
-                Cell: ({ row }) => (
+                header: analysisRecordFields.NAME.fieldName,
+                accessorKey: analysisRecordFields.NAME.key,
+                cell: ({ row }) => (
                     <Name analysis={row?.original} searchTerm={searchTerm} />
                 ),
             },
             {
-                Header: analysisRecordFields.START_DATE.fieldName,
-                accessor: analysisRecordFields.START_DATE.key,
-                Cell: ({ row }) => {
+                header: analysisRecordFields.START_DATE.fieldName,
+                accessorKey: analysisRecordFields.START_DATE.key,
+                cell: ({ row }) => {
                     const sd =
                         row.original[analysisRecordFields.START_DATE.key];
                     return <Typography>{formatDate(sd)}</Typography>;
                 },
             },
             {
-                Header: analysisRecordFields.STATUS.fieldName,
-                accessor: analysisRecordFields.STATUS.key,
+                header: analysisRecordFields.STATUS.fieldName,
+                accessorKey: analysisRecordFields.STATUS.key,
             },
             {
-                Header: "",
-                accessor: analysisRecordFields.ACTIONS.key,
-                Cell: ({ row }) => (
+                header: "",
+                accessorKey: analysisRecordFields.ACTIONS.key,
+                cell: ({ row }) => (
                     <Actions
                         analysis={row.original}
                         username={userProfile?.id}
@@ -156,7 +156,7 @@ export default function AnalysesSearchResults(props) {
                         handleDetailsClick={setSelectedAnalysis}
                     />
                 ),
-                disableSortBy: true,
+                enableSorting: false,
             },
         ],
         [analysisRecordFields, baseId, searchTerm, userProfile]

--- a/src/components/search/detailed/AppSearchResults.js
+++ b/src/components/search/detailed/AppSearchResults.js
@@ -152,9 +152,9 @@ export default function AppSearchResults(props) {
     const columns = React.useMemo(
         () => [
             {
-                Header: appRecordFields.NAME.fieldName,
-                accessor: appRecordFields.NAME.key,
-                Cell: ({ row }) => (
+                header: appRecordFields.NAME.fieldName,
+                accessorKey: appRecordFields.NAME.key,
+                cell: ({ row }) => (
                     <Name
                         selectedOption={row?.original}
                         searchTerm={searchTerm}
@@ -162,17 +162,17 @@ export default function AppSearchResults(props) {
                 ),
             },
             {
-                Header: appRecordFields.TYPE.fieldName,
-                accessor: appRecordFields.TYPE.key,
-                Cell: ({ row }) => {
+                header: appRecordFields.TYPE.fieldName,
+                accessorKey: appRecordFields.TYPE.key,
+                cell: ({ row }) => {
                     const app = row?.original;
                     return getAppTypeDisplay(app);
                 },
             },
             {
-                Header: "",
-                accessor: "actions",
-                Cell: ({ row }) => {
+                header: "",
+                accessorKey: "actions",
+                cell: ({ row }) => {
                     const app = row?.original;
                     return (
                         <AppActionCell
@@ -182,7 +182,7 @@ export default function AppSearchResults(props) {
                         />
                     );
                 },
-                disableSortBy: true,
+                enableSorting: false,
             },
         ],
         [

--- a/src/components/search/detailed/DataSearchResults.js
+++ b/src/components/search/detailed/DataSearchResults.js
@@ -66,6 +66,65 @@ function Name(props) {
     );
 }
 
+function DataActionCell(props) {
+    const { resource, baseId, setDetailsResource, dataI18n } = props;
+    const { t: i18nCommon } = useTranslation("common");
+    const partialLink = useDataNavigationLink(
+        resource?._source.path,
+        resource?._id,
+        resource?._type || resource?._source?.doc_type
+    )[1];
+
+    return (
+        <Grid spacing={1}>
+            <Grid item>
+                <IconButton
+                    id={buildID(baseId, ids.DETAILS_BUTTON)}
+                    onClick={() => setDetailsResource(resource)}
+                    size="small"
+                    color="primary"
+                >
+                    <Info fontSize="small" />
+                </IconButton>
+            </Grid>
+            <Grid item>
+                <CopyLinkButton
+                    baseId={baseId}
+                    onCopyLinkSelected={() => {
+                        const link = `${getHost()}${partialLink}`;
+                        const copyPromise = copyStringToClipboard(link);
+                        copyLinkToClipboardHandler(i18nCommon, copyPromise);
+                    }}
+                />
+            </Grid>
+            <Grid item>
+                <CopyPathButton
+                    baseId={baseId}
+                    onCopyPathSelected={() => {
+                        const copyPromise = copyStringToClipboard(
+                            resource?._source.path
+                        );
+                        copyPromise.then(
+                            () => {
+                                announce({
+                                    text: dataI18n("pathCopied"),
+                                    variant: SUCCESS,
+                                });
+                            },
+                            () => {
+                                announce({
+                                    text: dataI18n("pathCopiedFailed"),
+                                    variant: ERROR,
+                                });
+                            }
+                        );
+                    }}
+                />
+            </Grid>
+        </Grid>
+    );
+}
+
 function CopyPathButton(props) {
     const { baseId, onCopyPathSelected } = props;
     const { t } = useTranslation("data");
@@ -196,9 +255,9 @@ function DataSearchResults(props) {
     const columns = React.useMemo(
         () => [
             {
-                Header: "",
-                accessor: "icon",
-                Cell: ({ row }) => {
+                header: "",
+                accessorKey: "icon",
+                cell: ({ row }) => {
                     const original = row?.original;
                     return (
                         <ResourceIcon
@@ -208,90 +267,32 @@ function DataSearchResults(props) {
                         />
                     );
                 },
-                disableSortBy: true,
+                enableSorting: false,
             },
             {
-                Header: dataRecordFields.NAME.fieldName,
-                accessor: "_source.label",
-                Cell: ({ row }) => (
+                header: dataRecordFields.NAME.fieldName,
+                accessorKey: "_source.label",
+                cell: ({ row }) => (
                     <Name resource={row?.original} searchTerm={searchTerm} />
                 ),
             },
             {
-                Header: dataRecordFields.PATH.fieldName,
-                accessor: "_source.path",
-                disableSortBy: true,
+                header: dataRecordFields.PATH.fieldName,
+                accessorKey: "_source.path",
+                enableSorting: false,
             },
             {
-                Header: "",
-                accessor: "actions",
-                Cell: ({ row }) => {
-                    const original = row?.original;
-                    const { t: i18nCommon } = useTranslation("common");
-                    const partialLink = useDataNavigationLink(
-                        original?._source.path,
-                        original?._id,
-                        original?._type || original?._source?.doc_type
-                    )[1];
-                    return (
-                        <Grid spacing={1}>
-                            <Grid item>
-                                <IconButton
-                                    id={buildID(baseId, ids.DETAILS_BUTTON)}
-                                    onClick={() => setDetailsResource(original)}
-                                    size="small"
-                                    color="primary"
-                                >
-                                    <Info fontSize="small" />
-                                </IconButton>
-                            </Grid>
-                            <Grid item>
-                                <CopyLinkButton
-                                    baseId={baseId}
-                                    onCopyLinkSelected={() => {
-                                        const link = `${getHost()}${partialLink}`;
-                                        const copyPromise =
-                                            copyStringToClipboard(link);
-                                        copyLinkToClipboardHandler(
-                                            i18nCommon,
-                                            copyPromise
-                                        );
-                                    }}
-                                />
-                            </Grid>
-                            <Grid item>
-                                <CopyPathButton
-                                    baseId={baseId}
-                                    onCopyPathSelected={() => {
-                                        const copyPromise =
-                                            copyStringToClipboard(
-                                                original?._source.path
-                                            );
-                                        copyPromise.then(
-                                            () => {
-                                                announce({
-                                                    text: dataI18n(
-                                                        "pathCopied"
-                                                    ),
-                                                    variant: SUCCESS,
-                                                });
-                                            },
-                                            () => {
-                                                announce({
-                                                    text: dataI18n(
-                                                        "pathCopiedFailed"
-                                                    ),
-                                                    variant: ERROR,
-                                                });
-                                            }
-                                        );
-                                    }}
-                                />
-                            </Grid>
-                        </Grid>
-                    );
-                },
-                disableSortBy: true,
+                header: "",
+                accessorKey: "actions",
+                cell: ({ row }) => (
+                    <DataActionCell
+                        baseId={baseId}
+                        resource={row?.original}
+                        setDetailsResource={setDetailsResource}
+                        dataI18n={dataI18n}
+                    />
+                ),
+                enableSorting: false,
             },
         ],
         [

--- a/src/components/search/detailed/DataSearchResults.js
+++ b/src/components/search/detailed/DataSearchResults.js
@@ -270,6 +270,7 @@ function DataSearchResults(props) {
                 enableSorting: false,
             },
             {
+                id: "label",
                 header: dataRecordFields.NAME.fieldName,
                 accessorKey: "_source.label",
                 cell: ({ row }) => (
@@ -277,9 +278,9 @@ function DataSearchResults(props) {
                 ),
             },
             {
+                id: "path",
                 header: dataRecordFields.PATH.fieldName,
                 accessorKey: "_source.path",
-                enableSorting: false,
             },
             {
                 header: "",
@@ -351,12 +352,12 @@ function DataSearchResults(props) {
                 canFetchMore={hasNextPage}
                 initialSortBy={[
                     {
-                        id: "_source." + sortField,
+                        id: sortField,
                         desc: sortOrder === "descending",
                     },
                 ]}
                 onSort={(colId, descending) => {
-                    setSortField(colId?.split(".")[1]);
+                    setSortField(colId);
                     descending
                         ? setSortOrder("descending")
                         : setSortOrder("ascending");

--- a/src/components/search/detailed/SearchResultsTable.js
+++ b/src/components/search/detailed/SearchResultsTable.js
@@ -6,8 +6,14 @@
  *
  */
 
-import React, { useEffect } from "react";
-import { useRowSelect, useSortBy, useTable } from "react-table";
+import React, { useEffect, useMemo, useState } from "react";
+import {
+    useReactTable,
+    getCoreRowModel,
+    getSortedRowModel,
+    getFilteredRowModel,
+    flexRender,
+} from "@tanstack/react-table";
 import { useTranslation } from "i18n";
 
 import PageWrapper from "components/layout/PageWrapper";
@@ -46,56 +52,67 @@ const SearchResultsTable = ({
     selectable,
     setSelectedResources,
 }) => {
-    const {
-        toggleSortBy,
-        getTableProps,
-        headerGroups,
-        rows,
-        prepareRow,
-        selectedFlatRows,
-    } = useTable(
-        {
-            columns,
-            data,
-            manualSortBy: true,
-            disableMultiSort: true,
-            initialState: {
-                sortBy: initialSortBy,
-            },
-        },
-        useSortBy,
-        useRowSelect,
-        (hooks) =>
-            hooks.visibleColumns.push((columns) => {
-                return selectable
-                    ? [
-                          {
-                              id: "selection",
-                              Header: ({ getToggleAllRowsSelectedProps }) => (
-                                  <DECheckbox
-                                      {...getToggleAllRowsSelectedProps()}
-                                  />
-                              ),
-                              Cell: ({ row }) => (
-                                  <DECheckbox
-                                      {...row.getToggleRowSelectedProps()}
-                                  />
-                              ),
-                          },
-                          ...columns,
-                      ]
-                    : columns;
-            })
+    const [sorting, setSorting] = useState(initialSortBy || []);
+    const [rowSelection, setRowSelection] = useState({});
+
+    const selectionColumn = useMemo(
+        () => ({
+            id: "selection",
+            header: ({ table }) => (
+                <DECheckbox
+                    checked={table.getIsAllRowsSelected()}
+                    indeterminate={table.getIsSomeRowsSelected()}
+                    onChange={table.getToggleAllRowsSelectedHandler()}
+                />
+            ),
+            cell: ({ row }) => (
+                <DECheckbox
+                    checked={row.getIsSelected()}
+                    disabled={!row.getCanSelect()}
+                    onChange={row.getToggleSelectedHandler()}
+                />
+            ),
+            enableSorting: false,
+        }),
+        []
     );
+
+    const tableColumns = useMemo(
+        () => (selectable ? [selectionColumn, ...columns] : columns),
+        [selectable, selectionColumn, columns]
+    );
+
+    const table = useReactTable({
+        columns: tableColumns,
+        data,
+        state: { sorting, rowSelection },
+        onSortingChange: (updater) => {
+            const newSorting =
+                typeof updater === "function" ? updater(sorting) : updater;
+            setSorting(newSorting);
+            if (newSorting.length > 0) {
+                onSort?.(newSorting[0].id, newSorting[0].desc);
+            }
+        },
+        onRowSelectionChange: setRowSelection,
+        enableRowSelection: selectable,
+        manualSorting: true,
+        enableMultiSort: false,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        getFilteredRowModel: getFilteredRowModel(),
+    });
+
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
     const tableId = buildID(baseId, ids.TABLE_VIEW);
     const { t } = useTranslation("search");
 
     useEffect(() => {
-        setSelectedResources &&
-            setSelectedResources(selectedFlatRows.map((row) => row.original));
-    }, [selectedFlatRows, setSelectedResources]);
+        setSelectedResources?.(
+            table.getSelectedRowModel().rows.map((row) => row.original)
+        );
+    }, [rowSelection, setSelectedResources, table]);
 
     return (
         <PageWrapper appBarHeight={isMobile ? 250 : 270}>
@@ -115,43 +132,31 @@ const SearchResultsTable = ({
                 style={{ overflow: "auto" }}
                 id={tableId}
             >
-                <Table size="small" stickyHeader {...getTableProps()}>
+                <Table size="small" stickyHeader>
                     <TableHead>
-                        {headerGroups.map((headerGroup) => (
-                            <TableRow
-                                key={headerGroup.id}
-                                {...headerGroup.getHeaderGroupProps()}
-                            >
-                                {headerGroup.headers.map((column) => (
+                        {table.getHeaderGroups().map((headerGroup) => (
+                            <TableRow key={headerGroup.id}>
+                                {headerGroup.headers.map((header) => (
                                     <TableCell
-                                        key={column.id}
-                                        {...(column.id === "selection"
-                                            ? column.getHeaderProps()
-                                            : column.getHeaderProps(
-                                                  column.getSortByToggleProps()
-                                              ))}
-                                        onClick={() => {
-                                            if (column.id !== "selection") {
-                                                onSort &&
-                                                    onSort(
-                                                        column.id,
-                                                        !column.isSortedDesc
-                                                    );
-                                                toggleSortBy(
-                                                    column.id,
-                                                    !column.isSortedDesc,
-                                                    false
-                                                );
-                                            }
-                                        }}
+                                        key={header.id}
+                                        onClick={
+                                            header.column.getCanSort()
+                                                ? header.column.getToggleSortingHandler()
+                                                : undefined
+                                        }
                                     >
-                                        {column.render("Header")}
-                                        {column.canSort &&
-                                        column.id !== "selection" ? (
+                                        {flexRender(
+                                            header.column.columnDef.header,
+                                            header.getContext()
+                                        )}
+                                        {header.column.getCanSort() ? (
                                             <TableSortLabel
-                                                active={column.isSorted}
+                                                active={
+                                                    !!header.column.getIsSorted()
+                                                }
                                                 direction={
-                                                    column.isSortedDesc
+                                                    header.column.getIsSorted() ===
+                                                    "desc"
                                                         ? "desc"
                                                         : "asc"
                                                 }
@@ -171,26 +176,18 @@ const SearchResultsTable = ({
                     )}
                     {!loading && (
                         <TableBody>
-                            {rows.map((row) => {
-                                prepareRow(row);
-                                return (
-                                    <TableRow
-                                        key={row.id}
-                                        {...row.getRowProps()}
-                                    >
-                                        {row.cells.map((cell) => {
-                                            return (
-                                                <TableCell
-                                                    key={cell.row.id}
-                                                    {...cell.getCellProps()}
-                                                >
-                                                    {cell.render("Cell")}
-                                                </TableCell>
-                                            );
-                                        })}
-                                    </TableRow>
-                                );
-                            })}
+                            {table.getRowModel().rows.map((row) => (
+                                <TableRow key={row.id}>
+                                    {row.getVisibleCells().map((cell) => (
+                                        <TableCell key={cell.id}>
+                                            {flexRender(
+                                                cell.column.columnDef.cell,
+                                                cell.getContext()
+                                            )}
+                                        </TableCell>
+                                    ))}
+                                </TableRow>
+                            ))}
                         </TableBody>
                     )}
                 </Table>

--- a/src/components/search/detailed/SearchResultsTable.js
+++ b/src/components/search/detailed/SearchResultsTable.js
@@ -97,6 +97,7 @@ const SearchResultsTable = ({
         onRowSelectionChange: setRowSelection,
         enableRowSelection: selectable,
         manualSorting: true,
+        enableSortingRemoval: false,
         enableMultiSort: false,
         getCoreRowModel: getCoreRowModel(),
         getSortedRowModel: getSortedRowModel(),

--- a/src/components/sharing/UserTable.js
+++ b/src/components/sharing/UserTable.js
@@ -53,17 +53,19 @@ function UserTable(props) {
     const columns = useMemo(
         () => [
             {
-                Header: t("user"),
-                accessor: getUserPrimaryText,
-                Cell: ({ row, value }) => {
+                header: t("user"),
+                accessorFn: getUserPrimaryText,
+                id: "user",
+                cell: ({ row }) => {
                     const user = row.original;
                     return <SubjectTableCell subject={user} />;
                 },
             },
             {
-                Header: t("permission"),
-                accessor: (row) => row.displayPermission,
-                Cell: ({ row, value }) => {
+                header: t("permission"),
+                accessorFn: (row) => row.displayPermission,
+                id: "permission",
+                cell: ({ row, getValue }) => {
                     const user = row.original;
                     return (
                         <SharingPermissionSelector
@@ -72,7 +74,7 @@ function UserTable(props) {
                                 user.id,
                                 ids.PERMISSION_SELECTOR
                             )}
-                            currentPermission={value}
+                            currentPermission={getValue()}
                             onPermissionChange={(updatedPermission) =>
                                 onPermissionChange(user, updatedPermission)
                             }

--- a/src/components/table/BasicTable.js
+++ b/src/components/table/BasicTable.js
@@ -1,7 +1,7 @@
 /**
  * @author aramsey
  *
- * A simple table using react-table's helper functions
+ * A simple table using @tanstack/react-table's helper functions
  * Enabling sorting is optional
  */
 
@@ -20,7 +20,12 @@ import {
     TableSortLabel,
 } from "@mui/material";
 import PropTypes from "prop-types";
-import { useSortBy, useTable } from "react-table";
+import {
+    useReactTable,
+    getCoreRowModel,
+    getSortedRowModel,
+    flexRender,
+} from "@tanstack/react-table";
 
 import constants from "constants.js";
 
@@ -35,48 +40,53 @@ function BasicTable(props) {
         loading,
         emptyDataMessage,
     } = props;
-    const { getTableProps, headerGroups, rows, prepareRow } = useTable(
-        {
-            columns,
-            data,
-        },
-        sortable && useSortBy
-    );
+
+    const table = useReactTable({
+        columns,
+        data,
+        getCoreRowModel: getCoreRowModel(),
+        ...(sortable && { getSortedRowModel: getSortedRowModel() }),
+    });
 
     return (
         <TableContainer style={{ overflow: "auto" }}>
             <Table
                 size={tableSize}
                 stickyHeader
-                {...getTableProps()}
                 style={{ overflow: "auto" }}
             >
                 <TableHead>
-                    {headerGroups.map((headerGroup) => (
-                        <TableRow
-                            key={headerGroup.id}
-                            {...headerGroup.getHeaderGroupProps()}
-                        >
-                            {headerGroup.headers.map((column) => (
+                    {table.getHeaderGroups().map((headerGroup) => (
+                        <TableRow key={headerGroup.id}>
+                            {headerGroup.headers.map((header) => (
                                 <TableCell
-                                    key={column.id}
+                                    key={header.id}
                                     variant="head"
-                                    {...column.getHeaderProps(
+                                    onClick={
                                         sortable &&
-                                            column.getSortByToggleProps()
-                                    )}
+                                        header.column.getCanSort()
+                                            ? header.column.getToggleSortingHandler()
+                                            : undefined
+                                    }
                                 >
-                                    {column.render("Header")}
-                                    {sortable && column.canSort && (
-                                        <TableSortLabel
-                                            active={column.isSorted}
-                                            direction={
-                                                column.isSortedDesc
-                                                    ? constants.SORT_DESCENDING
-                                                    : constants.SORT_ASCENDING
-                                            }
-                                        />
+                                    {flexRender(
+                                        header.column.columnDef.header,
+                                        header.getContext()
                                     )}
+                                    {sortable &&
+                                        header.column.getCanSort() && (
+                                            <TableSortLabel
+                                                active={
+                                                    !!header.column.getIsSorted()
+                                                }
+                                                direction={
+                                                    header.column.getIsSorted() ===
+                                                    "desc"
+                                                        ? constants.SORT_DESCENDING
+                                                        : constants.SORT_ASCENDING
+                                                }
+                                            />
+                                        )}
                                 </TableCell>
                             ))}
                         </TableRow>
@@ -99,18 +109,19 @@ function BasicTable(props) {
                 )}
                 {!loading && data?.length > 0 && (
                     <TableBody>
-                        {rows.map((row) => {
-                            prepareRow(row);
+                        {table.getRowModel().rows.map((row) => {
                             return (
-                                <TableRow key={row.id} {...row.getRowProps()}>
-                                    {row.cells.map((cell) => {
+                                <TableRow key={row.id}>
+                                    {row.getVisibleCells().map((cell) => {
                                         return (
                                             <TableCell
-                                                key={cell.row.id}
+                                                key={cell.id}
                                                 padding={bodyCellPadding}
-                                                {...cell.getCellProps()}
                                             >
-                                                {cell.render("Cell")}
+                                                {flexRender(
+                                                    cell.column.columnDef.cell,
+                                                    cell.getContext()
+                                                )}
                                             </TableCell>
                                         );
                                     })}

--- a/src/components/teams/Listing.js
+++ b/src/components/teams/Listing.js
@@ -67,9 +67,9 @@ function Listing(props) {
     const columns = useMemo(() => {
         const baseColumns = [
             {
-                Header: TEAM_COLUMNS.NAME.fieldName,
-                accessor: TEAM_COLUMNS.NAME.key,
-                Cell: ({ row, value }) => {
+                header: TEAM_COLUMNS.NAME.fieldName,
+                accessorKey: TEAM_COLUMNS.NAME.key,
+                cell: ({ row, getValue }) => {
                     const team = row.original;
                     const rowId = buildID(tableId, team.id);
                     return (
@@ -77,18 +77,18 @@ function Listing(props) {
                             id={buildID(rowId, ids.TEAMS.LINK)}
                             onClick={() => onTeamNameSelected(team.name)}
                             searchTerm={searchTerm}
-                            text={value}
+                            text={getValue()}
                         />
                     );
                 },
             },
             {
-                Header: TEAM_COLUMNS.CREATOR.fieldName,
-                accessor: TEAM_COLUMNS.CREATOR.key,
+                header: TEAM_COLUMNS.CREATOR.fieldName,
+                accessorKey: TEAM_COLUMNS.CREATOR.key,
             },
             {
-                Header: TEAM_COLUMNS.DESCRIPTION.fieldName,
-                accessor: TEAM_COLUMNS.DESCRIPTION.key,
+                header: TEAM_COLUMNS.DESCRIPTION.fieldName,
+                accessorKey: TEAM_COLUMNS.DESCRIPTION.key,
             },
         ];
 
@@ -97,10 +97,10 @@ function Listing(props) {
             : [
                   ...baseColumns,
                   {
-                      Header: TEAM_COLUMNS.DETAILS.fieldName,
-                      accessor: TEAM_COLUMNS.DETAILS.key,
-                      defaultCanSort: false,
-                      Cell: ({ row }) => {
+                      header: TEAM_COLUMNS.DETAILS.fieldName,
+                      accessorKey: TEAM_COLUMNS.DETAILS.key,
+                      enableSorting: false,
+                      cell: ({ row }) => {
                           const team = row.original;
                           return (
                               <IconButton

--- a/src/components/teams/form/Members.js
+++ b/src/components/teams/form/Members.js
@@ -116,9 +116,10 @@ function Members(props) {
 
         return [
             {
-                Header: t("sharing:user"),
-                accessor: (row) => getUserPrimaryText(row.subject),
-                Cell: ({ row }) => {
+                header: t("sharing:user"),
+                accessorFn: (row) => getUserPrimaryText(row.subject),
+                id: "user",
+                cell: ({ row }) => {
                     return (
                         <Field name={`${name}.${row.index}.subject`}>
                             {({ field: { value } }) => {
@@ -129,9 +130,9 @@ function Members(props) {
                 },
             },
             {
-                Header: t("privilege"),
-                accessor: "name",
-                Cell: ({ row }) => {
+                header: t("privilege"),
+                accessorKey: "name",
+                cell: ({ row }) => {
                     const privilege = row.original;
                     const rowId = getRowId(row);
                     return (
@@ -154,9 +155,9 @@ function Members(props) {
                 },
             },
             {
-                Header: "",
-                accessor: "subject.id",
-                Cell: ({ row }) => {
+                header: "",
+                accessorKey: "subject.id",
+                cell: ({ row }) => {
                     const privilege = row.original;
                     const rowId = getRowId(row);
                     if (isAdmin && !isSelf(privilege)) {

--- a/src/components/vice/admin/accessRequests/TableView.js
+++ b/src/components/vice/admin/accessRequests/TableView.js
@@ -33,10 +33,11 @@ export default function TableView(props) {
     const columns = useMemo(
         () => [
             {
-                Header: t("user"),
-                accessor: "requesting_user",
-                Cell: ({ row, value }) => {
+                header: t("user"),
+                accessorKey: "requesting_user",
+                cell: ({ row, getValue }) => {
                     const original = row.original;
+                    const value = getValue();
                     return (
                         <>
                             <Typography>
@@ -60,9 +61,9 @@ export default function TableView(props) {
                 },
             },
             {
-                Header: t("approve"),
+                header: t("approve"),
                 id: ids.APPROVE_BTN,
-                Cell: ({ row, value }) => {
+                cell: ({ row }) => {
                     const original = row.original;
                     return (
                         <IconButton
@@ -89,9 +90,9 @@ export default function TableView(props) {
                 },
             },
             {
-                Header: t("reject"),
+                header: t("reject"),
                 id: ids.REJECT_BTN,
-                Cell: ({ row, value }) => {
+                cell: ({ row }) => {
                     const original = row.original;
                     return (
                         <IconButton
@@ -116,30 +117,30 @@ export default function TableView(props) {
                 },
             },
             {
-                Header: t("requestedDate"),
-                accessor: "created_date",
-                Cell: ({ row, value }) => {
+                header: t("requestedDate"),
+                accessorKey: "created_date",
+                cell: ({ getValue }) => {
                     return (
                         <Typography>
-                            {formatDateObject(new Date(value))}
+                            {formatDateObject(new Date(getValue()))}
                         </Typography>
                     );
                 },
             },
             {
-                Header: t("useCase"),
-                accessor: "details.intended_use",
-                Cell: ({ row, value }) => {
-                    return <Typography>{value}</Typography>;
+                header: t("useCase"),
+                accessorKey: "details.intended_use",
+                cell: ({ getValue }) => {
+                    return <Typography>{getValue()}</Typography>;
                 },
             },
             {
-                Header: t("lastUpdated"),
-                accessor: "updated_date",
-                Cell: ({ row, value }) => {
+                header: t("lastUpdated"),
+                accessorKey: "updated_date",
+                cell: ({ getValue }) => {
                     return (
                         <Typography>
-                            {formatDateObject(new Date(value))}
+                            {formatDateObject(new Date(getValue()))}
                         </Typography>
                     );
                 },

--- a/src/components/vice/admin/table/index.js
+++ b/src/components/vice/admin/table/index.js
@@ -20,7 +20,13 @@ import {
 
 import { KeyboardArrowUp, KeyboardArrowDown } from "@mui/icons-material";
 
-import { useTable, useExpanded, useSortBy } from "react-table";
+import {
+    useReactTable,
+    getCoreRowModel,
+    getSortedRowModel,
+    getExpandedRowModel,
+    flexRender,
+} from "@tanstack/react-table";
 
 import ActionButtons from "./actionButtons";
 
@@ -46,15 +52,15 @@ const ExtendedDataCard = ({
     const columnIDs = columns.map((c) => c.id);
 
     // Find only the cells for the hidden columns.
-    const filteredCells = row.allCells.filter((row) => {
-        return columnIDs.includes(row.column.id);
+    const filteredCells = row.getAllCells().filter((cell) => {
+        return columnIDs.includes(cell.column.id);
     });
 
     const newID = (value) => id(ids.BASE, collapseID, "cell", value);
 
     return (
         <Box>
-            <div className={classes.extended} {...row.getRowProps()}>
+            <div className={classes.extended}>
                 {filteredCells.map((cell, index) => {
                     const thisID = newID(index);
                     return (
@@ -63,8 +69,14 @@ const ExtendedDataCard = ({
                             key={thisID}
                             id={thisID}
                         >
-                            {cell.render("Header")}
-                            {cell.render("Cell")}
+                            {flexRender(
+                                cell.column.columnDef.header,
+                                cell.getContext()
+                            )}
+                            {flexRender(
+                                cell.column.columnDef.cell,
+                                cell.getContext()
+                            )}
                         </div>
                     );
                 })}
@@ -104,16 +116,14 @@ const CollapsibleTableRow = ({
 
     return (
         <>
-            <TableRow
-                className={classes.row}
-                key={rowID}
-                id={rowID}
-                {...row.getRowProps()}
-            >
-                {row.cells.map((cell) => {
+            <TableRow className={classes.row} key={rowID} id={rowID}>
+                {row.getVisibleCells().map((cell) => {
                     return (
-                        <TableCell key={cell.row.id} {...cell.getCellProps()}>
-                            {cell.render("Cell")}
+                        <TableCell key={cell.id}>
+                            {flexRender(
+                                cell.column.columnDef.cell,
+                                cell.getContext()
+                            )}
                         </TableCell>
                     );
                 })}
@@ -127,7 +137,7 @@ const CollapsibleTableRow = ({
                             paddingTop: 0,
                             width: "5%",
                         }}
-                        colSpan={row.isExpanded ? 1 : 0}
+                        colSpan={row.getIsExpanded() ? 1 : 0}
                     ></TableCell>
                 ) : null}
 
@@ -139,7 +149,11 @@ const CollapsibleTableRow = ({
                     }}
                     colSpan={visibleColumns.length}
                 >
-                    <Collapse in={row.isExpanded} timeout="auto" unmountOnExit>
+                    <Collapse
+                        in={row.getIsExpanded()}
+                        timeout="auto"
+                        unmountOnExit
+                    >
                         <ExtendedDataCard
                             columns={hiddenColumns}
                             row={row}
@@ -158,25 +172,25 @@ const CollapsibleTableRow = ({
     );
 };
 
+function ExpanderCell({ row }) {
+    const { t } = useTranslation("vice-admin");
+
+    return (
+        <IconButton
+            aria-label={t("expandRow")}
+            size="small"
+            onClick={row.getToggleExpandedHandler()}
+        >
+            {row.getIsExpanded() ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
+        </IconButton>
+    );
+}
+
 export const ExpanderColumn = {
     id: "expander",
-    Header: () => null,
-    Cell: ({ row }) => {
-        const { t } = useTranslation("vice-admin");
-
-        return (
-            <span {...row.getToggleRowExpandedProps()}>
-                <IconButton aria-label={t("expandRow")} size="small">
-                    {row.isExpanded ? (
-                        <KeyboardArrowUp />
-                    ) : (
-                        <KeyboardArrowDown />
-                    )}
-                </IconButton>
-            </span>
-        );
-    },
-    disableSortBy: true,
+    header: () => null,
+    cell: ({ row }) => <ExpanderCell row={row} />,
+    enableSorting: false,
 };
 
 export const defineColumn = (
@@ -186,20 +200,19 @@ export const defineColumn = (
     align = "left",
     enableSorting = true
 ) => ({
-    Header: (_table, _columnModel) => (
+    header: () => (
         <Typography variant="subtitle1" align={align}>
             {name}
         </Typography>
     ),
-    Cell: ({ value }) => (
+    cell: ({ getValue }) => (
         <Typography variant="body2" align={align}>
-            {value}
+            {getValue()}
         </Typography>
     ),
-    accessor: field,
+    accessorKey: field,
     align,
-    disableSortBy: !enableSorting,
-    key: keyID,
+    enableSorting,
     id: keyID,
 });
 
@@ -226,25 +239,21 @@ const CollapsibleTable = ({
     // Needs to be set in the useLayoutEffect, otherwise it acts weird
     // because the media queries generate incorrect results on the server.
     const [isMobile, setIsMobile] = useState(false);
-
-    const {
-        getTableProps,
-        getTableBodyProps,
-        headerGroups,
-        prepareRow,
-        setHiddenColumns,
-        rows,
-        visibleColumns,
-    } = useTable(
-        {
-            columns,
-            data,
-        },
-        useSortBy,
-        useExpanded
-    );
-
+    const [columnVisibility, setColumnVisibility] = useState({});
     const [hiddenColumnObjs, setHiddenColumnObjs] = useState([]);
+
+    const table = useReactTable({
+        columns,
+        data,
+        state: { columnVisibility },
+        onColumnVisibilityChange: setColumnVisibility,
+        getRowCanExpand: () => true,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        getExpandedRowModel: getExpandedRowModel(),
+    });
+
+    const visibleColumns = table.getVisibleLeafColumns();
 
     useLayoutEffect(() => {
         let numCols;
@@ -266,16 +275,13 @@ const CollapsibleTable = ({
 
         const hidden = columns.slice(numCols);
         setHiddenColumnObjs(hidden);
-        setHiddenColumns(hidden.map((column) => column.id));
-    }, [
-        setHiddenColumns,
-        columns,
-        isXL,
-        isLarge,
-        isMedium,
-        isSmall,
-        isExtraSmall,
-    ]);
+
+        const hiddenVisibility = {};
+        hidden.forEach((column) => {
+            hiddenVisibility[column.id] = false;
+        });
+        setColumnVisibility(hiddenVisibility);
+    }, [columns, isXL, isLarge, isMedium, isSmall, isExtraSmall]);
 
     const tableID = id(ids.ROOT);
 
@@ -290,37 +296,42 @@ const CollapsibleTable = ({
             </Typography>
 
             <TableContainer classes={{ root: classes.root }}>
-                <Table
-                    id={tableID}
-                    classes={{ root: classes.table }}
-                    {...getTableProps()}
-                >
+                <Table id={tableID} classes={{ root: classes.table }}>
                     <TableHead>
-                        {headerGroups.map((headerGroup) => (
-                            <TableRow
-                                key={headerGroup.id}
-                                {...headerGroup.getHeaderGroupProps()}
-                            >
-                                {headerGroup.headers.map((column) => (
+                        {table.getHeaderGroups().map((headerGroup) => (
+                            <TableRow key={headerGroup.id}>
+                                {headerGroup.headers.map((header) => (
                                     <TableCell
-                                        key={column.id}
-                                        {...column.getHeaderProps(
-                                            column.getSortByToggleProps()
-                                        )}
+                                        key={header.id}
+                                        onClick={
+                                            header.column.getCanSort()
+                                                ? header.column.getToggleSortingHandler()
+                                                : undefined
+                                        }
                                     >
-                                        {column.canSort ? (
+                                        {header.column.getCanSort() ? (
                                             <TableSortLabel
-                                                active={column.isSorted}
+                                                active={
+                                                    !!header.column.getIsSorted()
+                                                }
                                                 direction={
-                                                    column.isSortedDesc
+                                                    header.column.getIsSorted() ===
+                                                    "desc"
                                                         ? "desc"
                                                         : "asc"
                                                 }
                                             >
-                                                {column.render("Header")}
+                                                {flexRender(
+                                                    header.column.columnDef
+                                                        .header,
+                                                    header.getContext()
+                                                )}
                                             </TableSortLabel>
                                         ) : (
-                                            column.render("Header")
+                                            flexRender(
+                                                header.column.columnDef.header,
+                                                header.getContext()
+                                            )
                                         )}
                                     </TableCell>
                                 ))}
@@ -328,10 +339,8 @@ const CollapsibleTable = ({
                         ))}
                     </TableHead>
 
-                    <TableBody {...getTableBodyProps()}>
-                        {rows?.map((row) => {
-                            prepareRow(row);
-
+                    <TableBody>
+                        {table.getRowModel().rows?.map((row) => {
                             return (
                                 <CollapsibleTableRow
                                     row={row}


### PR DESCRIPTION
This PR will migrate table components using `react-table` v7 to `@tanstack/react-table` v8 for `react` v19 compatibility.

Most of this is boilerplate, but in a couple of instances some bugs were also fixed (such as correctly displaying the Checkbox column header in an indeterminate state).