### PR TITLE
Fix client-side crash after moving or deleting a selected file

### DIFF
--- a/src/__tests__/dataDotMenu.js
+++ b/src/__tests__/dataDotMenu.js
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import preloadAll from "jest-next-dynamic";
+import renderer from "react-test-renderer";
+
+import DataDotMenu from "components/data/toolbar/DataDotMenu";
+import ResourceTypes from "components/models/ResourceTypes";
+
+import { EmotionCacheProvider } from "__mocks__/EmotionCacheProvider";
+import { RQWrapper } from "__mocks__/RQWrapper";
+import { ConfigProvider } from "contexts/config";
+
+import { ThemeProvider } from "@mui/material/styles";
+import theme from "components/theme/default";
+
+// The shared I18nProviderWrapper loads locales over HTTP and suspends forever
+// under jest, so anything rendered inside it never runs. Stub the hook instead
+// so this component actually renders and its logic is exercised.
+jest.mock("i18n", () => ({
+    useTranslation: () => ({ t: (key) => key }),
+    Trans: ({ children }) => children,
+    i18n: {},
+    RequiredNamespaces: [],
+}));
+
+// The component calls useRouter during render, which throws outside a Next app.
+jest.mock("next/router", () => ({
+    useRouter: () => ({ push: jest.fn() }),
+}));
+
+beforeAll(async () => {
+    await preloadAll();
+});
+
+const TestProviderWrapper = ({ children }) => (
+    <RQWrapper>
+        <EmotionCacheProvider>
+            <ThemeProvider theme={theme}>
+                <ConfigProvider>{children}</ConfigProvider>
+            </ThemeProvider>
+        </EmotionCacheProvider>
+    </RQWrapper>
+);
+
+const folder = {
+    id: "folder-id",
+    path: "/cyverse/home/wregglej/grr",
+    type: ResourceTypes.FOLDER,
+    permission: "own",
+};
+
+// Moving or deleting the selected item out of the folder being viewed leaves
+// its ID in `selected` while the refreshed listing no longer resolves it, so
+// `selected` can be longer than the resources it maps to.
+const cases = [
+    { name: "an empty selection", selected: [], resources: [] },
+    { name: "a selected folder", selected: [folder.id], resources: [folder] },
+    {
+        name: "a selection that is no longer listed",
+        selected: [folder.id],
+        resources: [],
+    },
+    {
+        name: "more selected IDs than resolved resources",
+        selected: [folder.id, "also-gone"],
+        resources: [folder],
+    },
+];
+
+test.each(cases)(
+    "DataDotMenu renders with $name",
+    ({ selected, resources }) => {
+        const component = renderer.create(
+            <TestProviderWrapper>
+                <DataDotMenu
+                    baseId="data.toolbar"
+                    selected={selected}
+                    getSelectedResources={() => resources}
+                    uploadEnabled={true}
+                    sharingEnabled={true}
+                    bagEnabled={true}
+                    planCanShare={true}
+                    detailsEnabled={selected.length === 1}
+                />
+            </TestProviderWrapper>
+        );
+        // Guards against the suspend-forever trap above: if the component were
+        // never rendered, there would be no tree to find the menu button in.
+        expect(component.root.findAllByType("button").length).toBeGreaterThan(
+            0
+        );
+        component.unmount();
+    }
+);

--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -5,7 +5,7 @@
  * thumbnail/tile view.
  */
 
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 
 import TableView from "./TableView";
 
@@ -182,19 +182,30 @@ function Listing(props) {
         processSelectedFiles(files, trackAllUploads);
     };
 
