### PR TITLE
Make the publication requests be lazy-loaded when the tab is selected

### DIFF
--- a/src/components/apps/admin/publicationRequests/RequestListing.js
+++ b/src/components/apps/admin/publicationRequests/RequestListing.js
@@ -135,7 +135,7 @@ function ToolsUsed(props) {
     );
 }
 function AppPublicationRequests(props) {
-    const { parentId } = props;
+    const { parentId, tabIsActive } = props;
     const { t } = useTranslation("apps");
 
     const [requests, setRequests] = React.useState();
@@ -146,7 +146,7 @@ function AppPublicationRequests(props) {
     const { isFetching: isRequestsFetching } = useQuery({
         queryKey: [APP_PUBLICATION_REQUESTS_QUERY_KEY],
         queryFn: getAppPublicationRequests,
-        enabled: true,
+        enabled: !!tabIsActive,
         onSuccess: (resp) => {
             setRequests(resp?.publication_requests);
             setError(null);

--- a/src/components/apps/admin/publicationRequests/RequestListing.js
+++ b/src/components/apps/admin/publicationRequests/RequestListing.js
@@ -204,12 +204,13 @@ function AppPublicationRequests(props) {
                         />
                     )}
                     <TableBody>
-                        {(!requests || requests.length === 0) && (
-                            <EmptyTable
-                                message={t("noRequests")}
-                                numColumns={appColumnData(t).length}
-                            />
-                        )}
+                        {!isRequestsFetching &&
+                            (!requests || requests.length === 0) && (
+                                <EmptyTable
+                                    message={t("noRequests")}
+                                    numColumns={appColumnData(t).length}
+                                />
+                            )}
                         {requests &&
                             requests.length > 0 &&
                             requests.map((request) => (

--- a/src/pages/admin/apps.js
+++ b/src/pages/admin/apps.js
@@ -137,7 +137,10 @@ export default function Apps() {
                     value={TABS.pubRequest}
                     selectedTab={selectedTab}
                 >
-                    <AppPublicationRequests parentId={"pubRequestListing"} />
+                    <AppPublicationRequests
+                        parentId={"pubRequestListing"}
+                        tabIsActive={selectedTab === TABS.pubRequest}
+                    />
                 </DETabPanel>
             </>
         );


### PR DESCRIPTION
(rather than loaded with the whole admin page)

Minor performance improvement and the apps and metadata changes will make it matter less, but it still seems wasteful to request it when a lot of the time the publication requests won't be relevant.