### PR TITLE
Point user-portal links at the configured portal URL

### DIFF
--- a/src/components/dashboard/dashboardItem/Banner.js
+++ b/src/components/dashboard/dashboardItem/Banner.js
@@ -4,7 +4,8 @@
  * A banner to display for logged out users.
  *
  */
-import React, { useEffect, useRef } from "react";
+import React from "react";
+import getConfig from "next/config";
 import Image from "next/image";
 import { useTranslation } from "i18n";
 import { useRouter } from "next/router";
@@ -32,16 +33,17 @@ export default function Banner(props) {
 
     const cyverse_url = config?.cyverseURL;
 
+    // Read straight from the runtime config rather than the config context:
+    // the context is populated from an effect in _app, so it is still null
+    // when this banner first renders and the link would point at the default.
+    const { publicRuntimeConfig = {} } = getConfig() || {};
+    const userPortalURL =
+        publicRuntimeConfig.USER_PORTAL_URL ||
+        constants.DEFAULT_USER_PORTAL_URL;
+
     const onLoginClick = (event) => {
         router.push(`/${NavigationConstants.LOGIN}${router.asPath}`);
     };
-
-    const userPortalURLRef = useRef(constants.DEFAULT_USER_PORTAL_URL);
-    useEffect(() => {
-        if (config?.userPortalURL) {
-            userPortalURLRef.current = config.userPortalURL;
-        }
-    }, [config]);
 
     return (
         <Paper>
@@ -115,7 +117,7 @@ export default function Banner(props) {
                                 style={{
                                     margin: theme.spacing(0.4),
                                 }}
-                                href={userPortalURLRef.current}
+                                href={userPortalURL}
                             >
                                 {t("signUp")} |
                             </ExternalLink>

--- a/src/components/error/ErrorHandler.js
+++ b/src/components/error/ErrorHandler.js
@@ -6,6 +6,7 @@
 import React, { useEffect } from "react";
 import { useRouter } from "next/router";
 import { useTranslation } from "i18n";
+import getConfig from "next/config";
 
 import NavigationConstants from "../../common/NavigationConstants";
 import GridLabelValue from "../utils/GridLabelValue";
@@ -59,6 +60,11 @@ function ErrorHandler(props) {
     const router = useRouter();
     const { classes } = useStyles();
     const errBaseId = buildID(baseId, ids.ERROR_HANDLER);
+
+    const { publicRuntimeConfig = {} } = getConfig() || {};
+    const registerURL = `${
+        publicRuntimeConfig.USER_PORTAL_URL || constants.DEFAULT_USER_PORTAL_URL
+    }/register`;
 
     useEffect(() => {
         trackIntercomEvent(IntercomEvents.ENCOUNTERED_ERROR, errorObject);
@@ -125,7 +131,7 @@ function ErrorHandler(props) {
                             id={buildID(errBaseId, ids.REGISTER_LINK)}
                             color="primary"
                             onClick={() => {
-                                window.open(constants.USER_PORTAL);
+                                window.open(registerURL);
                             }}
                             underline="hover"
                         >

--- a/src/components/subscriptions/details/Drawer.js
+++ b/src/components/subscriptions/details/Drawer.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useTranslation } from "i18n";
+import getConfig from "next/config";
 
 import {
     Box,
@@ -292,7 +293,10 @@ function SubscriptionDrawer(props) {
 function SubscriptionHeader(props) {
     const { portalId, username } = props;
     const { classes } = useStyles();
-    const baseURL = constants.DEFAULT_USER_PORTAL_URL;
+    const { publicRuntimeConfig = {} } = getConfig() || {};
+    const baseURL =
+        publicRuntimeConfig.USER_PORTAL_URL ||
+        constants.DEFAULT_USER_PORTAL_URL;
     const subURL = navigationConstants.ADMIN_USER_PORTAL_USERS;
     const linkToUserPortal = `${baseURL}${subURL}/${portalId}`;
     return (

--- a/src/constants.js
+++ b/src/constants.js
@@ -29,7 +29,6 @@ const constants = {
     ONE_GiB: 2 ** 30,
     WS_PROTOCOL: "ws://",
     WSS_PROTOCOL: "wss://",
-    USER_PORTAL: "https://user.cyverse.org/register",
     USER_PORTAL_FAQ: "https://learning.cyverse.org/faq/#user-account",
 
     IMPORT_IRODS_METADATA_LINK:


### PR DESCRIPTION
The logged-out banner kept the signup link in a useRef seeded with constants.DEFAULT_USER_PORTAL_URL, updated it from a useEffect, and then read the ref during render. Mutating a ref triggers no re-render, so the link stayed on https://user.cyverse.org until some unrelated re-render happened to occur -- and every refresh reverted it, since the SSR'd HTML always carried the default.

Read publicRuntimeConfig.USER_PORTAL_URL directly instead of going through the config context: the context is assembled in an effect in _app, so it is still null when the banner first renders and would leave the initial paint pointing at the default either way.

The register link on the sign-in error page and the user-portal link in the admin subscription drawer had the same problem in a simpler form -- they read the hardcoded constants and never consulted the config at all. That leaves constants.USER_PORTAL unused, so drop it.