-    // Selections can outlive the listing they came from: moving or deleting an
-    // item leaves its ID in `selected` while the refreshed listing no longer
-    // contains it. Drop the misses so callers never see undefined entries.
+    // Selections outlive the listing they came from: moving or deleting an item
+    // leaves its ID in `selected` while the refreshed listing no longer contains
+    // it. Derive the surviving IDs during render rather than pruning in an
+    // effect -- an effect runs too late to stop the render in between from
+    // resolving a stale ID to undefined. Everything downstream reads this, so
+    // `listedSelected.length` and `getSelectedResources().length` always agree.
+    const listedSelected = useMemo(
+        () =>
+            selected.filter((id) =>
+                data?.listing?.some((resource) => resource.id === id)
+            ),
+        [data.listing, selected]
+    );
+
     const getSelectedResources = useCallback(
         (resources) => {
-            const items = resources ? resources : selected;
+            const items = resources ? resources : listedSelected;
             return items
                 .map((id) =>
                     data?.listing?.find((resource) => resource.id === id)
                 )
                 .filter(Boolean);
         },
-        [data.listing, selected]
+        [data.listing, listedSelected]
     );
 
     const { error, isFetching } = useQuery({
@@ -331,7 +342,7 @@ function Listing(props) {
         {
             onSuccess: (resp) => {
                 trackIntercomEvent(IntercomEvents.SUBMITTED_DOI_REQUEST, {
-                    folder: selected[0],
+                    folder: listedSelected[0],
                 });
             },
             onError: (e) => {
@@ -370,20 +381,6 @@ function Listing(props) {
         setSelected([]);
         setLocalContextsProjectURI(null);
     }, [path, rowsPerPage, orderBy, order, page, uploadsCompleted]);
-
-    // A move or delete refreshes the listing without changing `path`, so the
-    // effect above doesn't fire and stale IDs linger. Returning the original
-    // array when nothing was dropped keeps this from looping.
-    useEffect(() => {
-        setSelected((currentSelected) => {
-            const stillListed = currentSelected.filter((id) =>
-                data?.listing?.find((resource) => resource.id === id)
-            );
-            return stillListed.length === currentSelected.length
-                ? currentSelected
-                : stillListed;
-        });
-    }, [data.listing]);
 
     const viewUploadQueue = useCallback(() => {
         return (
@@ -454,8 +451,8 @@ function Listing(props) {
     });
 
     useEffect(() => {
-        setDetailsEnabled(selected && selected.length === 1);
-    }, [selected]);
+        setDetailsEnabled(listedSelected.length === 1);
+    }, [listedSelected]);
 
     useEffect(() => {
         if (download) {
@@ -489,7 +486,7 @@ function Listing(props) {
     };
 
     const handleSelectAllClick = (event) => {
-        if (event.target.checked && !selected.length && multiSelect) {
+        if (event.target.checked && !listedSelected.length && multiSelect) {
             const newSelecteds =
                 data?.listing?.map((resource) => resource.id) || [];
             setSelected(newSelecteds);
@@ -512,7 +509,7 @@ function Listing(props) {
                 rangeIds.push(data?.listing[i].id);
             }
 
-            let isTargetSelected = selected.includes(targetId);
+            let isTargetSelected = listedSelected.includes(targetId);
             isTargetSelected ? deselect(rangeIds) : select(rangeIds);
         }
     };
@@ -535,7 +532,7 @@ function Listing(props) {
     };
 
     const toggleSelection = (resourceId) => {
-        if (selected.includes(resourceId)) {
+        if (listedSelected.includes(resourceId)) {
             deselect([resourceId]);
         } else {
             select([resourceId]);
@@ -544,7 +541,7 @@ function Listing(props) {
 
     const select = (resourceIds) => {
         if (multiSelect) {
-            let newSelected = [...new Set([...selected, ...resourceIds])];
+            let newSelected = [...new Set([...listedSelected, ...resourceIds])];
             setSelected(newSelected);
         } else {
             setSelected(resourceIds);
@@ -552,7 +549,7 @@ function Listing(props) {
     };
 
     const deselect = (resourceIds) => {
-        const newSelected = selected.filter(
+        const newSelected = listedSelected.filter(
             (selectedID) => !resourceIds.includes(selectedID)
         );
 
@@ -621,7 +618,7 @@ function Listing(props) {
 
     const onDetailsSelected = () => {
         setDetailsOpen(true);
-        const selectedId = selected[0];
+        const selectedId = listedSelected[0];
         const resourceIndex = data.listing.findIndex(
             (item) => item.id === selectedId
         );
@@ -696,11 +693,11 @@ function Listing(props) {
     const localUploadId = buildID(baseId, ids.UPLOAD_MI, ids.UPLOAD_INPUT);
     return (
         <>
-            {render && render(selected.length, getSelectedResources)}
+            {render && render(listedSelected.length, getSelectedResources)}
             <UploadDropTarget path={path} uploadsEnabled={uploadsEnabled}>
                 <DataToolbar
                     path={path}
-                    selected={selected}
+                    selected={listedSelected}
                     getSelectedResources={getSelectedResources}
                     handlePathChange={onPathChange}
                     permission={data?.permission}
@@ -769,7 +766,7 @@ function Listing(props) {
                         handleClick={handleClick}
                         order={order}
                         orderBy={orderBy}
-                        selected={selected}
+                        selected={listedSelected}
                         setSharingDlgOpen={setSharingDlgOpen}
                         onMetadataSelected={onMetadataSelected}
                         onPublicLinksSelected={() =>
@@ -854,7 +851,7 @@ function Listing(props) {
                             onClick={() => {
                                 setConfirmDOIRequestDialogOpen(false);
                                 requestDOI({
-                                    folder: selected[0],
+                                    folder: listedSelected[0],
                                     type: "DOI",
                                 });
                             }}
@@ -895,7 +892,7 @@ function Listing(props) {
                 selectedResources={getSelectedResources()}
                 onClose={() => setMoveDlgOpen(false)}
                 onRemoveResource={(resource) => {
-                    const newSelected = selected?.filter(
+                    const newSelected = listedSelected.filter(
                         (sel) => sel !== resource?.id
                     );
                     setSelected(newSelected);

--- a/src/components/data/listing/Listing.js
+++ b/src/components/data/listing/Listing.js
@@ -182,12 +182,17 @@ function Listing(props) {
         processSelectedFiles(files, trackAllUploads);
     };
 
+    // Selections can outlive the listing they came from: moving or deleting an
+    // item leaves its ID in `selected` while the refreshed listing no longer
+    // contains it. Drop the misses so callers never see undefined entries.
     const getSelectedResources = useCallback(
         (resources) => {
             const items = resources ? resources : selected;
-            return items.map((id) =>
-                data?.listing?.find((resource) => resource.id === id)
-            );
+            return items
+                .map((id) =>
+                    data?.listing?.find((resource) => resource.id === id)
+                )
+                .filter(Boolean);
         },
         [data.listing, selected]
     );
@@ -365,6 +370,20 @@ function Listing(props) {
         setSelected([]);
         setLocalContextsProjectURI(null);
     }, [path, rowsPerPage, orderBy, order, page, uploadsCompleted]);
+
+    // A move or delete refreshes the listing without changing `path`, so the
+    // effect above doesn't fire and stale IDs linger. Returning the original
+    // array when nothing was dropped keeps this from looping.
+    useEffect(() => {
+        setSelected((currentSelected) => {
+            const stillListed = currentSelected.filter((id) =>
+                data?.listing?.find((resource) => resource.id === id)
+            );
+            return stillListed.length === currentSelected.length
+                ? currentSelected
+                : stillListed;
+        });
+    }, [data.listing]);
 
     const viewUploadQueue = useCallback(() => {
         return (

--- a/src/components/data/toolbar/DataDotMenu.js
+++ b/src/components/data/toolbar/DataDotMenu.js
@@ -140,7 +140,8 @@ function DataDotMenu(props) {
     };
 
     const applyBulkMetadataEnabled =
-        metadataMiEnabled && selectedResources[0].type === ResourceTypes.FOLDER;
+        metadataMiEnabled &&
+        selectedResources?.[0]?.type === ResourceTypes.FOLDER;
 
     return (
         <>


### PR DESCRIPTION
## Problem

Moving or deleting an item out of the folder being viewed refreshes the listing without changing `path`, so the effect that clears `selected` never fires and the removed item's ID lingers in the selection.

`getSelectedResources` resolved those stale IDs with `Array.find`, which returns `undefined`, and `formatSharedData` then destructured them during render:

    TypeError: Cannot destructure property 'label' of 'undefined'

That threw into the Next.js error boundary and unmounted the app, which looked like an unexpected logout even though the move had succeeded and the session was still valid.

A first pass filtered unresolvable IDs out of `getSelectedResources` and pruned `selected` in an effect. That was not enough — an effect runs after render, so the render in between still saw a `selected` containing an ID the refreshed listing no longer had. It also left `selected.length` and `getSelectedResources().length` free to disagree, which is the real hazard: `DataDotMenu` guards on `selected?.length === 1` but indexes `selectedResources[0]`, so the QA build traded the old crash for

    TypeError: can't access property "type", ef[0] is undefined

## Fix

- Derive `listedSelected` with `useMemo` during render in `Listing.js` and read it everywhere `selected` was read. The two lengths now agree by construction and no render can observe a stale ID.
- Drop the pruning effect — it was syncing state that is better derived.
- Guard the `selectedResources[0]` access in `DataDotMenu`, matching the optional chaining already used for `permission` two lines above.

## Tests

New `src/__tests__/dataDotMenu.js` covers a selection that outlives its listing, including the case where more IDs are selected than resolve to resources. Verified the test fails against the unguarded `DataDotMenu` and passes with the fix.

The shared `I18nProviderWrapper` loads locales over HTTP and suspends forever under jest, so the test stubs `useTranslation` and `useRouter` and asserts the component actually rendered — without those stubs the component never runs and the test proves nothing.

## Verification

- `npm run lint` — clean (zero warnings)
- `TZ=UTC npx jest` — 193 tests across 31 suites pass
- `npm run build` — succeeds
- Prettier check clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)