### PR TITLE
Reload onto maintenance page when API returns a maintenance 503

### DIFF
--- a/src/common/getAxios.js
+++ b/src/common/getAxios.js
@@ -4,6 +4,8 @@
  */
 import axios from "axios";
 
+import { isMaintenanceResponse, triggerMaintenanceReload } from "./maintenance";
+
 const axiosInstance = axios.create({
     timeout: 20000, //service call timeout
 });
@@ -16,18 +18,10 @@ if (typeof window !== "undefined") {
     axiosInstance.interceptors.response.use(
         (resp) => resp,
         (error) => {
-            const resp = error?.response;
-            const isMaintenance =
-                resp &&
-                resp.status === 503 &&
-                (resp.headers?.["x-maintenance-mode"] === "true" ||
-                    resp.data?.maintenance === true);
-
-            if (isMaintenance && !window.__deMaintenanceReloading) {
-                // Guard against many concurrent in-flight calls triggering repeat reloads.
-                window.__deMaintenanceReloading = true;
-                window.location.reload();
-                // Never resolve so no error UI flashes before the page reloads.
+            if (error?.response && isMaintenanceResponse(error.response)) {
+                triggerMaintenanceReload();
+                // Never resolve so no error UI flashes before the page reloads,
+                // even for concurrent calls that arrive after the reload starts.
                 return new Promise(() => {});
             }
             return Promise.reject(error);

--- a/src/common/getAxios.js
+++ b/src/common/getAxios.js
@@ -7,4 +7,32 @@ import axios from "axios";
 const axiosInstance = axios.create({
     timeout: 20000, //service call timeout
 });
+
+// Detect gateway maintenance mode on API/XHR responses and force a hard navigation
+// so the browser re-requests the page as a document and lands on the maintenance
+// page served by the gateway. Browser-only: this same instance is reused server-side
+// to proxy to Terrain, where `window` is undefined and a 503 must propagate normally.
+if (typeof window !== "undefined") {
+    axiosInstance.interceptors.response.use(
+        (resp) => resp,
+        (error) => {
+            const resp = error?.response;
+            const isMaintenance =
+                resp &&
+                resp.status === 503 &&
+                (resp.headers?.["x-maintenance-mode"] === "true" ||
+                    resp.data?.maintenance === true);
+
+            if (isMaintenance && !window.__deMaintenanceReloading) {
+                // Guard against many concurrent in-flight calls triggering repeat reloads.
+                window.__deMaintenanceReloading = true;
+                window.location.reload();
+                // Never resolve so no error UI flashes before the page reloads.
+                return new Promise(() => {});
+            }
+            return Promise.reject(error);
+        }
+    );
+}
+
 export default axiosInstance;

--- a/src/common/maintenance.js
+++ b/src/common/maintenance.js
@@ -1,0 +1,65 @@
+/**
+ * Shared detection and handling for gateway maintenance-mode responses.
+ *
+ * When the gateway enters maintenance mode it answers API/XHR requests with a
+ * 503 carrying an `x-maintenance-mode: true` header and/or a `{ maintenance:
+ * true }` body. Detecting either signal lets the client force a hard navigation
+ * so the browser re-requests the page as a document and lands on the
+ * maintenance page served by the gateway.
+ *
+ * @module common/maintenance
+ */
+
+const RELOADING_FLAG = "__deMaintenanceReloading";
+
+/**
+ * Reads a header value from either an axios-style headers object (plain object
+ * with lowercased keys) or a fetch `Headers` instance.
+ *
+ * @param {Object|Headers} headers - The response headers.
+ * @param {string} name - The header name (lowercase).
+ * @returns {string|undefined}
+ */
+const getHeader = (headers, name) => {
+    if (!headers) {
+        return undefined;
+    }
+    if (typeof headers.get === "function") {
+        return headers.get(name);
+    }
+    return headers[name];
+};
+
+/**
+ * Determines whether a response indicates the gateway is in maintenance mode.
+ * Accepts either signal so axios- and fetch-based callers behave identically.
+ *
+ * @param {Object} response - The response to inspect.
+ * @param {number} response.status - The HTTP status code.
+ * @param {Object|Headers} [response.headers] - The response headers.
+ * @param {*} [response.data] - The parsed response body, if available.
+ * @returns {boolean}
+ */
+export const isMaintenanceResponse = ({ status, headers, data } = {}) =>
+    status === 503 &&
+    (getHeader(headers, "x-maintenance-mode") === "true" ||
+        data?.maintenance === true);
+
+/**
+ * Forces a hard reload onto the gateway's maintenance page, guarding against
+ * many concurrent in-flight calls each triggering a repeat reload. Browser-only;
+ * a no-op when `window` is undefined (e.g. server-side rendering).
+ *
+ * @returns {boolean} Whether a maintenance reload is in progress, so callers can
+ *      avoid surfacing error UI before the page tears down.
+ */
+export const triggerMaintenanceReload = () => {
+    if (typeof window === "undefined") {
+        return false;
+    }
+    if (!window[RELOADING_FLAG]) {
+        window[RELOADING_FLAG] = true;
+        window.location.reload();
+    }
+    return true;
+};

--- a/src/components/uploads/api.js
+++ b/src/components/uploads/api.js
@@ -7,6 +7,10 @@
  */
 
 import { IntercomEvents, trackIntercomEvent } from "common/intercom";
+import {
+    isMaintenanceResponse,
+    triggerMaintenanceReload,
+} from "common/maintenance";
 
 import {
     errorAction,
@@ -64,23 +68,30 @@ export const startUpload = (
     })
         .then((resp) => {
             // Mirror the axios interceptor: a maintenance-mode 503 forces a hard
-            // reload so the browser lands on the gateway's maintenance page.
+            // reload so the browser lands on the gateway's maintenance page. Check
+            // the header before parsing so a non-JSON maintenance body can't throw
+            // first, then re-check once the body is available.
             if (
-                resp.status === 503 &&
-                resp.headers.get("x-maintenance-mode") === "true" &&
-                typeof window !== "undefined" &&
-                !window.__deMaintenanceReloading
+                isMaintenanceResponse({
+                    status: resp.status,
+                    headers: resp.headers,
+                })
             ) {
-                window.__deMaintenanceReloading = true;
-                window.location.reload();
+                triggerMaintenanceReload();
                 return new Promise(() => {});
             }
             // resp.json() contains the response body, but returns another promise
-            return resp.json().then((data) => ({
-                ok: resp.ok,
-                status: resp.status,
-                data,
-            }));
+            return resp.json().then((data) => {
+                if (isMaintenanceResponse({ status: resp.status, data })) {
+                    triggerMaintenanceReload();
+                    return new Promise(() => {});
+                }
+                return {
+                    ok: resp.ok,
+                    status: resp.status,
+                    data,
+                };
+            });
         })
         .then((resp) => {
             if (!resp.ok) {

--- a/src/components/uploads/api.js
+++ b/src/components/uploads/api.js
@@ -63,6 +63,18 @@ export const startUpload = (
         signal,
     })
         .then((resp) => {
+            // Mirror the axios interceptor: a maintenance-mode 503 forces a hard
+            // reload so the browser lands on the gateway's maintenance page.
+            if (
+                resp.status === 503 &&
+                resp.headers.get("x-maintenance-mode") === "true" &&
+                typeof window !== "undefined" &&
+                !window.__deMaintenanceReloading
+            ) {
+                window.__deMaintenanceReloading = true;
+                window.location.reload();
+                return new Promise(() => {});
+            }
             // resp.json() contains the response body, but returns another promise
             return resp.json().then((data) => ({
                 ok: resp.ok,

--- a/src/server/api/terrain.js
+++ b/src/server/api/terrain.js
@@ -60,6 +60,11 @@ export const handler = ({ method, pathname, headers }) => {
                         status: 302,
                     });
                 } else {
+                    // Forward the upstream response headers so signals like
+                    // `x-maintenance-mode` survive the proxy and reach the browser.
+                    if (e.response?.headers) {
+                        res.set(e.response.headers);
+                    }
                     res.status(e.response?.status || 500);
                     const stream = e.response?.data;
                     if (stream) {


### PR DESCRIPTION
## Summary

When the gateway enters maintenance mode it responds to API/XHR requests with a 503. Previously these surfaced as generic error UI inside the SPA instead of taking the user to the gateway's maintenance page. This branch detects the maintenance-mode 503 on the client and forces a hard navigation so the browser re-requests the page as a document and lands on the maintenance page.

## Changes

- **`src/common/getAxios.js`**: Add a browser-only response interceptor on the shared axios instance. On a 503 carrying `x-maintenance-mode: true` (or `{ maintenance: true }` body), it sets a one-shot `window.__deMaintenanceReloading` guard and calls `window.location.reload()`, returning a never-resolving promise so no error UI flashes first. Guarded by `typeof window !== "undefined"` because the same instance is reused server-side to proxy to Terrain, where a 503 must propagate normally.
- **`src/components/uploads/api.js`**: Mirror the same behavior in `startUpload`, which uses `fetch` rather than the axios instance, so maintenance-mode 503s during uploads also redirect to the maintenance page.

## Notes

The `window.__deMaintenanceReloading` guard prevents many concurrent in-flight calls from each triggering a reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)