### PR TITLE
CORE-2170 Add a custom request timeout for the `/api/uploads` endpoint

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -8,6 +8,12 @@ cyverse_url: https://cyverse.org/discovery-environment #// The CyVerse page for 
 queriesConcurrencyLimit: 8
 max_request_body_size: 10mb
 
+# The default body request timeout for all routes, in milliseconds.
+requestTimeoutDefault: 300000   # 5 minutes, the node http server default.
+
+# The body request timeout for uploads, in milliseconds (zero = unlimited)
+requestTimeoutUploads: 7200000  # 2 hours
+
 logging:
     level: info
     label: sonora server

--- a/src/server/api/fileio.js
+++ b/src/server/api/fileio.js
@@ -8,19 +8,58 @@
 import express from "express";
 
 import * as auth from "../auth";
+import { requestTimeoutUploads } from "../configuration";
 import logger from "../logging";
 
 import { handler as terrainHandler } from "./terrain";
 import uploadHandler from "./uploads";
 import downloadHandler from "./downloads";
 
+export function bodyTimeout(ms) {
+    return (req, res, next) => {
+        if (ms > 0) {
+            const timer = setTimeout(() => {
+                if (!res.headersSent) {
+                    res.status(408).send({ message: "request timeout" });
+                }
+                logger.warn(
+                    `request timeout after ${ms} ms for ${req.method} ${req.originalUrl}`
+                );
+                req.destroy();
+            }, ms);
+
+            const clear = () => clearTimeout(timer);
+            res.on("finish", clear);
+            res.on("close", clear); // client/socket gone
+        }
+
+        if (!req.socket.destroyed) {
+            next();
+        }
+    };
+}
+
+export function fileUploadRouter() {
+    const api = express.Router();
+
+    logger.info("************ Adding File Upload handler **********");
+
+    logger.info("adding the POST /api/upload handler");
+    // Set a long (or zero = unlimited) request timeout for uploads.
+    api.post(
+        "/upload",
+        bodyTimeout(requestTimeoutUploads),
+        auth.authnTokenMiddleware,
+        uploadHandler
+    );
+
+    return api;
+}
+
 export default function fileIORouter() {
     const api = express.Router();
 
     logger.info("************ Adding File I/O handlers **********");
-
-    logger.info("adding the POST /api/upload handler");
-    api.post("/upload", auth.authnTokenMiddleware, uploadHandler);
 
     logger.info("adding the POST /api/fileio/urlupload handler");
     api.post(

--- a/src/server/configuration.js
+++ b/src/server/configuration.js
@@ -155,6 +155,18 @@ export const listenPort = parseInt(config.get("listen_port"), 10);
 export const maxRequestBodySize = config.get("max_request_body_size");
 
 /**
+ * The default body request timeout for all routes, in milliseconds.
+ * @type {number}
+ */
+export const requestTimeoutDefault = config.get("requestTimeoutDefault");
+
+/**
+ * The body request timeout for uploads, in milliseconds (zero = unlimited).
+ * @type {number}
+ */
+export const requestTimeoutUploads = config.get("requestTimeoutUploads");
+
+/**
  * The URI to use when connecting to the database. Most database interaction
  * is managed by the API, but the UI does use the database to store user
  * session information.

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -8,7 +8,7 @@ import dashboardRouter from "./api/dashboard";
 import dataRouter from "./api/data";
 import debugRouter from "./api/debug";
 import doiRouter from "./api/doi";
-import fileIORouter from "./api/fileio";
+import fileIORouter, { bodyTimeout, fileUploadRouter } from "./api/fileio";
 import groupsRouter from "./api/groups";
 import instantlaunchRouter from "./api/instantlaunches";
 import metadataRouter from "./api/metadata";
@@ -122,6 +122,14 @@ app.prepare()
             "$$$$$$$$ adding the api router to the express server $$$$$$$$$"
         );
         server.use("/api", compression());
+
+        // The /upload endpoint requires a longer timeout,
+        // so mount it before the default timeout for all other routes, below.
+        server.use("/api", fileUploadRouter());
+
+        // Mount a custom body request timeout handler for all routes.
+        server.use(bodyTimeout(config.requestTimeoutDefault));
+
         server.use("/api", appsRouter());
         server.use("/api", analysesRouter());
         server.use("/api", bagsRouter());
@@ -186,6 +194,13 @@ app.prepare()
             if (err) throw err;
             console.log(`> Ready on http://localhost:${config.listenPort}`);
         });
+
+        // Disable the global timeout for all requests.
+        httpServer.requestTimeout = 0;
+
+        // Ensure headers still set a timeout:
+        // the node http server default of 60 seconds.
+        httpServer.headersTimeout = 60 * 1000;
 
         httpServer.on("upgrade", upgradeListener(server));
     })


### PR DESCRIPTION
This PR will add a custom request timeout for the `/api/uploads` endpoint, by disabling the `express` http server's global 5 minute request timeout, and adding express middleware body request timeouts: a longer timeout for the uploads endpoint (1 hour by default), and a reasonable timeout for all other routes (5 minutes by default).