### PR TITLE
Add mount data store toggle to VICE app launch Advanced Settings

### DIFF
--- a/public/static/locales/en/launch.json
+++ b/public/static/locales/en/launch.json
@@ -32,6 +32,8 @@
     "minDiskSpace": "Minimum Disk Space",
     "minCPUCores": "Minimum CPU Cores",
     "minMemory": "Minimum Memory",
+    "mountDataStore": "Mount data store in analysis",
+    "mountDataStoreHelp": "When enabled, your analysis reads and writes directly to the Data Store. When disabled, files are copied in at launch and copied back when the analysis completes.",
     "multiInputEmptyLabel": "Select the \"Browse\" button to add inputs.",
     "newAnalysisName": "{{appName}} analysis1",
     "name": "Name",

--- a/src/components/apps/launch/AppLaunchForm.js
+++ b/src/components/apps/launch/AppLaunchForm.js
@@ -166,6 +166,7 @@ const AppLaunchForm = (props) => {
             version_id,
             name: appName,
             app_type,
+            overall_job_type,
             groups,
             requirements,
         },
@@ -417,6 +418,7 @@ const AppLaunchForm = (props) => {
                                         <ResourceRequirementsForm
                                             baseId={stepIdResources}
                                             limits={values.limits}
+                                            overallJobType={overall_job_type}
                                             defaultMaxCPUCores={
                                                 defaultMaxCPUCores
                                             }

--- a/src/components/apps/launch/ResourceRequirements.js
+++ b/src/components/apps/launch/ResourceRequirements.js
@@ -19,7 +19,9 @@ import ids from "./ids";
 import styles from "./styles";
 
 import buildID from "components/utils/DebugIDUtil";
+import FormCheckbox from "components/forms/FormCheckbox";
 import FormSelectField from "components/forms/FormSelectField";
+import TOOL_TYPES from "components/models/ToolTypes";
 
 import {
     Accordion,
@@ -235,10 +237,12 @@ const ResourceRequirementsForm = ({
     defaultMaxCPUCores,
     defaultMaxMemory,
     defaultMaxDiskSpace,
+    overallJobType,
     limits,
 }) => {
     const { classes } = useStyles();
     const { t } = useTranslation("launch");
+    const isVICE = overallJobType === TOOL_TYPES.INTERACTIVE;
     return (
         <>
             <Accordion defaultExpanded>
@@ -319,6 +323,15 @@ const ResourceRequirementsForm = ({
                     )}
                 </AccordionDetails>
             </Accordion>
+            {isVICE && (
+                <FastField
+                    id={buildID(baseId, ids.RESOURCE_REQUESTS.MOUNT_DATA_STORE)}
+                    name="mount_data_store"
+                    label={t("mountDataStore")}
+                    helperText={t("mountDataStoreHelp")}
+                    component={FormCheckbox}
+                />
+            )}
         </>
     );
 };

--- a/src/components/apps/launch/formatters.js
+++ b/src/components/apps/launch/formatters.js
@@ -83,6 +83,7 @@ const initAppLaunchValues = (
         app_id: id,
         app_version_id: version_id,
         system_id,
+        mount_data_store: true,
         groups: initGroupValues(groups),
         limits: requirements,
         requirements: reqInitValues || [],
@@ -200,6 +201,7 @@ const formatSubmission = (
         system_id,
         app_id,
         app_version_id,
+        mount_data_store,
         requirements,
         groups,
     }
@@ -223,6 +225,7 @@ const formatSubmission = (
         system_id,
         app_id,
         app_version_id,
+        mount_data_store,
         requirements: formattedRequirements,
         config: groups?.reduce(paramConfigsReducer, {}),
     };

--- a/src/components/apps/launch/formatters.js
+++ b/src/components/apps/launch/formatters.js
@@ -38,7 +38,15 @@ const initAppLaunchValues = (
         defaultSelectedMaxCpus,
         defaultMaxCpuCores = defaultSelectedMaxCpus,
         defaultOutputDir,
-        app: { id, version_id, system_id, name, requirements, groups },
+        app: {
+            id,
+            version_id,
+            system_id,
+            name,
+            requirements,
+            groups,
+            mount_data_store,
+        },
     }
 ) => {
     // If no default_max_cpu_cores is returned from the API,
@@ -83,7 +91,7 @@ const initAppLaunchValues = (
         app_id: id,
         app_version_id: version_id,
         system_id,
-        mount_data_store: true,
+        mount_data_store: mount_data_store ?? true,
         groups: initGroupValues(groups),
         limits: requirements,
         requirements: reqInitValues || [],

--- a/src/components/apps/launch/ids.js
+++ b/src/components/apps/launch/ids.js
@@ -50,6 +50,7 @@ const ids = {
         MIN_DISK_SPACE: "minDiskSpace",
         TOOL_GPU: "idToolGpu",
         TOOL_GPU_MODELS: "idToolGpuModels",
+        MOUNT_DATA_STORE: "mountDataStore",
     },
 
     TEMPLATE_GROUP: "group",

--- a/stories/apps/launch/data/JupyterLabNoParamsApp.js
+++ b/stories/apps/launch/data/JupyterLabNoParamsApp.js
@@ -22,6 +22,7 @@ const JupyterLabNoParamsApp = {
     label: "Jupyter Lab no params",
     id: "4dcda8a6-5761-11ea-bd06-008cfa5ae621",
     app_type: "DE",
+    overall_job_type: "interactive",
     groups: [],
 };
 


### PR DESCRIPTION
Add a checkbox to the Advanced Settings step of the app launch wizard, visible only for interactive (VICE) apps. The checkbox is labelled "Mount data store in analysis" and defaults to checked (true), preserving existing behaviour. Helper text explains the difference between the direct-mount and copy-in/copy-out modes.

Wire mount_data_store into initAppLaunchValues (default true) and formatSubmission so it is included in the POST body to /analyses.

depends on https://github.com/cyverse-de/app-exposer/pull/160 https://github.com/cyverse-de/apps/pull/301 and https://github.com/cyverse-de/model/pull/29